### PR TITLE
Add missing DBAL connection parameter definitions

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -201,11 +201,28 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('unix_socket')->info('The unix socket to use for MySQL')->end()
                 ->booleanNode('persistent')->info('True to use as persistent connection for the ibm_db2 driver')->end()
                 ->scalarNode('protocol')->info('The protocol to use for the ibm_db2 driver (default to TCPIP if ommited)')->end()
-                ->booleanNode('service')->info('True to use dbname as service name instead of SID for Oracle')->end()
+                ->booleanNode('service')
+                    ->info('True to use SERVICE_NAME as connection parameter instead of SID for Oracle')
+                ->end()
+                ->scalarNode('servicename')
+                    ->info(
+                        'Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter ' .
+                        'for Oracle depending on the service parameter.'
+                    )
+                ->end()
                 ->scalarNode('sessionMode')
                     ->info('The session mode to use for the oci8 driver')
                 ->end()
-                ->booleanNode('pooled')->info('True to use a pooled server with the oci8 driver')->end()
+                ->scalarNode('server')
+                    ->info('The name of a running database server to connect to for SQL Anywhere.')
+                ->end()
+                ->scalarNode('sslmode')
+                    ->info(
+                        'Determines whether or with what priority a SSL TCP/IP connection will be negotiated with ' .
+                        'the server for PostgreSQL.'
+                    )
+                ->end()
+                ->booleanNode('pooled')->info('True to use a pooled server with the oci8/pdo_oracle driver')->end()
                 ->booleanNode('MultipleActiveResultSets')->info('Configuring MultipleActiveResultSets for the pdo_sqlsrv driver')->end()
             ->end()
             ->beforeNormalization()

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -51,8 +51,11 @@
         <xsd:attribute name="charset" type="xsd:string" />
         <xsd:attribute name="persistent" type="xsd:string" />
         <xsd:attribute name="protocol" type="xsd:string" />
+        <xsd:attribute name="server" type="xsd:string" />
         <xsd:attribute name="service" type="xsd:string" />
+        <xsd:attribute name="servicename" type="xsd:string" />
         <xsd:attribute name="session-mode" type="xsd:string" />
+        <xsd:attribute name="sslmode" type="xsd:string" />
         <xsd:attribute name="pooled" type="xsd:string" />
         <xsd:attribute name="multiple-active-result-sets" type="xsd:string" />
     </xsd:attributeGroup>

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -14,25 +14,34 @@ Configuration Reference
                 default_connection:   default
                 connections:
                     default:
-                        dbname:               database
-                        host:                 localhost
-                        port:                 1234
-                        user:                 user
-                        password:             secret
-                        driver:               pdo_mysql
-                        driver_class:         MyNamespace\MyDriverImpl
+                        dbname:                   database
+                        host:                     localhost
+                        port:                     1234
+                        user:                     user
+                        password:                 secret
+                        driver:                   pdo_mysql
+                        driver_class:             MyNamespace\MyDriverImpl
                         options:
                             foo: bar
-                        path:                 %kernel.data_dir%/data.sqlite
-                        memory:               true
-                        unix_socket:          /tmp/mysql.sock
-                        wrapper_class:        MyDoctrineDbalConnectionWrapper
-                        keep_slave:           true
-                        charset:              UTF8
-                        logging:              %kernel.debug%
-                        platform_service:     MyOwnDatabasePlatformService
-                        auto_commit:          false
-                        schema_filter:        ^sf2_
+                        path:                     %kernel.data_dir%/data.sqlite # SQLite specific
+                        memory:                   true                          # SQLite specific
+                        unix_socket:              /tmp/mysql.sock
+                        persistent:               true
+                        MultipleActiveResultSets: true                # pdo_sqlsrv driver specific
+                        pooled:                   true                # Oracle specific (SERVER=POOLED)
+                        protocol:                 TCPIP               # IBM DB2 specific (PROTOCOL)
+                        server:                   my_database_server  # SQL Anywhere specific (ServerName)
+                        service:                  true                # Oracle specific (SERVICE_NAME instead of SID)
+                        servicename:              MyOracleServiceName # Oracle specific (SERVICE_NAME)
+                        sessionMode:              2                   # oci8 driver specific (session_mode)
+                        sslmode:                  require             # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE)
+                        wrapper_class:            MyDoctrineDbalConnectionWrapper
+                        keep_slave:               true
+                        charset:                  UTF8
+                        logging:                  %kernel.debug%
+                        platform_service:         MyOwnDatabasePlatformService
+                        auto_commit:              false
+                        schema_filter:            ^sf2_
                         mapping_types:
                             enum: string
                     conn1:
@@ -91,9 +100,18 @@ Configuration Reference
                         password="secret"
                         driver="pdo_mysql"
                         driver-class="MyNamespace\MyDriverImpl"
-                        path="%kernel.data_dir%/data.sqlite"
-                        memory="true"
+                        path="%kernel.data_dir%/data.sqlite" <!-- SQLite specific -->
+                        memory="true"                        <!-- SQLite specific -->
                         unix-socket="/tmp/mysql.sock"
