### PR TITLE
Register the custom types from the config as to be commented

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -60,6 +60,9 @@ class ConnectionFactory
             foreach ($mappingTypes as $dbType => $doctrineType) {
                 $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
             }
+            foreach ($this->typesConfig as $type => $className) {
+                $platform->markDoctrineTypeCommented(Type::getType($type));
+            }
         }
 
         return $connection;


### PR DESCRIPTION
This PR solves problems of the custom types when creating diff of schema through SchemaTool. 
The schema tool already generates column definition (ALTER TABLE) of custom type, if for it is not specified comment with 'DC2Type' content.
