### PR TITLE
Fixed the reStructuredText syntax errors of the docs

### DIFF
--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -6,27 +6,28 @@ listener resolver. You can tag your entity listeners and they will automatically
 be added to the resolver. Use the entity_manager attribute to specify which
 entity manager it should be registered with. Example:
 
+.. configuration-block::
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    services:
-        user_listener:
-            class: \UserListener
-            tags:
-                - { name: doctrine.orm.entity_listener }
-                - { name: doctrine.orm.entity_listener, entity_manager: custom }
+        services:
+            user_listener:
+                class: \UserListener
+                tags:
+                    - { name: doctrine.orm.entity_listener }
+                    - { name: doctrine.orm.entity_listener, entity_manager: custom }
 
-.. code-block:: xml
+    .. code-block:: xml
 
-    <?xml version="1.0" ?>
+        <?xml version="1.0" ?>
 
-    <container xmlns="http://symfony.com/schema/dic/services"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-        <services>
-            <service id="user_listener" class="UserListener">
-                <tag name="doctrine.orm.entity_listener" />
-                <tag name="doctrine.orm.entity_listener" entity_manager="custom" />
-            </service>
-        </services>
-    </container>
+            <services>
+                <service id="user_listener" class="UserListener">
+                    <tag name="doctrine.orm.entity_listener" />
+                    <tag name="doctrine.orm.entity_listener" entity_manager="custom" />
+                </service>
+            </services>
+        </container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,6 +1,15 @@
 DoctrineBundle
 ==============
 
+Doctrine DBAL & ORM Bundle for the Symfony Framework.
+
+Symfony does not force or suggest a specific persistence solution on its users.
+That's why this bundle was removed from the core of the Symfony framework and
+moved into an independent repository.
+
+Since Doctrine2 will still be a major player in the Symfony world, the bundle is
+actively maintained by developers in the Doctrine and Symfony communities.
+
 .. toctree::
 
     installation

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,14 +1,8 @@
 DoctrineBundle
 ==============
 
-Doctrine DBAL & ORM Bundle for the Symfony Framework.
-
-Symfony does not force or suggest a specific persistence solution on its users.
-That's why this bundle was removed from the core of the Symfony framework and
-moved into an independent repository.
-
-Since Doctrine2 will still be a major player in the Symfony world, the bundle is
-actively maintained by developers in the Doctrine and Symfony communities.
+Integrates Doctrine's ORM and DBAL projects into Symfony applications. It provides
+configuration options, console commands and even a web debug toolbar collector.
 
 .. toctree::
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,0 +1,8 @@
+DoctrineBundle
+==============
+
+.. toctree::
+
+    installation
+    entity-listeners
+    configuration

--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -1,46 +1,43 @@
 Installation
 ============
 
-Doctrine DBAL & ORM Bundle for the Symfony Framework.
+Step 1: Download the Bundle
+---------------------------
 
-Because Symfony does not want to force or suggest a specific persistence
-solutions on the users this bundle was removed from the core of the Symfony
-framework. Doctrine2 will still be a major player in the Symfony world and the
-bundle is maintained by developers in the Doctrine and Symfony communities.
+Open a command console, enter your project directory and execute the following
+command to download the latest stable version of this bundle:
 
-IMPORTANT: This bundle is developed for Symfony 2.1 and up. For Symfony 2.0
-applications the DoctrineBundle is still shipped with the core Symfony
-repository.
+.. code-block:: bash
 
-Installation
-------------
+    $ composer require doctrine/doctrine-bundle
 
-1. Old deps and bin/vendors way
+This command requires you to have Composer installed globally, as explained
+in the `installation chapter`_ of the Composer documentation.
 
-Add the following snippets to "deps" files:
+Step 2: Enable the Bundle
+-------------------------
 
-.. code-block:: ini
+Then, enable the bundle by adding the following line in the ``app/AppKernel.php``
+file of your project::
 
-    [doctrine-mongodb]
-        git=http://github.com/doctrine/dbal.git
+    <?php
+    // app/AppKernel.php
 
-    [doctrine-mongodb-odm]
-        git=http://github.com/doctrine/doctrine2.git
+    // ...
+    class AppKernel extends Kernel
+    {
+        public function registerBundles()
+        {
+            $bundles = array(
+                // ...
 
-    [DoctrineBundle]
-        git=http://github.com/doctrine/DoctrineBundle.git
-        target=/bundles/Doctrine/Bundle/DoctrineBundle
+                new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            );
 
-2. Composer
+            // ...
+        }
 
-Add the following dependencies to your projects composer.json file:
-
-.. code-block:: json
-
-    "require": {
-        # ..
-        "doctrine/doctrine-bundle": "~1.2"
-        # ..
+        // ...
     }
 
-..
+.. _`installation chapter`: https://getcomposer.org/doc/00-intro.md

--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -1,14 +1,16 @@
-Doctrine Bundle
-===============
+Installation
+============
 
 Doctrine DBAL & ORM Bundle for the Symfony Framework.
 
-Because Symfony 2 does not want to force or suggest a specific persistence solutions on the users
-this bundle was removed from the core of the Symfony 2 framework. Doctrine2 will still be a major player
-in the Symfony world and the bundle is maintained by developers in the Doctrine and Symfony communities.
+Because Symfony does not want to force or suggest a specific persistence
+solutions on the users this bundle was removed from the core of the Symfony
+framework. Doctrine2 will still be a major player in the Symfony world and the
+bundle is maintained by developers in the Doctrine and Symfony communities.
 
-IMPORTANT: This bundle is developed for Symfony 2.1 and up. For Symfony 2.0 applications the DoctrineBundle
-is still shipped with the core Symfony repository.
+IMPORTANT: This bundle is developed for Symfony 2.1 and up. For Symfony 2.0
+applications the DoctrineBundle is still shipped with the core Symfony
+repository.
 
 Installation
 ------------
@@ -17,7 +19,7 @@ Installation
 
 Add the following snippets to "deps" files:
 
-.. code-block::
+.. code-block:: ini
 
     [doctrine-mongodb]
         git=http://github.com/doctrine/dbal.git
@@ -33,7 +35,7 @@ Add the following snippets to "deps" files:
 
 Add the following dependencies to your projects composer.json file:
 
-.. code-block::
+.. code-block:: json
 
     "require": {
         # ..
@@ -41,3 +43,4 @@ Add the following dependencies to your projects composer.json file:
         # ..
     }
 
+..


### PR DESCRIPTION
We're integrating the DoctrineBundle into symfony.com and we're facing some issues because of the following RST syntax errors:

```
doctrine-bundle/en/master/installation.rst:20: ERROR: Error in "code-block" directive:
1 argument(s) required, 0 supplied.

doctrine-bundle/en/master/installation.rst:36: ERROR: Error in "code-block" directive:
1 argument(s) required, 0 supplied.
```

In addition, an exception was triggered because there was no doctree in the docs. We've created the `index.rst` to solve this issue.