### PR TITLE
[DBAL-81] Add auto-commit DBAL configuration option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -135,6 +135,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue('pdo_mysql')->end()
                 ->scalarNode('platform_service')->end()
+                ->booleanNode('auto_commit')->end()
                 ->scalarNode('schema_filter')->end()
                 ->booleanNode('logging')->defaultValue($this->debug)->end()
                 ->booleanNode('profiling')->defaultValue($this->debug)->end()

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -136,6 +136,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
         unset($connection['profiling']);
 
+        if (isset($connection['auto_commit'])) {
+            $configuration->addMethodCall('setAutoCommit', array($connection['auto_commit']));
+        }
+
+        unset($connection['auto_commit']);
+
         if (isset($connection['schema_filter']) && $connection['schema_filter']) {
             $configuration->addMethodCall('setFilterSchemaAssetsExpression', array($connection['schema_filter']));
         }

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -32,6 +32,7 @@
         <xsd:attribute name="platform-service" type="xsd:string" />
         <xsd:attribute name="shard-choser" type="xsd:string" />
         <xsd:attribute name="shard-choser-service" type="xsd:string" />
+        <xsd:attribute name="auto-commit" type="xsd:string" />
         <xsd:attribute name="schema-filter" type="xsd:string" />
         <xsd:attribute name="logging" type="xsd:string" default="false" />
         <xsd:attribute name="profiling" type="xsd:string" default="false" />

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -31,6 +31,7 @@ Configuration Reference
                         charset:              UTF8
                         logging:              %kernel.debug%
                         platform_service:     MyOwnDatabasePlatformService
+                        auto_commit:          false
                         schema_filter:        ^sf2_
                         mapping_types:
                             enum: string
@@ -98,6 +99,7 @@ Configuration Reference
                         charset="UTF8"
                         logging="%kernel.debug%"
                         platform-service="MyOwnDatabasePlatformService"
+                        auto-commit="false"
                         schema-filter="^sf2_"
                     >
                         <doctrine:option key="foo">bar</doctrine:option>
@@ -272,6 +274,7 @@ can configure. The following block shows all possible configuration keys:
                 charset:              UTF8
                 logging:              %kernel.debug%
                 platform_service:     MyOwnDatabasePlatformService
+                auto_commit:          false
                 schema_filter:        ^sf2_
                 mapping_types:
                     enum: string
@@ -300,6 +303,7 @@ can configure. The following block shows all possible configuration keys:
                 charset="UTF8"
                 logging="%kernel.debug%"
                 platform-service="MyOwnDatabasePlatformService"
+                auto-commit="false"
                 schema-filter="^sf2_"
             >
                 <doctrine:option key="foo">bar</doctrine:option>

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -688,6 +688,20 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         )));
     }
 
+    public function testDbalAutoCommit()
+    {
+        $container = $this->getContainer();
+        $loader = new DoctrineExtension();
+        $container->registerExtension($loader);
+
+        $this->loadFromFile($container, 'dbal_auto_commit');
+
+        $this->compileContainer($container);
+
+        $definition = $container->getDefinition('doctrine.dbal.default_connection.configuration');
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setAutoCommit', array(false));
+    }
+
     public function testDbalSchemaFilter()
     {
         $container = $this->getContainer();

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_auto_commit.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_auto_commit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal auto-commit="false" />
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_auto_commit.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_auto_commit.yml
@@ -1,0 +1,3 @@
+doctrine:
+    dbal:
+        auto_commit: false


### PR DESCRIPTION
This makes DBAL auto-commit mode (introduced in [DBAL-81](http://www.doctrine-project.org/jira/browse/DBAL-81) / https://github.com/doctrine/dbal/pull/409) configurable in DoctrineBundle.
Please note that this is my first PR to this repo, so if I missed anything, please shout at me :)
