### PR TITLE
Added a way to configure the default entity repository class

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -259,6 +259,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('connection')->end()
                     ->scalarNode('class_metadata_factory_name')->defaultValue('Doctrine\ORM\Mapping\ClassMetadataFactory')->end()
+                    ->scalarNode('default_repository_class')->defaultValue('Doctrine\ORM\EntityRepository')->end()
                     ->scalarNode('auto_mapping')->defaultFalse()->end()
                 ->end()
                 ->fixXmlConfig('hydrator')

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -266,6 +266,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             'setProxyNamespace'           => '%doctrine.orm.proxy_namespace%',
             'setAutoGenerateProxyClasses' => '%doctrine.orm.auto_generate_proxy_classes%',
             'setClassMetadataFactoryName' => $entityManager['class_metadata_factory_name'],
+            'setDefaultRepositoryClassName' => $entityManager['default_repository_class'],
         );
         foreach ($methods as $method => $arg) {
             $ormConfigDef->addMethodCall($method, array($arg));

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -118,6 +118,7 @@
         <xsd:attribute name="proxy-dir" type="xsd:string" />
         <xsd:attribute name="proxy-namespace" type="xsd:string" />
         <xsd:attribute name="auto-generate-proxy-classes" type="xsd:string" default="false" />
+        <xsd:attribute name="default-repository-class" type="xsd:string" />
         <xsd:attribute name="result-cache-driver" type="xsd:string" />
         <xsd:attribute name="metadata-cache-driver" type="xsd:string" />
         <xsd:attribute name="query-cache-driver" type="xsd:string" />
@@ -145,6 +146,7 @@
         <xsd:attribute name="auto-mapping" type="xsd:string" />
         <xsd:attribute name="connection" type="xsd:string" />
         <xsd:attribute name="name" type="xsd:string" />
+        <xsd:attribute name="default-repository-class" type="xsd:string" />
         <xsd:attribute name="result-cache-driver" type="xsd:string" />
         <xsd:attribute name="metadata-cache-driver" type="xsd:string" />
         <xsd:attribute name="query-cache-driver" type="xsd:string" />

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -297,6 +297,9 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertDICConstructorArguments($definition, array(
             new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration')
         ));
+
+        $configDef = $container->getDefinition('doctrine.orm.default_configuration');
+        $this->assertDICDefinitionMethodCallOnce($configDef, 'setDefaultRepositoryClassName', array('Acme\Doctrine\Repository'));
     }
 
     public function testLoadMultipleConnections()

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
@@ -25,7 +25,7 @@
                 default-entity-manager="default"
                 auto-generate-proxy-classes="true"
             >
-            <entity-manager name="default" connection="default">
+            <entity-manager name="default" connection="default" default-repository-class="Acme\Doctrine\Repository">
                 <metadata-cache-driver type="memcache">
                     <class>Doctrine\Common\Cache\MemcacheCache</class>
                     <host>localhost</host>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
@@ -16,6 +16,7 @@ doctrine:
         entity_managers:
             default:
                 connection: default
+                default_repository_class: Acme\Doctrine\Repository
                 mappings:
                     YamlBundle: ~
                 metadata_cache_driver:


### PR DESCRIPTION
Changing the default repository class is supported as of Doctrine 2.2
