### PR TITLE
Retrieve and use tagged filters

### DIFF
--- a/DependencyInjection/Compiler/FilterConfigurationPass.php
+++ b/DependencyInjection/Compiler/FilterConfigurationPass.php
@@ -7,6 +7,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -15,7 +16,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 /**
  * Combines the filters from the config with the filters that are tagged with
- * doctrine.filter
+ * doctrine.orm.filter
  *
  * @author Nico Schoenmaker<nschoenmaker@hostnet.nl>
  */

--- a/DependencyInjection/Compiler/FilterConfigurationPass.php
+++ b/DependencyInjection/Compiler/FilterConfigurationPass.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle (c) Fabien Potencier
+ * <fabien@symfony.com> (c) Doctrine Project, Benjamin Eberlei
+ * <kontakt@beberlei.de> For the full copyright and license information, please
+ * view the LICENSE file that was distributed with this source code.
+ */
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Combines the filters from the config with the filters that are tagged with
+ * doctrine.filter
+ *
+ * @author Nico Schoenmaker<nschoenmaker@hostnet.nl>
+ */
+class FilterConfigurationPass implements CompilerPassInterface
+{
+
+    private $tagPrefix;
+
+    public function __construct($tagPrefix)
+    {
+        $this->tagPrefix = $tagPrefix;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $filtersFromTags = $this->gatherFiltersFromTags(
+                $container->findTaggedServiceIds($this->tagPrefix . '.filter'));
+        $entityManagers = $container->getParameter('doctrine.entity_managers');
+        foreach ($entityManagers as $name => $service_id) {
+            // Get the configurator of the entity manager, this needs to be a
+            // Reference
+            $callable = $container->getDefinition($service_id)->getConfigurator();
+            if (! is_array($callable) || count($callable) != 2 ||
+                     ! isset($callable[0])) {
+                throw new \RuntimeException(
+                        sprintf(
+                                'Should have gotten a callable as configurator of "%s"',
+                                $service_id));
+            }
+            $reference = $callable[0];
+            if (! $reference instanceof Reference) {
+                throw new \RuntimeException(
+                        'Expected to get an instance of reference');
+            }
+            $definition = $container->getDefinition($reference);
+            $this->importTaggedFilters($definition, $filtersFromTags);
+        }
+    }
+
+    private function gatherFiltersFromTags(array $taggedFilters)
+    {
+        $filtersFromTags = array();
+        foreach ($taggedFilters as $id => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                if (! isset($attributes['filter_name'])) {
+                    throw new \RuntimeException(
+                            sprintf(
+                                    'Service %s is missing a name attribute on it\'s tag',
+                                    $id));
+                }
+                $enabled = isset($attributes['enabled']) ? $attributes['enabled'] : true;
+
+                // TODO enable parameter support
+                $filtersFromTags[$attributes['filter_name']] = array(
+                        'identifier' => $id,
+                        'enabled' => $enabled,
+                        'parameters' => array()
+                );
+            }
+        }
+        return $filtersFromTags;
+    }
+
+    private function importTaggedFilters(Definition $managerConfigurator,
+            $filtersFromTags)
+    {
+        $filters = $managerConfigurator->getArgument(0);
+        $resultingFilters = array();
+
+        foreach ($filtersFromTags as $name => $filter) {
+            $resultingFilters[$name] = $filter;
+            if (isset($filters[$name]['enabled'])) {
+                $resultingFilters['enabled'] = $filters[$name]['enabled'];
+            }
+        }
+
+        $filters = array_diff_key($filters, $filtersFromTags);
+        foreach ($filters as $name => $filter) {
+            if (! isset($filter['class'])) {
+                throw new InvalidConfigurationException(
+                        sprintf('Filter %s should have a class attribute',
+                                $name));
+            }
+            $resultingFilters[$name] = array(
+                    'identifier' => $filter['class'],
+                    'enabled' => $filter['enabled'],
+                    'parameters' => $filter['parameters']
+            );
+        }
+
+        $managerConfigurator->replaceArgument(0, $resultingFilters);
+    }
+}

