### PR TITLE
Added missing parameter for sprintf call

### DIFF
--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -91,7 +91,7 @@ EOT
                     $connection->getSchemaManager()->dropDatabase($name);
                     $output->writeln(sprintf('<info>Dropped database for connection named <comment>%s</comment></info>', $name));
                 } else {
-                    $output->writeln(sprintf('<info>Database for connection named <comment>%s</comment> doesn\'t exists. Skipped.</info>'));
+                    $output->writeln(sprintf('<info>Database for connection named <comment>%s</comment> doesn\'t exists. Skipped.</info>', $name));
                 }
             } catch (\Exception $e) {
                 $output->writeln(sprintf('<error>Could not drop database for connection named <comment>%s</comment></error>', $name));


### PR DESCRIPTION
The <code>DropDatabaseDoctrineCommand</code> class yields an error when the database doesn't exist:

```
PHP Warning:  sprintf(): Too few arguments in /home/vagrant/vendor/doctrine/doctrine-bundle/Command/DropDatabaseDoctrineCommand.php on line 94
```

I added the missing <code>$name</code> argument.
