### PR TITLE
Ability to move generated Entities to Entity subdirectory

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -40,6 +40,7 @@ class ImportMappingDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:mapping:import')
             ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to import the mapping information to')
             ->addArgument('mapping-type', InputArgument::OPTIONAL, 'The mapping type to export the imported mapping information to')
+            ->addOption('prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix entity with name. For entity subdirectory use name with backslash e.g "Db1\\"')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command')
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be mapped.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force to overwrite existing mapping files.')
@@ -49,6 +50,10 @@ The <info>doctrine:mapping:import</info> command imports mapping information
 from an existing database:
 
 <info>php app/console doctrine:mapping:import "MyCustomBundle" xml</info>
+
+<info>--prefix</info> option:
+If you would like to move entities to subdirectory, use prefix name with backslash.
+<info>php app/console doctrine:mapping:import "MyCustomBundle" xml --prefix="Db1\\"</info>
 
 You can also optionally specify which entity manager to import from with the
 <info>--em</info> option:
@@ -98,6 +103,7 @@ EOT
         $em = $this->getEntityManager($input->getOption('em'));
 
         $databaseDriver = new DatabaseDriver($em->getConnection()->getSchemaManager());
+        $databaseDriver->setNamespace($input->getOption('prefix'));
         $em->getConfiguration()->setMetadataDriverImpl($databaseDriver);
 
         $emName = $input->getOption('em');


### PR DESCRIPTION
there is no way to move generated entities to subdirectory 
e.g. from Acme/DemoBundle/Entity to Acme/DemoBundle/Entity/Database1