### PR TITLE
Added support for tagging entity listeners, without the need to map the listener

### DIFF
--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -48,7 +48,7 @@ class EntityListenerPass implements CompilerPassInterface
                     continue;
                 }
 
-                if (isset($attributes['entity'])) {
+                if (isset($attributes['entity']) && isset($attributes['type'])) {
                     $this->attachToListener($container, $name, $id, $attributes);
                 }
 

--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -71,7 +71,7 @@ class EntityListenerPass implements CompilerPassInterface
         $serviceDef = $container->getDefinition($id);
 
         $args = array(
-	        $attributes['entity'],
+            $attributes['entity'],
             $serviceDef->getClass(),
         );
 

--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -48,8 +48,41 @@ class EntityListenerPass implements CompilerPassInterface
                     continue;
                 }
 
+                if (isset($attributes['entity'])) {
+                    $this->attachToListener($container, $name, $id, $attributes);
+                }
+
                 $container->getDefinition($resolver)->addMethodCall('register', array(new Reference($id)));
             }
         }
+    }
+
+    private function attachToListener(ContainerBuilder $container, $name, $id, array $attributes)
+    {
+        $listenerId   = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $name);
+        if ($container->hasAlias($listenerId)) {
+            $listenerId = (string)$container->getAlias($listenerId);
+        }
+
+        if (!$container->hasDefinition($listenerId)) {
+            return;
+        }
+
+        $serviceDef = $container->getDefinition($id);
+
+        $args = array(
+            $serviceDef->getClass(),
+            $attributes['entity'],
+        );
+
+        if (isset($attributes['type'])) {
+            $args[] = $attributes['type'];
+        }
+
+        if (isset($attributes['method'])) {
+            $args[] = $attributes['method'];
+        }
+
+        $container->getDefinition($listenerId)->addMethodCall('addEntityListener', $args);
     }
 }

--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -71,8 +71,8 @@ class EntityListenerPass implements CompilerPassInterface
         $serviceDef = $container->getDefinition($id);
 
         $args = array(
+	        $attributes['entity'],
             $serviceDef->getClass(),
-            $attributes['entity'],
         );
 
         if (isset($attributes['type'])) {

--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -48,7 +48,7 @@ class EntityListenerPass implements CompilerPassInterface
                     continue;
                 }
 
-                if (isset($attributes['entity']) && isset($attributes['type'])) {
+                if (isset($attributes['entity']) && isset($attributes['event'])) {
                     $this->attachToListener($container, $name, $id, $attributes);
                 }
 
@@ -75,8 +75,8 @@ class EntityListenerPass implements CompilerPassInterface
             $serviceDef->getClass(),
         );
 
-        if (isset($attributes['type'])) {
-            $args[] = $attributes['type'];
+        if (isset($attributes['event'])) {
+            $args[] = $attributes['event'];
         }
 
         if (isset($attributes['method'])) {

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -501,7 +501,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         );
 
         if (isset($entityManager['entity_listeners'])) {
-            if (!$listenerDef) {
+            if (!isset($listenerDef)) {
                 throw new InvalidArgumentException('Entity listeners configuration requires doctrine-orm 2.5.0 or newer');
             }
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -429,11 +429,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ));
         }
 
-	    if (version_compare(Version::VERSION, "2.5.0-DEV") < 0) {
-		    $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
-		    $listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
-            $listenerDef->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
-        }
+	    if (version_compare(Version::VERSION, "2.5.0-DEV") >= 0) {
+			$listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
+			$listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
+			$listenerDef->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+		}
 
         if (isset($entityManager['second_level_cache'])) {
             $this->loadOrmSecondLevelCache($entityManager, $ormConfigDef, $container);

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -429,11 +429,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ));
         }
 
-	    if (version_compare(Version::VERSION, "2.5.0-DEV") >= 0) {
-			$listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
-			$listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
-			$listenerDef->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
-		}
+        if (version_compare(Version::VERSION, "2.5.0-DEV") >= 0) {
+            $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
+            $listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
+            $listenerDef->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+        }
 
         if (isset($entityManager['second_level_cache'])) {
             $this->loadOrmSecondLevelCache($entityManager, $ormConfigDef, $container);
@@ -505,7 +505,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 throw new InvalidArgumentException('Entity listeners configuration requires doctrine-orm 2.5.0 or newer');
             }
 
