### PR TITLE
always attach resolve_target_entity listener

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -239,16 +239,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $this->loadOrmEntityManager($entityManager, $container);
         }
 
-        if ($config['resolve_target_entities']) {
-            $def = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
-            foreach ($config['resolve_target_entities'] as $name => $implementation) {
-                $def->addMethodCall('addResolveTargetEntity', array(
-                    $name, $implementation, array()
-                ));
-            }
-
-            $def->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+        $def = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
+        foreach ($config['resolve_target_entities'] as $name => $implementation) {
+            $def->addMethodCall('addResolveTargetEntity', array(
+                $name, $implementation, array()
+            ));
         }
+
+        $def->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
     }
 
     /**


### PR DESCRIPTION
I'm trying to add a call to the addResolveTargetEntity method of the resolve_target_entity listener using a Compiler Pass, but because no resolve requests are added from the config, the listener is never actually tagged
