### PR TITLE
Added option to configure repository factory service

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -306,6 +306,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('auto_mapping')->defaultFalse()->end()
                     ->scalarNode('naming_strategy')->defaultValue('doctrine.orm.naming_strategy.default')->end()
                     ->scalarNode('entity_listener_resolver')->defaultNull()->end()
+                    ->scalarNode('repository_factory')->defaultNull()->end()
                 ->end()
                 ->fixXmlConfig('hydrator')
                 ->children()

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -303,6 +303,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if ($entityManager['entity_listener_resolver']) {
             $methods['setEntityListenerResolver'] = new Reference($entityManager['entity_listener_resolver']);
         }
+        if ($entityManager['repository_factory']) {
+            $methods['setRepositoryFactory'] = new Reference($entityManager['repository_factory']);
+        }
         foreach ($methods as $method => $arg) {
             $ormConfigDef->addMethodCall($method, array($arg));
         }

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -130,6 +130,7 @@
         <xsd:attribute name="query-cache-driver" type="xsd:string" />
         <xsd:attribute name="naming-strategy" type="xsd:string" />
         <xsd:attribute name="entity-listener-resolver" type="xsd:string" />
+        <xsd:attribute name="repository-factory" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="resolve_target_entity">
@@ -180,7 +181,7 @@
         <xsd:attribute name="class" type="xsd:string" />
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
-    
+
     <xsd:complexType name="parameter">
         <xsd:simpleContent>
             <xsd:extension base="xsd:string">

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -791,17 +791,17 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'addResolveTargetEntity', array('Symfony\Component\Security\Core\User\UserInterface', 'MyUserClass', array()));
         $this->assertEquals(array('doctrine.event_listener' => array( array('event' => 'loadClassMetadata') ) ), $definition->getTags());
     }
-    
+
     public function testDbalSchemaFilter()
     {
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
         $container->registerExtension($loader);
-    
+
         $this->loadFromFile($container, 'dbal_schema_filter');
-    
+
         $this->compileContainer($container);
-        
+
         $definition = $container->getDefinition('doctrine.dbal.default_connection.configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setFilterSchemaAssetsExpression', array('^sf2_'));
     }
@@ -818,6 +818,20 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityListenerResolver', array('entity_listener_resolver'));
+    }
+
+    public function testRepositoryFactory()
+    {
+        $container = $this->getContainer();
+        $loader = new DoctrineExtension();
+        $container->registerExtension($loader);
+
+        $this->loadFromFile($container, 'orm_repository_factory');
+
+        $this->compileContainer($container);
+
+        $definition = $container->getDefinition('doctrine.orm.default_configuration');
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setRepositoryFactory', array('repository_factory'));
     }
 
     protected function getContainer($bundles = 'YamlBundle', $vendor = null)
@@ -905,14 +919,14 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
                 if ($called > $nbCalls) {
                     break;
                 }
-                
+
                 if (isset($params[$called])) {
                     $this->assertEquals($params[$called], $call[1], "Expected parameters to methods '".$methodName."' do not match the actual parameters.");
                 }
                 $called++;
             }
         }
-        
+
         $this->assertEquals($nbCalls, $called, sprintf('The method "%s" should be called %d times', $methodName, $nbCalls));
     }
 

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_repository_factory.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_repository_factory.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm default-entity-manager="default" repository-factory="repository_factory" />
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_repository_factory.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_repository_factory.yml
@@ -1,0 +1,9 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        repository_factory: repository_factory


### PR DESCRIPTION
In a similar fashion as #176, this allows you to assign a custom repository factory:

``` yaml
doctrine:
    orm:
        repository_factory: repository_factory
```

I noticed my editor removed some unnecessary whitespace, I'm not sure if this is a problem for this pull request.
