### PR TITLE
Add an exception when the ORM layer is configured but not DBAL

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -76,6 +76,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         if (!empty($config['orm'])) {
+            if (empty($config['dbal'])) {
+                throw new \LogicException('Configuring the ORM layer requires to configure the DBAL layer as well.');
+            }
+
             $this->ormLoad($config['orm'], $container);
         }
 

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -39,6 +39,17 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $container->getParameter('doctrine.default_connection'), '->load() overrides existing configuration options');
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Configuring the ORM layer requires to configure the DBAL layer as well.
+     */
+    public function testOrmRequiresDbal()
+    {
+        $extension = new DoctrineExtension();
+
+        $extension->load(array(array('orm' => array('auto_mapping' => true))), $this->getContainer());
+    }
+
     public function getAutomappingConfigurations()
     {
         return array(


### PR DESCRIPTION
This gives a better error message than the one reported in #395 when doing invalid configuration of the bundle.