### PR TITLE
Add custom namespace option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -421,6 +421,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('instance_class')->end()
                 ->scalarNode('class')->end()
                 ->scalarNode('id')->end()
+                ->scalarNode('namespace')->defaultNull()->end()
             ->end()
         ;
 


### PR DESCRIPTION
In the current Doctrine bridge, Symfony will generate a random hash for a cache namespace. The issue we have is when we do a composer update it tends destroys our entire cache and it has to be re-built under the newly generated namespace.

Beyond that, this can also cause problems when one memcached server is being used for multiple sites that have similar `vendor` directories. The other site, if it using similar data access code (and the same entity types), will load another site's content as the keys are the same.

This change allows an option `namespace` for each cache driver to be used like so:

``` yml
doctrine:
    orm:
        entity_managers:
                metadata_cache_driver:
                    type: memcached
                    namespace: my_custom_namespace1
                query_cache_driver:
                    type: memcached
                    namespace: my_custom_namespace2
                result_cache_driver:
                    type: memcached
                    namespace: my_results_namespace
```

This defaults to null to make sure this option is not required and Symfony's default behaviour is retained. It is also still compatible with current Symfony as this option would be ignored in the current version.

This change depends on https://github.com/Tatsh/symfony/compare/di-cache-namespace to work.
