### PR TITLE
This partially fixes doctrine/DoctrineCacheBundle#46

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,6 +197,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('port')->defaultNull()->end()
                 ->scalarNode('user')->defaultValue('root')->end()
                 ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('database')->defaultNull()->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('path')->end()
                 ->booleanNode('memory')->end()
@@ -614,6 +615,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('id')->end()
                 ->scalarNode('namespace')->defaultNull()->end()
                 ->scalarNode('cache_provider')->defaultNull()->end()
+                ->scalarNode('database')->end()
             ->end()
         ;
 


### PR DESCRIPTION
This eradicates  "InvalidConfigurationException in ArrayNode.php line 309.", when defining a Redis database in config.yml

``` yml
doctrine:
    orm:
        metadata_cache_driver: 
            type: redis
            database: 8
            host: 192.168.0.1
        query_cache_driver:
            type: redis
            database: 8
            host: 192.168.0.1
        result_cache_driver:
            type: redis
            database: 8
            host: 192.168.0.1
```
