### PR TITLE
Added display of connection name for queries - #43

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -59,6 +59,9 @@
                         <small>
                             <strong>Parameters</strong>: {{ query.params|yaml_encode }}<br />
                             <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
+                            {% if query.connectionName is defined %}
+                            <strong>Connection</strong>: {{ query.connectionName }}
+                            {% endif %}
                         </small>
                         {% if query.explainable %}
                         <div id="explain-{{ i }}-{{ loop.parent.loop.index }}" class="loading"></div>


### PR DESCRIPTION
Hi,

After reading #43 I think it would be more useful to have the connection name in the collector so that it can be displayed in Profiler rather that only in log.

I haven't included the log part as I don't have any clue where to do it at the moment of this PR.

This is dependent on symfony/symfony#3749 to display data but it's made so that it doesn't break anything until that PR gets merged.

[![Build Status](https://secure.travis-ci.org/dlsniper/DoctrineBundle.png?branch=add-connection-name-to-doctrine-collector)](http://travis-ci.org/dlsniper/DoctrineBundle)