-	        $entities = $entityManager['entity_listeners']['entities'];
+            $entities = $entityManager['entity_listeners']['entities'];
 
             foreach ($entities as $entityListenerClass => $entity) {
                 foreach ($entity['listeners'] as $listenerClass => $listener) {

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -429,6 +429,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ));
         }
 
+	    if (version_compare(Version::VERSION, "2.5.0-DEV") < 0) {
+		    $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
+		    $listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
+            $listenerDef->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+        }
+
         if (isset($entityManager['second_level_cache'])) {
             $this->loadOrmSecondLevelCache($entityManager, $ormConfigDef, $container);
         }
@@ -495,13 +501,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         );
 
         if (isset($entityManager['entity_listeners'])) {
-            if (version_compare(Version::VERSION, "2.5.0-DEV") < 0) {
+            if (!$listenerDef) {
                 throw new InvalidArgumentException('Entity listeners configuration requires doctrine-orm 2.5.0 or newer');
             }
 
-            $entities = $entityManager['entity_listeners']['entities'];
-            $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
-            $listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
+	        $entities = $entityManager['entity_listeners']['entities'];
 
             foreach ($entities as $entityListenerClass => $entity) {
                 foreach ($entity['listeners'] as $listenerClass => $listener) {
@@ -516,7 +520,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 }
             }
 
-            $listenerDef->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
         }
     }
 

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -655,6 +655,30 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener2')));
     }
 
+    public function testAttachEntityListenerTag()
+    {
+        $container = $this->getContainer(array());
+        $loader = new DoctrineExtension();
+        $container->registerExtension($loader);
+        $container->addCompilerPass(new EntityListenerPass());
+
+        $this->loadFromFile($container, 'orm_attach_entity_listener_tag');
+
+        $this->compileContainer($container);
+
+        $listener = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
+        $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener1')));
+
+        $listener = $container->getDefinition('doctrine.orm.em2_entity_listener_resolver');
+        $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener2')));
+
+        $attachListener = $container->getDefinition('doctrine.orm.em1_listeners.attach_entity_listeners');
+        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('EntityListener1', 'My/Entity1'));
+
+        $attachListener = $container->getDefinition('doctrine.orm.em2_listeners.attach_entity_listeners');
+        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('EntityListener2', 'My/Entity2', 'preFlush', 'preFlushHandler'));
+    }
+
     public function testRepositoryFactory()
     {
         $container = $this->loadContainer('orm_repository_factory');

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -673,7 +673,7 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener2')));
 
         $attachListener = $container->getDefinition('doctrine.orm.em1_listeners.attach_entity_listeners');
-        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('EntityListener1', 'My/Entity1'));
+        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('EntityListener1', 'My/Entity1', 'postLoad'));
 
         $attachListener = $container->getDefinition('doctrine.orm.em2_listeners.attach_entity_listeners');
         $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('EntityListener2', 'My/Entity2', 'preFlush', 'preFlushHandler'));

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -657,6 +657,10 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testAttachEntityListenerTag()
     {
+	    if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
+		    $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
+	    }
+
         $container = $this->getContainer(array());
         $loader = new DoctrineExtension();
         $container->registerExtension($loader);

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -673,10 +673,10 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener2')));
 
         $attachListener = $container->getDefinition('doctrine.orm.em1_listeners.attach_entity_listeners');
-        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('EntityListener1', 'My/Entity1', 'postLoad'));
+        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('My/Entity1', 'EntityListener1', 'postLoad'));
 
         $attachListener = $container->getDefinition('doctrine.orm.em2_listeners.attach_entity_listeners');
