### PR TITLE
Hacking in support for dbal result cache

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -134,6 +134,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue('pdo_mysql')->end()
                 ->scalarNode('platform_service')->end()
+                ->append($this->getCacheDriverNode('result_cache_driver'))
                 ->scalarNode('schema_filter')->end()
                 ->booleanNode('logging')->defaultValue($this->debug)->end()
                 ->booleanNode('profiling')->defaultValue($this->debug)->end()
@@ -296,9 +297,9 @@ class Configuration implements ConfigurationInterface
             ->useAttributeAsKey('name')
             ->prototype('array')
                 ->addDefaultsIfNotSet()
-                ->append($this->getOrmCacheDriverNode('query_cache_driver'))
-                ->append($this->getOrmCacheDriverNode('metadata_cache_driver'))
-                ->append($this->getOrmCacheDriverNode('result_cache_driver'))
+                ->append($this->getCacheDriverNode('query_cache_driver'))
+                ->append($this->getCacheDriverNode('metadata_cache_driver'))
+                ->append($this->getCacheDriverNode('result_cache_driver'))
                 ->children()
                     ->scalarNode('connection')->end()
                     ->scalarNode('class_metadata_factory_name')->defaultValue('Doctrine\ORM\Mapping\ClassMetadataFactory')->end()
@@ -396,13 +397,13 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * Return a ORM cache driver node for an given entity manager
+     * Return a Doctrine cache driver node for a given connection or entity manager
      *
      * @param string $name
      *
      * @return ArrayNodeDefinition
      */
-    private function getOrmCacheDriverNode($name)
+    private function getCacheDriverNode($name)
     {
         $treeBuilder = new TreeBuilder();
         $node = $treeBuilder->root($name);

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -133,6 +133,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $configuration->addMethodCall('setSQLLogger', array($logger));
         }
 
+        if (isset($connection['result_cache_driver']) && $connection['result_cache_driver']) {
+            /** @todo Alternate solution is needed to address loading cache driver for either dbal or orm */
+            $connection['name'] = 'dbal.'.$name; # temporary fix to ensure unique to dbal. also see line 140
+            $this->loadObjectManagerCacheDriver($connection, $container, 'result_cache');
+            $configuration->addMethodCall('setResultCacheImpl', array(new Reference(sprintf('doctrine.orm.dbal.%s_result_cache', $name))));
+            unset($connection['result_cache_driver']);
+        }
+
         // event manager
         $def = $container->setDefinition(sprintf('doctrine.dbal.%s_connection.event_manager', $name), new DefinitionDecorator('doctrine.dbal.connection.event_manager'));
 

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -17,6 +17,25 @@
         <parameter key="doctrine.class">Doctrine\Bundle\DoctrineBundle\Registry</parameter>
         <parameter key="doctrine.entity_managers" type="collection"></parameter>
         <parameter key="doctrine.default_entity_manager"></parameter>
+
+        <!-- cache -->
+        <parameter key="doctrine.dbal.cache.array.class">Doctrine\Common\Cache\ArrayCache</parameter>
+        <parameter key="doctrine.dbal.cache.apc.class">Doctrine\Common\Cache\ApcCache</parameter>
+        <parameter key="doctrine.dbal.cache.memcache.class">Doctrine\Common\Cache\MemcacheCache</parameter>
+        <parameter key="doctrine.dbal.cache.memcache_host">localhost</parameter>
+        <parameter key="doctrine.dbal.cache.memcache_port">11211</parameter>
+        <parameter key="doctrine.dbal.cache.memcache_instance.class">Memcache</parameter>
+        <parameter key="doctrine.dbal.cache.memcached.class">Doctrine\Common\Cache\MemcachedCache</parameter>
+        <parameter key="doctrine.dbal.cache.memcached_host">localhost</parameter>
+        <parameter key="doctrine.dbal.cache.memcached_port">11211</parameter>
+        <parameter key="doctrine.dbal.cache.memcached_instance.class">Memcached</parameter>
+        <parameter key="doctrine.dbal.cache.redis.class">Doctrine\Common\Cache\RedisCache</parameter>
+        <parameter key="doctrine.dbal.cache.redis_host">localhost</parameter>
+        <parameter key="doctrine.dbal.cache.redis_port">6379</parameter>
+        <parameter key="doctrine.dbal.cache.redis_instance.class">Redis</parameter>
+        <parameter key="doctrine.dbal.cache.xcache.class">Doctrine\Common\Cache\XcacheCache</parameter>
+        <parameter key="doctrine.dbal.cache.wincache.class">Doctrine\Common\Cache\WinCacheCache</parameter>
+        <parameter key="doctrine.dbal.cache.zenddata.class">Doctrine\Common\Cache\ZendDataCache</parameter>
     </parameters>
 
     <services>

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -14,17 +14,22 @@
         </xsd:complexType>
     </xsd:element>
 
-    <xsd:attributeGroup name="connection-config">
+    <xsd:complexType name="connection-config">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="result-cache-driver" type="cache_driver" minOccurs="0" maxOccurs="1" />
+        </xsd:choice>
+
         <xsd:attribute name="driver" type="xsd:string" />
         <xsd:attribute name="driver-class" type="xsd:string" />
         <xsd:attribute name="wrapper-class" type="xsd:string" />
         <xsd:attribute name="keep-slave" type="xsd:string" />
         <xsd:attribute name="platform-service" type="xsd:string" />
+        <xsd:attribute name="result-cache-driver" type="xsd:string" />
         <xsd:attribute name="schema-filter" type="xsd:string" />
         <xsd:attribute name="logging" type="xsd:string" default="false" />
         <xsd:attribute name="profiling" type="xsd:string" default="false" />
         <xsd:attributeGroup ref="driver-config" />
-    </xsd:attributeGroup>
+    </xsd:complexType>
 
     <xsd:attributeGroup name="driver-config">
         <xsd:attribute name="dbname" type="xsd:string" />
@@ -54,7 +59,7 @@
         </xsd:choice>
 
         <xsd:attribute name="default-connection" type="xsd:string" />
-        <xsd:attributeGroup ref="connection-config" />
+        <xsd:attribute name="connection-config" type="connection-config" />
     </xsd:complexType>
 
     <xsd:complexType name="option">
@@ -88,7 +93,7 @@
             <xsd:element name="slave" type="slave" />
         </xsd:choice>
         <xsd:attribute name="name" type="xsd:string" use="required" />
-        <xsd:attributeGroup ref="connection-config" />
+        <xsd:attribute name="connection-config" type="connection-config" />
     </xsd:complexType>
 
     <xsd:complexType name="slave">


### PR DESCRIPTION
Refs #114

This is hacked-in support. Some of the code may be usable, but really this shows that some refactoring is needed so that cache support isn't limited to ORM only.

Please do not merge in this code, just submitting it so that others can see where modifications are needed and run with it. I pretty much have no clue re: the XSD changes, but I didn't get any errors out of Symfony2 or PHPStorm with my changes. Regardless, even the XSD changes need refactoring, as the cache type definitions should be moved into a reusable location in the schema imho (so that it's accessible by both dbal and orm namespaces).

Also, this has only been tested with Service type cache instance. I don't have the time to attempt this proper.
