### PR TITLE
on line 696 printf is changed to sprintf

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -693,7 +693,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
     {
         if (!empty($driverMap['cache_provider'])) {
             $aliasId = $this->getObjectManagerElementName($driverName);
-            $serviceId = printf('doctrine_cache.providers.%s', $driverMap['cache_provider']);
+            $serviceId = sprintf('doctrine_cache.providers.%s', $driverMap['cache_provider']);
 
             $container->setAlias($aliasId, new Alias($serviceId, false));
 


### PR DESCRIPTION
on line 696 printf() is changed to sprintf(). printf() causes to output `doctrine_cache.providers.metadata_cache` as string on screen.