### PR TITLE
Change branch alias to 1.3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "1.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
New releases are tagged as 1.3.x, so updating the branch alias is appropriate.
