### PR TITLE
Take a look if exists Namespace in the Classname

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -113,9 +113,9 @@ EOT
                 $className = $class->name;
                 $class->name = $bundle->getNamespace().'\\Entity\\'.$className;
                 if ('annotation' === $type) {
-                    $path = $destPath.'/'.$className.'.php';
+                    $path = $destPath.'/'.str_replace('\\', '/', $className).'.php';
                 } else {
-                    $path = $destPath.'/'.$className.'.orm.'.$type;
+                    $path = $destPath.'/'.str_replace('\\', '/', $className).'.orm.'.$type;
                 }
                 $output->writeln(sprintf('  > writing <comment>%s</comment>', $path));
                 $code = $exporter->exportClassMetadata($class);


### PR DESCRIPTION
If we work with PostgreSQL Schema The Doctrine Generator may put Namespace in the Classname. The Namespace of the Entity represents the schema name for a table.

Right now, when we work with PostgreSQL Schema name 'access' and a table named 'user' and therefore therefore the Class name contain a string like 'Access\User' will be created a file named (on linux) 'Access\User.php'.
