### PR TITLE
Adapt collector template name to webprofiler conventions

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -35,7 +35,7 @@
         </service>
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
-            <tag name="data_collector" template="DoctrineBundle:Collector:db" id="db" />
+            <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" />
             <argument type="service" id="doctrine" />
         </service>
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | fabpot/Twig#1156 |
| License | MIT |

Debugging the issue I noticed that the @WebProfiler templates use a different convention than this bundle.

This is a quick fix.

To allow the conventions most bundles use the Twig_Loader_Filesystem needs to be updated instead.
