### PR TITLE
Split indexes returned by mysql

### DIFF
--- a/Resources/views/Collector/explain.html.twig
+++ b/Resources/views/Collector/explain.html.twig
@@ -11,8 +11,8 @@
     <tbody>
         {% for row in data %}
         <tr>
-            {% for item in row %}
-                <td>{{ item }}</td>
+            {% for key, item in row %}
+                <td>{{ 'possible_keys' == key ? item|replace({',': ', '}) : item }}</td>
             {% endfor %}
         </tr>
         {% endfor %}


### PR DESCRIPTION
Currently PDO returns indexes from MySQL Explain query separated by comma without space, which leads to a very long lines in Symfony profiler.
- [ ] Check that other DBs will handle this
