### PR TITLE
mappingErrors key checking in db.html.twig

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -206,7 +206,7 @@
                     <tr>
                         <td>{{ class }}</td>
                         <td>
-                            {% if collector.mappingErrors[manager][class] is defined %}
+                            {% if collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class] is defined %}
                                 <ul>
                                     {% for error in collector.mappingErrors[manager][class] %}
                                         <li>{{ error }}</li>


### PR DESCRIPTION
This error was returned without the patch:
'Key "default" does not exist as the array is empty in @Doctrine/Collector/db.html.twig at line 209'