### PR TITLE
[WIP] add compiler pass for bundles to register mappings

### DIFF
--- a/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -89,12 +89,12 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
     }
 
     /**
-     * @param array  $mappings            Hashmap of directory path to namespace
+     * @param array    $mappings          Hashmap of directory path to namespace
      * @param string[] $managerParameters List of parameters that could which object manager name
      *                                    your bundle uses. This compiler pass will automatically
      *                                    append the parameter name for the default entity manager
      *                                    to this list.
-     * @param string $enabledParameter    Service container parameter that must be present to
+     * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
      */
@@ -108,13 +108,13 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
     }
 
     /**
-     * @param array  $namespaces          List of namespaces that are handled with annotation mapping
-     * @param array  $directories         List of directories to look for annotated classes
+     * @param array    $namespaces        List of namespaces that are handled with annotation mapping
+     * @param array    $directories       List of directories to look for annotated classes
      * @param string[] $managerParameters List of parameters that could which object manager name
      *                                    your bundle uses. This compiler pass will automatically
      *                                    append the parameter name for the default entity manager
      *                                    to this list.
-     * @param string $enabledParameter    Service container parameter that must be present to
+     * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
      */
@@ -127,13 +127,13 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
     }
 
     /**
-     * @param array  $namespaces          List of namespaces that are handled with static php mapping
-     * @param array  $directories         List of directories to look for static php mapping files
+     * @param array    $namespaces        List of namespaces that are handled with static php mapping
+     * @param array    $directories       List of directories to look for static php mapping files
      * @param string[] $managerParameters List of parameters that could which object manager name
      *                                    your bundle uses. This compiler pass will automatically
      *                                    append the parameter name for the default entity manager
      *                                    to this list.
-     * @param string $enabledParameter    Service container parameter that must be present to
+     * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
      */


### PR DESCRIPTION
use the compiler pass added to the doctrine bridge to provide a nice compiler pass for bundles. See https://github.com/symfony/symfony/pull/7599

i will also write documentation once we agree on the exact format. for now see https://github.com/FriendsOfSymfony/FOSUserBundle/pull/1081 for an example how this is intended to be used.
