### PR TITLE
fix dependeny to symfony in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.1.*",
+        "symfony/doctrine-bridge": "2.1.*",
         "doctrine/dbal": ">=2.2,<2.4-dev"
     },
     "require-dev": {


### PR DESCRIPTION
according to nadermann, bundles should only require the symfony framework-bundle not the whole symfony