+                        persistent="true"
+                        multiple-active-result-sets="true" <!-- pdo_sqlsrv driver specific -->
+                        pooled="true"                      <!-- Oracle specific (SERVER=POOLED) -->
+                        protocol="TCPIP"                   <!-- IBM DB2 specific (PROTOCOL) -->
+                        server="my_database_server"        <!-- SQL Anywhere specific (ServerName) -->
+                        service="true"                     <!-- Oracle specific (SERVICE_NAME instead of SID) -->
+                        servicename="MyOracleServiceName"  <!-- Oracle specific (SERVICE_NAME) -->
+                        sessionMode"2"                     <!-- oci8 driver specific (session_mode) -->
+                        sslmode="require"                  <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLMODE) -->
                         wrapper-class="MyDoctrineDbalConnectionWrapper"
                         keep-slave="true"
                         charset="UTF8"
@@ -258,24 +276,33 @@ can configure. The following block shows all possible configuration keys:
 
         doctrine:
             dbal:
-                dbname:               database
-                host:                 localhost
-                port:                 1234
-                user:                 user
-                password:             secret
-                driver:               pdo_mysql
-                driver_class:         MyNamespace\MyDriverImpl
+                dbname:                   database
+                host:                     localhost
+                port:                     1234
+                user:                     user
+                password:                 secret
+                driver:                   pdo_mysql
+                driver_class:             MyNamespace\MyDriverImpl
                 options:
                     foo: bar
-                path:                 %kernel.data_dir%/data.sqlite
-                memory:               true
-                unix_socket:          /tmp/mysql.sock
-                wrapper_class:        MyDoctrineDbalConnectionWrapper
-                charset:              UTF8
-                logging:              %kernel.debug%
-                platform_service:     MyOwnDatabasePlatformService
-                auto_commit:          false
-                schema_filter:        ^sf2_
+                path:                     %kernel.data_dir%/data.sqlite # SQLite specific
+                memory:                   true                          # SQLite specific
+                unix_socket:              /tmp/mysql.sock
+                persistent:               true
+                MultipleActiveResultSets: true                # pdo_sqlsrv driver specific
+                pooled:                   true                # Oracle specific (SERVER=POOLED)
+                protocol:                 TCPIP               # IBM DB2 specific (PROTOCOL)
+                server:                   my_database_server  # SQL Anywhere specific (ServerName)
+                service:                  true                # Oracle specific (SERVICE_NAME instead of SID)
+                servicename:              MyOracleServiceName # Oracle specific (SERVICE_NAME)
+                sessionMode:              2                   # oci8 driver specific (session_mode)
+                sslmode:                  require             # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE)
+                wrapper_class:            MyDoctrineDbalConnectionWrapper
+                charset:                  UTF8
+                logging:                  %kernel.debug%
+                platform_service:         MyOwnDatabasePlatformService
+                auto_commit:              false
+                schema_filter:            ^sf2_
                 mapping_types:
                     enum: string
                 types:
@@ -296,9 +323,18 @@ can configure. The following block shows all possible configuration keys:
                 password="secret"
                 driver="pdo_mysql"
                 driver-class="MyNamespace\MyDriverImpl"
-                path="%kernel.data_dir%/data.sqlite"
-                memory="true"
+                path="%kernel.data_dir%/data.sqlite" <!-- SQLite specific -->
+                memory="true"                        <!-- SQLite specific -->
                 unix-socket="/tmp/mysql.sock"
+                persistent="true"
+                multiple-active-result-sets="true" <!-- pdo_sqlsrv driver specific -->
+                pooled="true"                      <!-- Oracle specific (SERVER=POOLED) -->
+                protocol="TCPIP"                   <!-- IBM DB2 specific (PROTOCOL) -->
+                server="my_database_server"        <!-- SQL Anywhere specific (ServerName) -->
+                service="true"                     <!-- Oracle specific (SERVICE_NAME instead of SID) -->
+                servicename="MyOracleServiceName"  <!-- Oracle specific (SERVICE_NAME) -->
+                sessionMode"2"                     <!-- oci8 driver specific (session_mode) -->
+                sslmode="require"                  <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLMODE) -->
                 wrapper-class="MyDoctrineDbalConnectionWrapper"
                 charset="UTF8"
                 logging="%kernel.debug%"

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -47,11 +47,52 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
 
         // doctrine.dbal.sqlite_connection
         $config = $container->getDefinition('doctrine.dbal.sqlite_connection')->getArgument(0);
-        $this->assertArrayHasKey('memory', $config);
+        $this->assertSame('pdo_sqlite', $config['driver']);
+        $this->assertSame('sqlite_db', $config['dbname']);
+        $this->assertSame('sqlite_user', $config['user']);
+        $this->assertSame('sqlite_s3cr3t', $config['password']);
+        $this->assertSame('/tmp/db.sqlite', $config['path']);
+        $this->assertTrue($config['memory']);
 
         // doctrine.dbal.oci8_connection
         $config = $container->getDefinition('doctrine.dbal.oci_connection')->getArgument(0);