--- a/DependencyInjection/Compiler/FilterConfigurationPass.php
+++ b/DependencyInjection/Compiler/FilterConfigurationPass.php
@@ -32,7 +32,7 @@ class FilterConfigurationPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $filtersFromTags = $this->gatherFiltersFromTags(
-                $container->findTaggedServiceIds($this->tagPrefix . '.filter'));
+                $container->findTaggedServiceIds($this->tagPrefix . '.orm.filter'));
         $entityManagers = $container->getParameter('doctrine.entity_managers');
         foreach ($entityManagers as $name => $service_id) {
             // Get the configurator of the entity manager, this needs to be a
@@ -88,7 +88,7 @@ class FilterConfigurationPass implements CompilerPassInterface
         foreach ($filtersFromTags as $name => $filter) {
             $resultingFilters[$name] = $filter;
             if (isset($filters[$name]['enabled'])) {
-                $resultingFilters['enabled'] = $filters[$name]['enabled'];
+                $resultingFilters[$name]['enabled'] = $filters[$name]['enabled'];
             }
         }
 
@@ -105,7 +105,6 @@ class FilterConfigurationPass implements CompilerPassInterface
                     'parameters' => $filter['parameters']
             );
         }
-
         $managerConfigurator->replaceArgument(0, $resultingFilters);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -397,7 +397,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->fixXmlConfig('parameter')
                             ->children()
-                                ->scalarNode('class')->isRequired()->end()
+                                ->scalarNode('class')->end()
                                 ->booleanNode('enabled')->defaultFalse()->end()
                                 ->arrayNode('parameters')
                                     ->useAttributeAsKey('name')

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -361,23 +361,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
             }
         }
 
-        $enabledFilters = array();
-        $filtersParameters = array();
-        foreach ($entityManager['filters'] as $name => $filter) {
-            $ormConfigDef->addMethodCall('addFilter', array($name, $filter['class']));
-            if ($filter['enabled']) {
-                $enabledFilters[] = $name;
-            }
-            if ($filter['parameters']) {
-                $filtersParameters[$name] = $filter['parameters'];
-            }
-        }
-
         $managerConfiguratorName = sprintf('doctrine.orm.%s_manager_configurator', $entityManager['name']);
         $managerConfiguratorDef = $container
             ->setDefinition($managerConfiguratorName, new DefinitionDecorator('doctrine.orm.manager_configurator.abstract'))
-            ->replaceArgument(0, $enabledFilters)
-            ->replaceArgument(1, $filtersParameters)
+            ->replaceArgument(0, $entityManager['filters'])
         ;
 
         if (!isset($entityManager['connection'])) {

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -336,6 +336,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $container->setDefinition(sprintf('doctrine.orm.%s_entity_listener_resolver', $entityManager['name']), new Definition('%doctrine.orm.entity_listener_resolver.class%'));
         }
 
