### PR TITLE
Ensure DoctrineDataCollector manages ClassMetadataInfo

### DIFF
--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -70,6 +70,9 @@ class DoctrineDataCollector extends BaseCollector
 
             /** @var $class \Doctrine\ORM\Mapping\ClassMetadataInfo */
             foreach ($factory->getLoadedMetadata() as $class) {
+                if (!$class instanceof ClassMetadataInfo) {
+                    continue;
+                }
                 if (!isset($entities[$name][$class->getName()])) {
                     $classErrors = $validator->validateClass($class);
                     $entities[$name][$class->getName()] = $class->getName();

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -70,7 +70,7 @@ class DoctrineDataCollector extends BaseCollector
 
             /** @var $class \Doctrine\ORM\Mapping\ClassMetadataInfo */
             foreach ($factory->getLoadedMetadata() as $class) {
-                if (!$class instanceof ClassMetadataInfo) {
+                if (!$class instanceof \Doctrine\ORM\Mapping\ClassMetadataInfo) {
                     continue;
                 }
                 if (!isset($entities[$name][$class->getName()])) {


### PR DESCRIPTION
A bug in Doctrine 2.5-dev could load transient classes so the DataCollector fails. A simple check could avoid it