### PR TITLE
Updated configuration - fix #37

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -443,7 +443,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $memcacheInstance->addMethodCall('connect', array(
                     $memcacheHost, $memcachePort
                 ));
-                $container->setDefinition(sprintf('doctrine.orm.%s%_%s_memcache_instance', $entityManager['name'], $cacheDriverType), $memcacheInstance);
+                $container->setDefinition(sprintf('doctrine.orm.%s_%s_memcache_instance', $entityManager['name'], $cacheDriverType), $memcacheInstance);
                 $cacheDef->addMethodCall('setMemcache', array(new Reference(sprintf('doctrine.orm.%s_%s_memcache_instance', $entityManager['name'], $cacheDriverType))));
                 break;
             case 'memcached':

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -535,10 +535,10 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $definition = $container->getDefinition('doctrine.orm.default_metadata_cache');
         $this->assertDICDefinitionClass($definition, 'Doctrine\Common\Cache\MemcacheCache');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setMemcache',
-            array(new Reference('doctrine.orm.default_memcache_instance'))
+            array(new Reference('doctrine.orm.default_metadata_memcache_instance'))
         );
 
-        $definition = $container->getDefinition('doctrine.orm.default_memcache_instance');
+        $definition = $container->getDefinition('doctrine.orm.default_metadata_memcache_instance');
         $this->assertDICDefinitionClass($definition, 'Memcache');
         $this->assertDICDefinitionMethodCallOnce($definition, 'connect', array(
             'localhost', '11211'


### PR DESCRIPTION
Updated configuration to support different settings for same cache driver on different cache type.

This PR fixes #37 BUT, and this one is the real catch, it will also decimate system resources in terms of connections to memcache(d) servers as currently there's no way to see if the memcache(d) connection from one EM matches the another existing one. This means that if you have multiple EMs, like me, and want to configure them to use memcache(d) for all cache types it will spawn as many as 3xEMs number connections to the memcache(d) server (if my math is right).

I believe that this configuration should be done different but I'm not sure about the direction for it. It should also support a pool of servers as currently you can only use one server / cache type and this is not good for a production/fail-over system.

So, while merging this will solve the current bug, this instead will open another bunch of issues.

Please advise on how to proceed with this as it should be fixed and I'm willing to do the required changes for this if I have the input from the dev team.

Thank you.