+        $container->setDefinition(sprintf('doctrine.orm.%s_filter_factory', $entityManager['name']), new DefinitionDecorator('doctrine.orm.filter_factory'));
+
         $methods = array(
             'setMetadataCacheImpl'        => new Reference(sprintf('doctrine.orm.%s_metadata_cache', $entityManager['name'])),
             'setQueryCacheImpl'           => new Reference(sprintf('doctrine.orm.%s_query_cache', $entityManager['name'])),
@@ -346,6 +348,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             'setAutoGenerateProxyClasses' => '%doctrine.orm.auto_generate_proxy_classes%',
             'setClassMetadataFactoryName' => $entityManager['class_metadata_factory_name'],
             'setDefaultRepositoryClassName' => $entityManager['default_repository_class'],
+            'setFilterFactory'            => new Reference(sprintf('doctrine.orm.%s_filter_factory', $entityManager['name'])),
         );
         // check for version to keep BC
         if (version_compare(\Doctrine\ORM\Version::VERSION, "2.3.0-DEV") >= 0) {
@@ -487,7 +490,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
     /**
      * Loads an ORM second level cache bundle mapping information.
-     * 
+     *
      * @example
      *  entity_managers:
      *      default:

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -14,10 +14,13 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
+
+
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\FilterConfigurationPass;
 use Doctrine\ORM\Proxy\Autoloader;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -44,7 +47,10 @@ class DoctrineBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass('doctrine.connections', 'doctrine.dbal.%s_connection.event_manager', 'doctrine'), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+        $tagPrefix = 'doctrine';
+
+        $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass('doctrine.connections', 'doctrine.dbal.%s_connection.event_manager', $tagPrefix), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+        $container->addCompilerPass(new FilterConfigurationPass($tagPrefix));
 
         if ($container->hasExtension('security')) {
             $container->getExtension('security')->addUserProviderFactory(new EntityFactory('entity', 'doctrine.orm.security.user.provider'));

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -14,15 +14,11 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
-use Doctrine\Bundle\DoctrineBundle\Query\ContainerFilterCollection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Filter\SQLFilter;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Configurator for an EntityManager
- *
- * Gets  a container so it can lazy-load filters
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
@@ -30,17 +26,13 @@ class ManagerConfigurator
 {
     private $filters;
 
-    private $container;
-
     /**
      * Construct.
      * @param array $filters
-     * @param ContainerInterface $container
      */
-    public function __construct(array $filters, ContainerInterface $container)
+    public function __construct(array $filters)
     {
         $this->filters = $filters;
-        $this->container = $container;
     }
 
     /**
@@ -72,7 +64,6 @@ class ManagerConfigurator
         if (empty($enabledFilters)) {
             return;
         }
-        $entityManager->setFilters(new ContainerFilterCollection($entityManager, $this->container));
 
         $filterCollection = $entityManager->getFilters();
         foreach ($enabledFilters as $name => $filter) {

--- a/Query/ContainerFilterCollection.php
+++ b/Query/ContainerFilterCollection.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+*
+* The code was originally distributed inside the Symfony framework.
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+* (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Doctrine\Bundle\DoctrineBundle\Query;
+
+use Doctrine\ORM\Query\FilterCollection;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filter collection that can retrieve filters from the DI container
+ *
+ * @author Nico Schoenmaker <nschoenmaker@hostnet.nl>
+ */
+class ContainerFilterCollection extends FilterCollection
+{
+    private $config;
+    private $container;
+
+    /**
+     * @param EntityManagerInterface $em
+     * @param ContainerInterface $container
+     */
+    public function __construct(EntityManagerInterface $em, ContainerInterface $container)
+    {
+        parent::__construct($em);
+        $this->config = $em->getConfiguration();
+        $this->container = $container;
+    }
+
+    /**
+     * @see \Doctrine\ORM\Query\FilterCollection::enable()
+     */
+    public function enable($name)
+    {
+        if ( ! $this->has($name)) {
+            throw new \InvalidArgumentException("Filter '" . $name . "' does not exist.");
+        }
+
+        if ( ! $this->isEnabled($name)) {
+            $service_id = $this->config->getFilterClassName($name);
+            if(strpos($service_id, '.') === false) {
+                return parent::enable($name);
+            }
+            $this->enabledFilters[$name] = $this->container->get($service_id);
+
+            // Keep the enabled filters sorted for the hash
+            ksort($this->enabledFilters);
+
+            // Now the filter collection is dirty
+            $this->filtersState = self::FILTERS_STATE_DIRTY;
+        }
+
+        return $this->enabledFilters[$name];
+    }
+}

--- a/Query/ContainerFilterCollection.php
+++ b/Query/ContainerFilterCollection.php
@@ -42,28 +42,14 @@ class ContainerFilterCollection extends FilterCollection
     }
 
     /**
-     * @see \Doctrine\ORM\Query\FilterCollection::enable()
+     * @see \Doctrine\ORM\Query\FilterCollection::createFilterClass()
      */
