### PR TITLE
Correct the require string for jdorn/sql-formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/framework-bundle": ">=2.1,<2.3-dev",
         "symfony/doctrine-bridge": ">=2.1,<2.3-dev",
         "doctrine/dbal": ">=2.2,<2.4-dev",
-        "jdorn/sql-formatter": "1.0.1"
+        "jdorn/sql-formatter": "v1.0.1"
     },
     "require-dev": {
         "doctrine/orm": ">=2.2,<2.4-dev",


### PR DESCRIPTION
I'm not sure about this but, as I was trying to install Symfony bundle
with composer I had this error:
Problem 1
    - Installation request for doctrine/doctrine-bundle dev-master -> satisfiable by doctrine/doctrine-bundle dev-master.
    - doctrine/doctrine-bundle dev-master requires jdorn/sql-formatter 1.0.1 -> no matching package

If I've understood how packgist and composer work, the corret 
require line should be the corrected one.
Or at least, should be this:
"jdorn/sql-formatter": "1.0.x-dev"
