### PR TITLE
db profiller template fix

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -206,7 +206,7 @@
                     <tr>
                         <td>{{ class }}</td>
                         <td>
-                            {% if collector.mappingErrors[manager][class] is defined %}
+                            {% if collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class] is defined %}
                                 <ul>
                                     {% for error in collector.mappingErrors[manager][class] %}
                                         <li>{{ error }}</li>


### PR DESCRIPTION
fixing the error 
Key "default" for array with keys "" does not exist in @Doctrine/Collector/db.html.twig at line 209