### PR TITLE
Fix Twig error when mappingErrors is unpopulated

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -206,7 +206,7 @@
                     <tr>
                         <td>{{ class }}</td>
                         <td>
-                            {% if collector.mappingErrors[manager][class] is defined %}
+                            {% if collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class] is defined %}
                                 <ul>
                                     {% for error in collector.mappingErrors[manager][class] %}
                                         <li>{{ error }}</li>


### PR DESCRIPTION
Undefined collector.mappingErrors['default'] could result in Twig error 'Key "default" does not exist as the array is empty'.