### PR TITLE
[DBAL-1114] Drop database without having it opened

### DIFF
--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -14,6 +14,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
+use Doctrine\DBAL\DriverManager;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -80,6 +81,11 @@ EOT
         unset($params['dbname']);
 
         if ($input->getOption('force')) {
+            // Reopen connection without database name set
+            // as some vendors do not allow dropping the database connected to.
+            $connection->close();
+            $connection = DriverManager::getConnection($params);
+
             // Only quote if we don't have a path
             if (!isset($params['path'])) {
                 $name = $connection->getDatabasePlatform()->quoteSingleIdentifier($name);


### PR DESCRIPTION
A recent fix in DBAL https://github.com/doctrine/dbal/commit/4a603c7a711f9399dbb03b5b88b8ecce8c41df84 makes the drop database command fail on PostgreSQL. PostgreSQL does not allow dropping a database currently opened by a connection so instead a "temporary" connection without database name specified should be used to drop the database (as already done in create database command).
Successfully tested this with MySQL, SQLite, PostgreSQL, SQL Anywhere, SQL Server (DB2 and Oracle do not support dropping and creating databases anyways).

See: http://www.doctrine-project.org/jira/browse/DBAL-1114