-    public function enable($name)
+    protected function createFilterClass($name)
     {
-        if ( ! $this->has($name)) {
-            throw new \InvalidArgumentException("Filter '" . $name . "' does not exist.");
+        $service_id = $this->config->getFilterClassName($name);
+        if (strpos($service_id, '.') === false) {
+            return parent::createFilterClass($name);
         }
-
-        if ( ! $this->isEnabled($name)) {
-            $service_id = $this->config->getFilterClassName($name);
-            if(strpos($service_id, '.') === false) {
-                return parent::enable($name);
-            }
-            $this->enabledFilters[$name] = $this->container->get($service_id);
-
-            // Keep the enabled filters sorted for the hash
-            ksort($this->enabledFilters);
-
-            // Now the filter collection is dirty
-            $this->filtersState = self::FILTERS_STATE_DIRTY;
-        }
-
-        return $this->enabledFilters[$name];
+        return $this->container->get($service_id);
     }
 }

--- a/Query/ContainerFilterFactory.php
+++ b/Query/ContainerFilterFactory.php
@@ -14,10 +14,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Query;
 
-use Doctrine\ORM\Query\FilterCollection;
-
-use Doctrine\ORM\EntityManagerInterface;
-
+use Doctrine\ORM\Query\Filter\DefaultFilterFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -25,30 +22,26 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Nico Schoenmaker <nschoenmaker@hostnet.nl>
  */
-class ContainerFilterCollection extends FilterCollection
+class ContainerFilterFactory extends DefaultFilterFactory
 {
-    private $config;
     private $container;
 
     /**
-     * @param EntityManagerInterface $em
      * @param ContainerInterface $container
      */
-    public function __construct(EntityManagerInterface $em, ContainerInterface $container)
+    public function __construct(ContainerInterface $container)
     {
-        parent::__construct($em);
-        $this->config = $em->getConfiguration();
         $this->container = $container;
     }
 
     /**
-     * @see \Doctrine\ORM\Query\FilterCollection::createFilterClass()
+     * {@inheritDoc}
      */
-    protected function createFilterClass($name)
+    public function createFilter($name)
     {
-        $service_id = $this->config->getFilterClassName($name);
+        $service_id = $this->getConfig()->getFilterClassName($name);
         if (strpos($service_id, '.') === false) {
-            return parent::createFilterClass($name);
+            return parent::createFilter($name);
         }
         return $this->container->get($service_id);
     }

--- a/Query/ContainerFilterFactory.php
+++ b/Query/ContainerFilterFactory.php
@@ -14,6 +14,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Query;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\DefaultFilterFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -37,11 +38,11 @@ class ContainerFilterFactory extends DefaultFilterFactory
     /**
      * {@inheritDoc}
      */
-    public function createFilter($name)
+    public function createFilter(EntityManagerInterface $em, $name)
     {
-        $service_id = $this->getConfig()->getFilterClassName($name);
+        $service_id = $em->getConfiguration()->getFilterClassName($name);
         if (strpos($service_id, '.') === false) {
-            return parent::createFilter($name);
+            return parent::createFilter($em, $name);
         }
         return $this->container->get($service_id);
     }

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -8,6 +8,7 @@
         <parameter key="doctrine.orm.configuration.class">Doctrine\ORM\Configuration</parameter>
         <parameter key="doctrine.orm.entity_manager.class">Doctrine\ORM\EntityManager</parameter>
         <parameter key="doctrine.orm.manager_configurator.class">Doctrine\Bundle\DoctrineBundle\ManagerConfigurator</parameter>
+        <parameter key="doctrine.orm.container_filter_factory.class">Doctrine\Bundle\DoctrineBundle\Query\ContainerFilterFactory</parameter>
 
         <!-- cache -->
         <parameter key="doctrine.orm.cache.array.class">Doctrine\Common\Cache\ArrayCache</parameter>
@@ -96,6 +97,9 @@
         <!-- The configurator cannot be a private service -->
         <service id="doctrine.orm.manager_configurator.abstract" class="%doctrine.orm.manager_configurator.class%" abstract="true">
             <argument type="collection" />
+        </service>
+
+        <service id="doctrine.orm.filter_factory" class="%doctrine.orm.container_filter_factory.class%" abstract="true" public="false">
             <argument type="service" id="service_container" />
         </service>
 

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -83,7 +83,7 @@
         <!-- The configurator cannot be a private service -->
         <service id="doctrine.orm.manager_configurator.abstract" class="%doctrine.orm.manager_configurator.class%" abstract="true">
             <argument type="collection" />
-            <argument type="collection" />
+            <argument type="service" id="service_container" />
         </service>
 
         <!-- validator -->

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -605,8 +605,7 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
                 'enabled' => true,
                 'identifier' => 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter',
                 'parameters' => array('myParameter' => 'myValue', 'mySecondParameter' => 'mySecondValue'
-            ))),
-            new Reference('service_container')
+            )))
         ));
 
         // Let's create the instance to check the configurator work.

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -127,12 +127,9 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('doctrine.orm.default_query_cache', (string) $calls[2][1][0]);
         $this->assertEquals('doctrine.orm.default_result_cache', (string) $calls[3][1][0]);
 