-        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('EntityListener2', 'My/Entity2', 'preFlush', 'preFlushHandler'));
+        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('My/Entity2', 'EntityListener2', 'preFlush', 'preFlushHandler'));
     }
 
     public function testRepositoryFactory()

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -657,9 +657,9 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testAttachEntityListenerTag()
     {
-	    if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
-		    $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
-	    }
+        if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
+            $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
+        }
 
         $container = $this->getContainer(array());
         $loader = new DoctrineExtension();

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
@@ -8,11 +8,11 @@
 
     <services>
         <service id="entity_listener1" class="EntityListener1">
-            <tag name="doctrine.orm.entity_listener" entity="My/Entity1" type="postLoad" />
+            <tag name="doctrine.orm.entity_listener" entity="My/Entity1" event="postLoad" />
         </service>
 
         <service id="entity_listener2" class="EntityListener2">
-            <tag name="doctrine.orm.entity_listener" entity_manager="em2" entity="My/Entity2" type="preFlush" method="preFlushHandler" />
+            <tag name="doctrine.orm.entity_listener" entity_manager="em2" entity="My/Entity2" event="preFlush" method="preFlushHandler" />
         </service>
     </services>
 

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <services>
+        <service id="entity_listener1" class="EntityListener1">
+            <tag name="doctrine.orm.entity_listener" entity="My/Entity1"/>
+        </service>
+
+        <service id="entity_listener2" class="EntityListener2">
+            <tag name="doctrine.orm.entity_listener" entity_manager="em2" entity="My/Entity2" type="preFlush" method="preFlushHandler" />
+        </service>
+    </services>
+
+    <doctrine:config>
+        <doctrine:dbal default-connection="default">
+            <doctrine:connection name="default" dbname="db" />
+        </doctrine:dbal>
+
+        <doctrine:orm default-entity-manager="em1">
+            <doctrine:entity-manager name="em1" />
+            <doctrine:entity-manager name="em2" />
+        </doctrine:orm>
+    </doctrine:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
@@ -8,7 +8,7 @@
 
     <services>
         <service id="entity_listener1" class="EntityListener1">
-            <tag name="doctrine.orm.entity_listener" entity="My/Entity1"/>
+            <tag name="doctrine.orm.entity_listener" entity="My/Entity1" type="postLoad" />
         </service>
 
         <service id="entity_listener2" class="EntityListener2">

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
@@ -2,12 +2,12 @@ services:
     entity_listener1:
         class: EntityListener1
         tags:
-            - { name: doctrine.orm.entity_listener, entity: My/Entity1, type: postLoad}
+            - { name: doctrine.orm.entity_listener, entity: My/Entity1, event: postLoad}
 
     entity_listener2:
         class: EntityListener2
         tags:
-            - { name: doctrine.orm.entity_listener, entity_manager: em2, entity: My/Entity2, type: preFlush, method: preFlushHandler}
+            - { name: doctrine.orm.entity_listener, entity_manager: em2, entity: My/Entity2, event: preFlush, method: preFlushHandler}
 
 doctrine:
     dbal:

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
@@ -2,7 +2,7 @@ services:
     entity_listener1:
         class: EntityListener1
         tags:
-            - { name: doctrine.orm.entity_listener, entity: My/Entity1 }
+            - { name: doctrine.orm.entity_listener, entity: My/Entity1, type: postLoad}
 
     entity_listener2:
         class: EntityListener2

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
@@ -1,0 +1,23 @@
+services:
+    entity_listener1:
+        class: EntityListener1
+        tags:
+            - { name: doctrine.orm.entity_listener, entity: My/Entity1 }
+
+    entity_listener2:
+        class: EntityListener2
+        tags:
+            - { name: doctrine.orm.entity_listener, entity_manager: em2, entity: My/Entity2, type: preFlush, method: preFlushHandler}
+
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        default_entity_manager: em1
+        entity_managers:
+            em1:
+            em2:


### PR DESCRIPTION
Adds support for tagging entity listeners, defining entity and method. 

Every listener service is created when the entitymanager is created for now. A solution could be marking the services lazy as suggested by @Ocramius and @Stof in https://github.com/doctrine/DoctrineBundle/issues/223