### PR TITLE
Fix Symfony doctrine-bridge dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.2",
-        "symfony/doctrine-bridge": "~2.2",
+        "symfony/doctrine-bridge": "dev-master",
         "doctrine/dbal": ">=2.3,<2.6-dev",
         "jdorn/sql-formatter": "~1.1"
     },


### PR DESCRIPTION
Since the AbstractDoctrineExtension::loadCacheDriver() ins not implemented in the last tag, 2.4, the dependency will point to dev-master, who implements the method.
