### PR TITLE
Add support to set PostgreSQL application_name

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,6 +197,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('port')->defaultNull()->end()
                 ->scalarNode('user')->defaultValue('root')->end()
                 ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('application_name')->defaultNull()->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('path')->end()
                 ->booleanNode('memory')->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,7 +197,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('port')->defaultNull()->end()
                 ->scalarNode('user')->defaultValue('root')->end()
                 ->scalarNode('password')->defaultNull()->end()
-                ->scalarNode('application_name')->defaultNull()->end()
+                ->scalarNode('application_name')->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('path')->end()
                 ->booleanNode('memory')->end()

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -47,6 +47,7 @@
         <xsd:attribute name="port" type="xsd:string" />
         <xsd:attribute name="user" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />
+        <xsd:attribute name="application_name" type="xsd:string" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="unix-socket" type="xsd:string" />
         <xsd:attribute name="memory" type="xsd:string" />
@@ -255,7 +256,7 @@
         <xsd:attribute name="region-lifetime" type="xsd:integer" />
         <xsd:attribute name="region-lock-lifetime" type="xsd:integer" />
     </xsd:complexType>
-    
+
     <xsd:complexType name="dql">
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="string-function" type="named_scalar" />

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -47,7 +47,7 @@
         <xsd:attribute name="port" type="xsd:string" />
         <xsd:attribute name="user" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />
-        <xsd:attribute name="application_name" type="xsd:string" />
+        <xsd:attribute name="application-name" type="xsd:string" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="unix-socket" type="xsd:string" />
         <xsd:attribute name="memory" type="xsd:string" />


### PR DESCRIPTION
This PR is dependant upon https://github.com/doctrine/dbal/pull/798 .
PostgreSQL allows the user to set the application_name is connecting
to database. It is useful for monitoring purposes.
Currently one could just manually add 'application_name=foo' to DSN
by appending it to dbname, like:

> dbname:   %database_name% application_name=foo

It works but having a parameter eases setting it.