### PR TITLE
Fix if-exists evaluation in drop database command

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -79,11 +79,9 @@ EOT
 
         $error = false;
         try {
-            $shouldCreateDatabase = $ifNotExists && in_array($name, $tmpConnection->getSchemaManager()->listDatabases())
-                ? false
-                : true;
+            $shouldNotCreateDatabase = $ifNotExists && in_array($name, $tmpConnection->getSchemaManager()->listDatabases());
 
-            if (! $shouldCreateDatabase) {
+            if ($shouldNotCreateDatabase) {
                 $output->writeln(sprintf('<info>Database for connection named <comment>%s</comment> already exists. Skipped.</info>'));
             } else {
                 $tmpConnection->getSchemaManager()->createDatabase($name);

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -86,9 +86,7 @@ EOT
             }
 
             try {
-                $shouldDropDatabase = $ifExists && ! in_array($name, $connection->getSchemaManager()->listDatabases())
-                    ? false
-                    : true;
+                $shouldDropDatabase = !$ifExists || in_array($name, $connection->getSchemaManager()->listDatabases());
 
                 if ($shouldDropDatabase) {
                     $connection->getSchemaManager()->dropDatabase($name);


### PR DESCRIPTION
PR https://github.com/doctrine/DoctrineBundle/pull/337 introduced the `if-exists` option for the drop database command. However the evaluation of that option now makes it mandatory to pass the option to drop the database, which should not be the case.

See https://github.com/doctrine/DoctrineBundle/issues/361
