### PR TITLE
Much faster method for getting Metadata of a class

### DIFF
--- a/Mapping/MetadataFactory.php
+++ b/Mapping/MetadataFactory.php
@@ -167,25 +167,24 @@ class MetadataFactory
     }
 
     /**
-     * @param string $entity
+     * @param string $entity Entity class name
      *
      * @return ClassMetadataCollection
      */
     private function getMetadataForClass($entity)
     {
-        $entityManagers = $this->registry->getManagers();
+        $metadata                 = array();
+        $entityManagers           = $this->registry->getManagers();
         $metadataFactoryClassName = $this->getClassMetadataFactoryClass();
 
         foreach ($entityManagers as $em) {
             $cmf = new $metadataFactoryClassName();
             $cmf->setEntityManager($em);
 
-            $metadata = $cmf->getMetadataFor($entity);
-            
-            return new ClassMetadataCollection(array($metadata));
+            $metadata[] = $cmf->getMetadataFor($entity);
         }
 
-        return new ClassMetadataCollection(array());
+        return new ClassMetadataCollection($metadata);
     }
 
     /**


### PR DESCRIPTION
Since commit [cc6673](https://github.com/symfony/symfony/commit/cc66739f3d0fb50fba673f921d971bf62dc1b2f9) resolving issue [#2688](https://github.com/symfony/symfony/issues/2688), generating entities with the `app/console doctrine:generate:entities` command have become very slow, especially with many entities.

The problem comes from the `getMetadataForClass` method of the `Doctrine\Bundle\DoctrineBundle\Mapping\MetadataFactory` class which was looking for the right class after getting the metadata of all classes.
I changed the implementation so that only the metadata of the given class is retrieved.
Generating my entities is now about 12 times faster in my project.

~~Maybe we should consider updating all these classes to the latest version of the jms metadata project (https://github.com/schmittjoh/metadata) in the future.~~

edit: removed last sentence
