### PR TITLE
excluded DBAL v2.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.2",
-        "doctrine/dbal": "~2.3",
+        "doctrine/dbal": "~2.3,!=2.5.0",
         "jdorn/sql-formatter": "~1.1",
         "symfony/doctrine-bridge": "~2.2",
         "doctrine/doctrine-cache-bundle": "~1.0"


### PR DESCRIPTION
excluded DBAL v2.5.0 due to this bug:
http://www.doctrine-project.org/jira/browse/DBAL-1057

the bug causes massiv problems in the sf2 context when the database connection cannot be established. almost any command even an `assetic:dump` may trigger a db-connect which makes remote deployments impossible.
