### PR TITLE
Close connection after dropping database

### DIFF
--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -85,6 +85,9 @@ EOT
 
             try {
                 $connection->getSchemaManager()->dropDatabase($name);
+                if ($connection->isConnected()) {
+                    $connection->close();
+                }
                 $output->writeln(sprintf('<info>Dropped database for connection named <comment>%s</comment></info>', $name));
             } catch (\Exception $e) {
                 $output->writeln(sprintf('<error>Could not drop database for connection named <comment>%s</comment></error>', $name));


### PR DESCRIPTION
If you call any CLI command after DropDatabase in your CLI application it will fail with 
````
[Doctrine\DBAL\DBALException]                                                              
An exception occurred while executing 'SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'':  
                                                                                            
SQLSTATE[3D000]: Invalid catalog name: 1046 No database selected                     
````
Detailed problem description available here: http://blog.nocontext.net/2012/11/symfony-2-drop-create-and-update.html

Also I've created a gist illustrating this issue: https://gist.github.com/iVariable/c9d185f9386fa46249da#file-doctrine_drop_database_fail-php