-        if (version_compare(Version::VERSION, "2.3.0-DEV") >= 0) {
-            $this->assertEquals('doctrine.orm.naming_strategy.default', (string) $calls[10][1][0]);
-        }
-        if (version_compare(Version::VERSION, "2.4.0-DEV") >= 0) {
-            $this->assertEquals('doctrine.orm.default_entity_listener_resolver', (string) $calls[11][1][0]);
-        }
+        $this->assertEquals('doctrine.orm.default_filter_factory', (string) $calls[10][1][0]);
+        $this->assertEquals('doctrine.orm.naming_strategy.default', (string) $calls[11][1][0]);
+        $this->assertEquals('doctrine.orm.default_entity_listener_resolver', (string) $calls[12][1][0]);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_cache');
         $this->assertEquals('%doctrine.orm.cache.array.class%', $definition->getClass());

--- a/Tests/Query/ContainerFilterFactoryTest.php
+++ b/Tests/Query/ContainerFilterFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Query;
+
+use Doctrine\Bundle\DoctrineBundle\Query\ContainerFilterFactory;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+
+class ContainerFilterFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateFilter()
+    {
+        $configuration = new Configuration();
+        $configuration->addFilter('oldSkoolFilter', 'Doctrine\Bundle\DoctrineBundle\Tests\Query\MockFilter');
+        $configuration->addFilter('containerFilter', 'my.service');
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em->expects($this->any())->method('getConfiguration')->will($this->returnValue($configuration));
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerFilter = new MockContainerFilter($em);
+        $container->expects($this->once())->method('get')->will($this->returnValue($containerFilter));
+        $factory = new ContainerFilterFactory($container);
+
+        $filter = $factory->createFilter($em, 'oldSkoolFilter');
+        $this->assertInstanceOf('Doctrine\Bundle\DoctrineBundle\Tests\Query\MockFilter', $filter);
+
+        $filter = $factory->createFilter($em, 'containerFilter');
+        $this->assertEquals($containerFilter, $filter);
+    }
+}
+
+class MockFilter extends SQLFilter
+{
+    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
+    {
+    }
+}
+
+class MockContainerFilter extends SQLFilter
+{
+  public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
+  {
+  }
+}


### PR DESCRIPTION
Allows bundles to add their own filters.

Using tags for the filters feels nicer in the Symfony ecosystem. It also allows setter injection of application specific dependencies that one might want to use in a filter.

The author of a bundle can say whether a filter should be enabled by default
```
   my_bundle.valid_date_filter:
        class: Hostnet\MyBundle\Filter\ValidDateFilter
        arguments: ["@doctrine.orm.entity_manager"]
        tags:
            - { name: doctrine.filter, filter_name: page_valid_date, enabled: true }
```

The user of the bundle can, of course, ignore the authors suggestion and do something different in ```config.yml```:
```
                filters:
                    page_valid_date:
                        enabled: false
```

The current implementation requires some adjustment in Doctrine\ORM as well
- ```Doctrine\ORM\EntityManager``` gets a setFilters method.
- In ```Doctrine\ORM\Query\FilterCollection``` $enabledFilters and $filtersState become protected.

Adding filters as is done right now is still supported. Tips & tricks to improve this PR are appreciated :)