### PR TITLE
Typo at documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following dependencies to your projects composer.json file:
 
     "require": {
         # ..
-        "doctrine/doctrine-bundle": ">=2.1"
+        "doctrine/doctrine-bundle": ">=1.2"
         # ..
     }
 


### PR DESCRIPTION
The oldest stable version of doctrine/doctrine-bundle is 1.2.0, but at installation instructions required ">=2.1".
