### PR TITLE
disabled escaping of parameters in DB Profiler Collector

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -107,7 +107,7 @@
                                 {{ query.sql|doctrine_replace_query_parameters(query.params)|raw }}
                             </span>
                             <small>
-                                <strong>Parameters</strong>: {{ query.params|yaml_encode }} <br />
+                                <strong>Parameters</strong>: {{ query.params|yaml_encode|raw }} <br />
                                 [<span id="expandParams-{{ i }}-{{ loop.parent.loop.index }}" onclick="javascript:toggleRunnableQuery(this);" target-data-id="original-query-{{ i }}-{{ loop.parent.loop.index }}" style="cursor: pointer;">Display runnable query</span>]<br/>
                                 <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
                             </small>


### PR DESCRIPTION
When using binary parameters in Queries, the Doctrine Profiler page fails to load, because the parameters are being escaped. Changed it to raw, which works for binary UUID data as well as other scalar values.