### PR TITLE
Make data collector test compatible with different ORM versions

### DIFF
--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -39,9 +39,11 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
             ->method('getConfiguration')
             ->will($this->returnValue($config));
 
-        $config->expects($this->once())
-            ->method('isSecondLevelCacheEnabled')
-            ->will($this->returnValue(false));
+        if (method_exists($config, 'isSecondLevelCacheEnabled')) {
+            $config->expects($this->once())
+                ->method('isSecondLevelCacheEnabled')
+                ->will($this->returnValue(false));
+        }
 
         $metadatas = array(
             $this->createEntityMetadata(self::FIRST_ENTITY),
@@ -68,6 +70,7 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
     {
         $metadata = new ClassMetadataInfo($entityFQCN);
         $metadata->name = $entityFQCN;
+        $metadata->reflClass = new \ReflectionClass('stdClass');
 
         return $metadata;
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit colors="true" bootstrap="vendor/autoload.php">
+    <php>
+        <!-- Disable E_USER_DEPRECATED until reaching compatibility with Symfony 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="DoctrineBundle for the Symfony Framework">
             <directory>./Tests</directory>


### PR DESCRIPTION
This is the first step in making the test suite go green again. It makes the `Doctrine\Bundle\DoctrineBundle\Tests\DataCollector\DoctrineDataCollectorTest` compatible with ORM < 2.5.0-DEV again.
The test suite is still failing because of recent Symfony deprecations. Also composer is still installing ORM `2.4.x-dev` while it should install `dev-master` IMO.
Both issues should be dealt with separately though.