### PR TITLE
Update composer.json to allow dev-master of doctrine/dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.2",
         "symfony/doctrine-bridge": "~2.2",
-        "doctrine/dbal": ">=2.2,<2.5-dev",
+        "doctrine/dbal": ">=2.2,<2.6-dev",
         "jdorn/sql-formatter": "~1.1"
     },
     "require-dev": {


### PR DESCRIPTION
For development purposes and bug fixes the latest dev-master of dbal is required sometimes. With the current constraint of ">=2.2,<2.5-dev" it is not possible to install doctrine/dbal through composer.
