### PR TITLE
Modify the method to get all the metadaclasses to use the filter paramet...

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -106,7 +106,6 @@ EOT
         $cmf = new DisconnectedClassMetadataFactory();
         $cmf->setEntityManager($em);
         $metadata = $cmf->getAllFilteredMetadata($input->getOption('filter'));
-
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {


### PR DESCRIPTION
Hi,

I needed to import the mapping of an existing database in order to create doctrine2 entities, but when you run the command, it throw an exception on every table without a primary key.

I tried to use the filter option, but the error still occurs because the exception was throw in the method which get all the metadata informations.

I added a method which get the metadata of some tables according to a filter.

This is linked with a request on doctrine2 : https://github.com/doctrine/doctrine2/pull/603

What are your thought bout my issue?
