### PR TITLE
Fix loading of cache providers

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -687,8 +687,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
     protected function loadCacheDriver($driverName, $entityManagerName, array $driverMap, ContainerBuilder $container)
     {
         if (!empty($driverMap['cache_provider'])) {
-            $aliasId = $this->getObjectManagerElementName($driverName);
-            $serviceId = printf('doctrine_cache.providers.%s', $driverMap['cache_provider']);
+            $aliasId = $this->getObjectManagerElementName($entityManagerName.'_'.$driverName);
+            $serviceId = sprintf('doctrine_cache.providers.%s', $driverMap['cache_provider']);
 
             $container->setAlias($aliasId, new Alias($serviceId, false));
 

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -144,6 +144,7 @@
             <xsd:element name="host" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="port" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="instance-class" type="xsd:string" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="cache-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
         </xsd:all>
 
         <xsd:attribute name="type" type="xsd:string" />
@@ -250,7 +251,7 @@
         <xsd:attribute name="region-lifetime" type="xsd:integer" />
         <xsd:attribute name="region-lock-lifetime" type="xsd:integer" />
     </xsd:complexType>
-    
+
     <xsd:complexType name="dql">
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="string-function" type="named_scalar" />

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -329,6 +329,21 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testEntityManagerCacheProviderMetadataCacheDriverConfiguration()
+    {
+        $container = $this->getContainer();
+        $loader = new DoctrineExtension();
+        $container->registerExtension($loader);
+
+        $this->loadFromFile($container, 'orm_service_multiple_entity_managers');
+
+        $this->compileContainer($container);
+
+        $alias = $container->getAlias('doctrine.orm.em3_metadata_cache');
+
+        $this->assertEquals('doctrine_cache.providers.service', (string) $alias, 'Expected Service Id of the DIC Container Alias Definition is wrong');
+    }
+
     public function testDependencyInjectionImportsOverrideDefaults()
     {
         $container = $this->getContainer();

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
@@ -35,6 +35,12 @@
             <entity-manager name="em2" connection="conn2" metadata-cache-driver="apc">
                 <mapping name="YamlBundle" />
             </entity-manager>
+            <entity-manager name="em3" connection="conn2">
+                <metadata-cache-driver>
+                    <cache-provider>service</cache-provider>
+                </metadata-cache-driver>
+                <mapping name="YamlBundle" />
+            </entity-manager>
         </orm>
     </config>
 </srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_service_multiple_entity_managers.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_service_multiple_entity_managers.yml
@@ -32,3 +32,9 @@ doctrine:
                 connection: conn2
                 mappings:
                     YamlBundle: ~
+            em3:
+                metadata_cache_driver:
+                    cache_provider: service
+                connection: conn2
+                mappings:
+                    YamlBundle: ~


### PR DESCRIPTION
Fix a typo and prefixed cache services with the entity manager name which is needed if you have more than one.

I'm not really sure why the cache_provider needs to be prefixed with doctrine_cache.providers. instead of just using it as it is. This would allow to user other Cache adapter services that implement the Doctrine Cache interface.