### PR TITLE
Utilize EntityManagerInterface

### DIFF
--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -14,7 +14,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 
 /**
@@ -41,9 +41,9 @@ class ManagerConfigurator
     /**
      * Create a connection by name.
      *
-     * @param EntityManager $entityManager
+     * @param EntityManagerInterface $entityManager
      */
-    public function configure(EntityManager $entityManager)
+    public function configure(EntityManagerInterface $entityManager)
     {
         $this->enableFilters($entityManager);
     }
@@ -51,11 +51,11 @@ class ManagerConfigurator
     /**
      * Enable filters for an given entity manager
      *
-     * @param EntityManager $entityManager
+     * @param EntityManagerInterface $entityManager
      *
      * @return null
      */
-    private function enableFilters(EntityManager $entityManager)
+    private function enableFilters(EntityManagerInterface $entityManager)
     {
         if (empty($this->enabledFilters)) {
             return;


### PR DESCRIPTION
In my efforts to create a custom entity manager for my Symfony2 project, I've come down to an issue tied to this file.

I've created my custom entity manager using the decorator and such rather than extending the EntityManager class itself, which is frowned upon in the documentation.

So far, the only issue I have run into is this class. It is tied directly to the EntityManager class, when it would be sufficient to use the EntityManagerInterface interface instead.

By using EntityManagerInterface for the function arguments on "configure()" and "enableFilters()", the functionality shouldn't be affected, but allows for more entity manager implementations (like when using the EntityManagerDecorator) than just the core EntityManager.

(I submitted a pull request earlier, but ended up messing it up; I'm new to Git/GitHub and didn't fully know what I was doing.)