### PR TITLE
Added the support for SQL filters

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -310,6 +310,33 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->fixXmlConfig('filter')
+                ->children()
+                    ->arrayNode('filters')
+                        ->setInfo('Register SQL Filters in the entity manager')
+                        ->useAttributeAsKey('name')
+                        ->prototype('array')
+                            ->beforeNormalization()
+                                ->ifString()
+                                ->then(function($v) { return array('class' => $v); })
+                            ->end()
+                            ->beforeNormalization()
+                                // The content of the XML node is returned as the "value" key so we need to rename it
+                                ->ifTrue(function($v) {return is_array($v) && isset($v['value']); })
+                                ->then(function($v) {
+                                    $v['class'] = $v['value'];
+                                    unset($v['value']);
+
+                                    return $v;
+                                })
+                            ->end()
+                            ->children()
+                                ->scalarNode('class')->isRequired()->end()
+                                ->booleanNode('enabled')->defaultFalse()->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -287,6 +287,20 @@ class DoctrineExtension extends AbstractDoctrineExtension
             }
         }
 
+        $enabledFilters = array();
+        foreach ($entityManager['filters'] as $name => $filter) {
+            $ormConfigDef->addMethodCall('addFilter', array($name, $filter['class']));
+            if ($filter['enabled']) {
+                $enabledFilters[] = $name;
+            }
+        }
+
+        $managerConfiguratorName = sprintf('doctrine.orm.%s_manager_configurator', $entityManager['name']);
+        $managerConfiguratorDef = $container
+            ->setDefinition($managerConfiguratorName, new DefinitionDecorator('doctrine.orm.manager_configurator.abstract'))
+            ->replaceArgument(0, $enabledFilters)
+        ;
+
         if (!isset($entityManager['connection'])) {
             $entityManager['connection'] = $this->defaultConnection;
         }
@@ -297,6 +311,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 new Reference(sprintf('doctrine.dbal.%s_connection', $entityManager['connection'])),
                 new Reference(sprintf('doctrine.orm.%s_configuration', $entityManager['name']))
             ))
+            ->setConfigurator(array(new Reference($managerConfiguratorName), 'configure'))
         ;
 
         $container->setAlias(

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle;
+
+use Doctrine\ORM\EntityManager;
+
+/**
+ * Configurator for an EntityManager
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ManagerConfigurator
+{
+    private $enabledFilters = array();
+
+    /**
+     * Construct.
+     *
+     * @param array $enabledFilters
+     */
+    public function __construct(array $enabledFilters)
+    {
+        $this->enabledFilters = $enabledFilters;
+    }
+
+    /**
+     * Create a connection by name.
+     *
+     * @param EntityManager $entityManager
+     */
+    public function configure(EntityManager $entityManager)
+    {
+        $this->enableFilters($entityManager);
+    }
+
+    private function enableFilters(EntityManager $entityManager)
+    {
+        if (empty($this->enabledFilters)) {
+            return;
+        }
+
+        $filterCollection = $entityManager->getFilters();
+        foreach ($this->enabledFilters as $filter) {
+            $filterCollection->enable($filter);
+        }
+    }
+}

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="doctrine.orm.configuration.class">Doctrine\ORM\Configuration</parameter>
         <parameter key="doctrine.orm.entity_manager.class">Doctrine\ORM\EntityManager</parameter>
+        <parameter key="doctrine.orm.manager_configurator.class">Doctrine\Bundle\DoctrineBundle\ManagerConfigurator</parameter>
 
         <!-- cache -->
         <parameter key="doctrine.orm.cache.array.class">Doctrine\Common\Cache\ArrayCache</parameter>
@@ -65,6 +66,10 @@
         <service id="doctrine.orm.configuration" class="%doctrine.orm.configuration.class%" abstract="true" public="false" />
 
         <service id="doctrine.orm.entity_manager.abstract" class="%doctrine.orm.entity_manager.class%" factory-class="%doctrine.orm.entity_manager.class%" factory-method="create" abstract="true" />
+
+        <service id="doctrine.orm.manager_configurator.abstract" class="%doctrine.orm.manager_configurator.class%" abstract="true" public="false">
+            <argument type="collection" />
+        </service>
 
         <!-- validator -->
         <service id="doctrine.orm.validator.unique" class="%doctrine.orm.validator.unique.class%">

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -109,6 +109,7 @@
             <xsd:element name="mapping" type="mapping" />
             <xsd:element name="metadata-cache-driver" type="metadata_cache_driver" minOccurs="0" maxOccurs="1" />
             <xsd:element name="dql" type="dql" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="filter" type="filter" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
 
         <xsd:attribute name="auto-mapping" type="xsd:string" />
@@ -140,6 +141,7 @@
             <xsd:element name="metadata-cache-driver" type="metadata_cache_driver" minOccurs="0" maxOccurs="1" />
             <xsd:element name="dql" type="dql" minOccurs="0" maxOccurs="1" />
             <xsd:element name="hydrator" type="type" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="filter" type="filter" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
 
         <xsd:attribute name="auto-mapping" type="xsd:string" />
@@ -148,6 +150,15 @@
         <xsd:attribute name="result-cache-driver" type="xsd:string" />
         <xsd:attribute name="metadata-cache-driver" type="xsd:string" />
         <xsd:attribute name="query-cache-driver" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="filter">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:string" use="required" />
+                <xsd:attribute name="enabled" type="xsd:boolean" />
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
 
     <xsd:complexType name="dql">

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -724,6 +724,27 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomHydrationMode', array('test_hydrator', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator'));
     }
 
+    public function testAddFilter()
+    {
+        $container = $this->getContainer(array('YamlBundle'));
+
+        $loader = new DoctrineExtension();
+        $container->registerExtension($loader);
+        $this->loadFromFile($container, 'orm_filters');
+        $this->compileContainer($container);
+
+        $definition = $container->getDefinition('doctrine.orm.default_configuration');
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addFilter', array('soft_delete', 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter'));
+
+        $definition = $container->getDefinition('doctrine.orm.default_manager_configurator');
+        $this->assertDICConstructorArguments($definition, array(array('soft_delete')));
+
+        // Let's create the instance to check the configurator work.
+        /** @var $entityManager \Doctrine\ORM\EntityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+        $this->assertCount(1, $entityManager->getFilters()->getEnabledFilters());
+    }
+
     protected function getContainer($bundles = 'YamlBundle', $vendor = null)
     {
         $bundles = (array) $bundles;

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm>
+            <filter name="soft_delete" enabled="true">Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter</filter>
+        </orm>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
@@ -1,0 +1,12 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        filters:
+            soft_delete:
+                class: Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter
+                enabled: true

--- a/Tests/DependencyInjection/TestFilter.php
+++ b/Tests/DependencyInjection/TestFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
+
+use Doctrine\ORM\Query\Filter\SQLFilter;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+class TestFilter extends SQLFilter
+{
+    /**
+     * Gets the SQL query part to add to a query.
+     *
+     * @return string The constraint SQL if there is available, empty string otherwise
+     */
+    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
+    {
+    }
+}


### PR DESCRIPTION
I finally took some time to implement #14

Note that I understand why @Burgow failed to configure it. I had to use a hidden feature of the DI component, undocumented of course, and used for the first time in all the Symfony2 code I ever saw (thanks @schmittjoh for thinking about it when writing the component :heart_eyes: ).

[![Build Status](https://secure.travis-ci.org/stof/DoctrineBundle.png?branch=sql_filters)](http://travis-ci.org/stof/DoctrineBundle)
