### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,17 +25,17 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.3",
-        "symfony/console": "~2.3",
+        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/console": "~2.3|~3.0",
         "doctrine/dbal": "~2.3",
         "jdorn/sql-formatter": "~1.1",
-        "symfony/doctrine-bridge": "~2.2",
+        "symfony/doctrine-bridge": "~2.2|~3.0",
         "doctrine/doctrine-cache-bundle": "~1.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.3",
-        "symfony/yaml": "~2.2",
-        "symfony/validator": "~2.2",
+        "symfony/yaml": "~2.2|~3.0",
+        "symfony/validator": "~2.2|~3.0",
         "twig/twig": "~1.10",
         "satooshi/php-coveralls": "~0.6.1",
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0