### PR TITLE
removed usage of a deprecated class

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -29,7 +29,7 @@
         <parameter key="doctrine.orm.cache.zenddata.class">Doctrine\Common\Cache\ZendDataCache</parameter>
 
         <!-- metadata -->
-        <parameter key="doctrine.orm.metadata.driver_chain.class">Doctrine\ORM\Mapping\Driver\DriverChain</parameter>
+        <parameter key="doctrine.orm.metadata.driver_chain.class">Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain</parameter>
         <parameter key="doctrine.orm.metadata.annotation.class">Doctrine\ORM\Mapping\Driver\AnnotationDriver</parameter>
         <parameter key="doctrine.orm.metadata.xml.class">Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver</parameter>
         <parameter key="doctrine.orm.metadata.yml.class">Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver</parameter>

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -38,7 +38,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Doctrine\DBAL\Connection', $container->get('doctrine.dbal.default_connection'));
         $this->assertInstanceOf('Doctrine\Common\Annotations\Reader', $container->get('doctrine.orm.metadata.annotation_reader'));
         $this->assertInstanceOf('Doctrine\ORM\Configuration', $container->get('doctrine.orm.default_configuration'));
-        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\DriverChain', $container->get('doctrine.orm.default_metadata_driver'));
+        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain', $container->get('doctrine.orm.default_metadata_driver'));
         $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $container->get('doctrine.orm.default_metadata_cache'));
         $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $container->get('doctrine.orm.default_query_cache'));
         $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $container->get('doctrine.orm.default_result_cache'));

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -68,7 +68,7 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('11211', $container->getParameter('doctrine.orm.cache.memcache_port'));
         $this->assertEquals('Memcache', $container->getParameter('doctrine.orm.cache.memcache_instance.class'));
         $this->assertEquals('Doctrine\Common\Cache\XcacheCache', $container->getParameter('doctrine.orm.cache.xcache.class'));
-        $this->assertEquals('Doctrine\ORM\Mapping\Driver\DriverChain', $container->getParameter('doctrine.orm.metadata.driver_chain.class'));
+        $this->assertEquals('Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain', $container->getParameter('doctrine.orm.metadata.driver_chain.class'));
         $this->assertEquals('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $container->getParameter('doctrine.orm.metadata.annotation.class'));
         $this->assertEquals('Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver', $container->getParameter('doctrine.orm.metadata.xml.class'));
         $this->assertEquals('Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver', $container->getParameter('doctrine.orm.metadata.yml.class'));

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.2",
         "symfony/doctrine-bridge": "~2.2",
-        "doctrine/dbal": ">=2.2,<2.6-dev",
+        "doctrine/dbal": ">=2.3,<2.6-dev",
         "jdorn/sql-formatter": "~1.1"
     },
     "require-dev": {
-        "doctrine/orm": "~2.2",
+        "doctrine/orm": "~2.3",
         "symfony/yaml": "~2.2",
         "symfony/validator": "~2.2"
     },


### PR DESCRIPTION
The `DriverChain` class is deprecated, so it should not be used anymore.
