### PR TITLE
[WIP] Bump Symfony requirement to 2.6

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -43,7 +43,9 @@
             <argument>%doctrine.dbal.connection_factory.types%</argument>
         </service>
 
-        <service id="doctrine.dbal.connection" class="Doctrine\DBAL\Connection" factory-service="doctrine.dbal.connection_factory" factory-method="createConnection" abstract="true" />
+        <service id="doctrine.dbal.connection" class="Doctrine\DBAL\Connection" abstract="true">
+            <factory service="doctrine.dbal.connection_factory" method="createConnection" />
+        </service>
 
         <service id="doctrine.dbal.connection.event_manager" class="%doctrine.dbal.connection.event_manager.class%" public="false" abstract="true">
             <argument type="service" id="service_container" />

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -91,7 +91,9 @@
 
         <service id="doctrine.orm.configuration" class="%doctrine.orm.configuration.class%" abstract="true" public="false" />
 
-        <service id="doctrine.orm.entity_manager.abstract" class="%doctrine.orm.entity_manager.class%" factory-class="%doctrine.orm.entity_manager.class%" factory-method="create" abstract="true" />
+        <service id="doctrine.orm.entity_manager.abstract" class="%doctrine.orm.entity_manager.class%" abstract="true">
+            <factory class="%doctrine.orm.entity_manager.class%" method="create" />
+        </service>
 
         <!-- The configurator cannot be a private service -->
         <service id="doctrine.orm.manager_configurator.abstract" class="%doctrine.orm.manager_configurator.class%" abstract="true">

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -170,9 +170,10 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         ));
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
+        $factory = $definition->getFactory();
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
-        $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
-        $this->assertEquals('create', $definition->getFactoryMethod());
+        $this->assertEquals('%doctrine.orm.entity_manager.class%', $factory[0]);
+        $this->assertEquals('create', $factory[1]);
 
         $this->assertDICConstructorArguments($definition, array(
             new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
@@ -202,9 +203,10 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         ));
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
+        $factory = $definition->getFactory();
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
-        $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
-        $this->assertEquals('create', $definition->getFactoryMethod());
+        $this->assertEquals('%doctrine.orm.entity_manager.class%', $factory[0]);
+        $this->assertEquals('create', $factory[1]);
 
         $this->assertDICConstructorArguments($definition, array(
             new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
@@ -230,9 +232,10 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('doctrine.orm.em2_entity_manager', (string) $container->getAlias('doctrine.orm.entity_manager'));
 
         $definition = $container->getDefinition('doctrine.orm.em1_entity_manager');
+        $factory = $definition->getFactory();
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
-        $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
-        $this->assertEquals('create', $definition->getFactoryMethod());
+        $this->assertEquals('%doctrine.orm.entity_manager.class%', $factory[0]);
+        $this->assertEquals('create', $factory[1]);
 
         $arguments = $definition->getArguments();
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
@@ -250,9 +253,10 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('doctrine.dbal.conn2_connection.event_manager', (string) $args[2]);
 
         $definition = $container->getDefinition('doctrine.orm.em2_entity_manager');
+        $factory = $definition->getFactory();
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
-        $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
-        $this->assertEquals('create', $definition->getFactoryMethod());
+        $this->assertEquals('%doctrine.orm.entity_manager.class%', $factory[0]);
+        $this->assertEquals('create', $factory[1]);
 
         $arguments = $definition->getArguments();
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -216,9 +216,11 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('doctrine.dbal.default_connection.event_manager', (string) $args[2]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
+        $factory = $definition->getFactory();
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
-        $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
-        $this->assertEquals('create', $definition->getFactoryMethod());
+        $this->assertEquals('%doctrine.orm.entity_manager.class%', $factory[0]);
+        $this->assertEquals('create', $factory[1]);
+
 
         $this->assertEquals(array('default' => 'doctrine.orm.default_entity_manager'), $container->getParameter('doctrine.entity_managers'), "Set of the existing EntityManagers names is incorrect.");
         $this->assertEquals('%doctrine.entity_managers%', $container->getDefinition('doctrine')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
@@ -283,9 +285,10 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->compileContainer($container);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
+        $factory = $definition->getFactory();
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
-        $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
-        $this->assertEquals('create', $definition->getFactoryMethod());
+        $this->assertEquals('%doctrine.orm.entity_manager.class%', $factory[0]);
+        $this->assertEquals('create', $factory[1]);
 
         $this->assertDICConstructorArguments($definition, array(
             new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,16 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.2",
+        "symfony/framework-bundle": "~2.6",
         "doctrine/dbal": "~2.3",
         "jdorn/sql-formatter": "~1.1",
-        "symfony/doctrine-bridge": "~2.2",
+        "symfony/doctrine-bridge": "~2.6",
         "doctrine/doctrine-cache-bundle": "~1.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.3",
-        "symfony/yaml": "~2.2",
-        "symfony/validator": "~2.2",
+        "symfony/yaml": "~2.6",
+        "symfony/validator": "~2.6",
         "twig/twig": "~1",
         "satooshi/php-coveralls": "~0.6.1",
         "phpunit/phpunit": "~3.7",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit colors="true" bootstrap="vendor/autoload.php">
-    <php>
-        <!-- Disable E_USER_DEPRECATED until reaching compatibility with Symfony 3.0 -->
-        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
-        <ini name="error_reporting" value="-16385"/>
-    </php>
-
     <testsuites>
         <testsuite name="DoctrineBundle for the Symfony Framework">
             <directory>./Tests</directory>


### PR DESCRIPTION
Following https://github.com/doctrine/DoctrineBundle/pull/364 this PR is intended to reach compatibility with Symfony >= 2.6.
It makes DoctrineBundle use the new service factory definition as the current one is deprecated. It also bumps the Symfony requirements to `~2.6` and allows `E_USER_DEPRECATED` to trigger errors in the test suite again.
I marked it as WIP until the next Symfony LTS 2.7 is released as we won't bump the Symfony requirements before.