-        $this->assertArrayHasKey('charset', $config);
+        $this->assertSame('oci8', $config['driver']);
+        $this->assertSame('oracle_db', $config['dbname']);
+        $this->assertSame('oracle_user', $config['user']);
+        $this->assertSame('oracle_s3cr3t', $config['password']);
+        $this->assertSame('oracle_service', $config['servicename']);
+        $this->assertTrue($config['service']);
+        $this->assertTrue($config['pooled']);
+        $this->assertSame('utf8', $config['charset']);
+
+        // doctrine.dbal.ibmdb2_connection
+        $config = $container->getDefinition('doctrine.dbal.ibmdb2_connection')->getArgument(0);
+        $this->assertSame('ibm_db2', $config['driver']);
+        $this->assertSame('ibmdb2_db', $config['dbname']);
+        $this->assertSame('ibmdb2_user', $config['user']);
+        $this->assertSame('ibmdb2_s3cr3t', $config['password']);
+        $this->assertSame('TCPIP', $config['protocol']);
+
+        // doctrine.dbal.pgsql_connection
+        $config = $container->getDefinition('doctrine.dbal.pgsql_connection')->getArgument(0);
+        $this->assertSame('pdo_pgsql', $config['driver']);
+        $this->assertSame('pgsql_db', $config['dbname']);
+        $this->assertSame('pgsql_user', $config['user']);
+        $this->assertSame('pgsql_s3cr3t', $config['password']);
+        $this->assertSame('require', $config['sslmode']);
+        $this->assertSame('utf8', $config['charset']);
+
+        // doctrine.dbal.sqlanywhere_connection
+        $config = $container->getDefinition('doctrine.dbal.sqlanywhere_connection')->getArgument(0);
+        $this->assertSame('sqlanywhere', $config['driver']);
+        $this->assertSame('localhost', $config['host']);
+        $this->assertSame(2683, $config['port']);
+        $this->assertSame('sqlanywhere_server', $config['server']);
+        $this->assertSame('sqlanywhere_db', $config['dbname']);
+        $this->assertSame('sqlanywhere_user', $config['user']);
+        $this->assertSame('sqlanywhere_s3cr3t', $config['password']);
+        $this->assertTrue($config['persistent']);
+        $this->assertSame('utf8', $config['charset']);
     }
 
     public function testDbalLoadFromXmlSingleConnections()

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -20,6 +20,7 @@
                 dbname="sqlite_db"
                 user="sqlite_user"
                 password="sqlite_s3cr3t"
+                path="/tmp/db.sqlite"
                 memory="true" />
             <connection
                 name="oci"
@@ -27,6 +28,35 @@
                 dbname="oracle_db"
                 user="oracle_user"
                 password="oracle_s3cr3t"
+                servicename="oracle_service"
+                service="true"
+                pooled="true"
+                charset="utf8" />
+            <connection
+                name="ibmdb2"
+                driver="ibm_db2"
+                dbname="ibmdb2_db"
+                user="ibmdb2_user"
+                password="ibmdb2_s3cr3t"
+                protocol="TCPIP" />
+            <connection
+                name="pgsql"
+                driver="pdo_pgsql"
+                dbname="pgsql_db"
+                user="pgsql_user"
+                password="pgsql_s3cr3t"
+                sslmode="require"
+                charset="utf8" />
+            <connection
+                name="sqlanywhere"
+                driver="sqlanywhere"
+                host="localhost"
+                port="2683"
+                server="sqlanywhere_server"
+                dbname="sqlanywhere_db"
+                user="sqlanywhere_user"
+                password="sqlanywhere_s3cr3t"
+                persistent="true"
                 charset="utf8" />
         </dbal>
     </config>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -9,10 +9,40 @@ doctrine:
                 unix_socket: /path/to/mysqld.sock
             sqlite:
                 driver: pdo_sqlite
+                dbname: sqlite_db
+                user: sqlite_user
+                password: sqlite_s3cr3t
+                path: /tmp/db.sqlite
                 memory: true
             oci:
                 driver: oci8
                 dbname: oracle_db
                 user: oracle_user
                 password: oracle_s3cr3t
+                servicename: oracle_service
+                service: true
+                pooled: true
+                charset: utf8
+            ibmdb2:
+                driver: ibm_db2
+                dbname: ibmdb2_db
+                user: ibmdb2_user
+                password: ibmdb2_s3cr3t
+                protocol: TCPIP
+            pgsql:
+                driver: pdo_pgsql
+                dbname: pgsql_db
+                user: pgsql_user
+                password: pgsql_s3cr3t
+                sslmode: require
+                charset: utf8
+            sqlanywhere:
+                driver: sqlanywhere
+                host: localhost
+                port: 2683
+                server: sqlanywhere_server
+                dbname: sqlanywhere_db
+                user: sqlanywhere_user
+                password: sqlanywhere_s3cr3t
+                persistent: true
                 charset: utf8


### PR DESCRIPTION
Fixes issue #266.

There have been some recent changes and additions over the last months concerning DBAL driver connection parameters. This PR fills the gap and adds the missing configuration definitions.
Besides that the documentation has been updated to provide a full reference of all available driver connection parameters available.
