### PR TITLE
Fixed cache provider alias in extension

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -692,8 +692,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
     protected function loadCacheDriver($driverName, $entityManagerName, array $driverMap, ContainerBuilder $container)
     {
         if (!empty($driverMap['cache_provider'])) {
-            $aliasId = $this->getObjectManagerElementName($driverName);
-            $serviceId = printf('doctrine_cache.providers.%s', $driverMap['cache_provider']);
+            $aliasId = $this->getObjectManagerElementName(sprintf('%s_%s', $entityManagerName, $driverName));
+            $serviceId = sprintf('doctrine_cache.providers.%s', $driverMap['cache_provider']);
 
             $container->setAlias($aliasId, new Alias($serviceId, false));
 

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -429,6 +429,39 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Fixtures\Bundles\Vendor\AnnotationsBundle\Entity', $calls[0][1][1]);
     }
 
+    public function testCacheConfiguration()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $config = $this->getConnectionConfig();
+        $config['orm'] = array(
+            'metadata_cache_driver' => array(
+                'cache_provider' => 'metadata_cache',
+            ),
+            'query_cache_driver' => array(
+                'cache_provider' => 'query_cache',
+            ),
+            'result_cache_driver' => array(
+                'cache_provider' => 'result_cache',
+            ),
+        );
+
+        $extension->load(array($config), $container);
+
+        $this->assertTrue($container->hasAlias('doctrine.orm.default_metadata_cache'));
+        $alias = $container->getAlias('doctrine.orm.default_metadata_cache');
+        $this->assertEquals('doctrine_cache.providers.metadata_cache', (string) $alias);
+
+        $this->assertTrue($container->hasAlias('doctrine.orm.default_query_cache'));
+        $alias = $container->getAlias('doctrine.orm.default_query_cache');
+        $this->assertEquals('doctrine_cache.providers.query_cache', (string) $alias);
+
+        $this->assertTrue($container->hasAlias('doctrine.orm.default_result_cache'));
+        $alias = $container->getAlias('doctrine.orm.default_result_cache');
+        $this->assertEquals('doctrine_cache.providers.result_cache', (string) $alias);
+    }
+
     private function getContainer($bundles = 'YamlBundle', $vendor = null)
     {
         $bundles = (array) $bundles;


### PR DESCRIPTION
Replacement for doctrine/DoctrineBundle#371

Regarding the error in [this post](https://github.com/doctrine/DoctrineCacheBundle/issues/38#issuecomment-69631811), it seems that the extension currently has 2 problems:

1. A `printf` call that should be `sprintf`
2. An alias with the wrong name

It seems to me that either the alias name should be changed from `doctrine.orm.<cache_provider>` to `doctrine.orm.<entity_manager>_<cache_provider>`, or that this alias should be added, besides the current alias. I prefer the first one as it creates 1 working alias, but I'm not sure if it will break things when `doctrine.orm.<cache_provider>` is no longer available.

This PR uses the first solution, if it should be solved differently let me know.