### PR TITLE
Compare with dbname with existing databases needs unquoted dbname

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -71,6 +71,7 @@ EOT
         unset($params['dbname']);
 
         $tmpConnection = DriverManager::getConnection($params);
+        $shouldNotCreateDatabase = $ifNotExists && in_array($name, $tmpConnection->getSchemaManager()->listDatabases());
 
         // Only quote if we don't have a path
         if (!isset($params['path'])) {
@@ -79,10 +80,8 @@ EOT
 
         $error = false;
         try {
-            $shouldNotCreateDatabase = $ifNotExists && in_array($name, $tmpConnection->getSchemaManager()->listDatabases());
-
             if ($shouldNotCreateDatabase) {
-                $output->writeln(sprintf('<info>Database for connection named <comment>%s</comment> already exists. Skipped.</info>'));
+                $output->writeln(sprintf('<info>Database for connection named <comment>%s</comment> already exists. Skipped.</info>', $name));
             } else {
                 $tmpConnection->getSchemaManager()->createDatabase($name);
                 $output->writeln(sprintf('<info>Created database for connection named <comment>%s</comment></info>', $name));

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -85,6 +85,7 @@ EOT
             // as some vendors do not allow dropping the database connected to.
             $connection->close();
             $connection = DriverManager::getConnection($params);
+            $shouldDropDatabase = !$ifExists || in_array($name, $connection->getSchemaManager()->listDatabases());
 
             // Only quote if we don't have a path
             if (!isset($params['path'])) {
@@ -92,8 +93,6 @@ EOT
             }
 
             try {
-                $shouldDropDatabase = !$ifExists || in_array($name, $connection->getSchemaManager()->listDatabases());
-
                 if ($shouldDropDatabase) {
                     $connection->getSchemaManager()->dropDatabase($name);
                     $output->writeln(sprintf('<info>Dropped database for connection named <comment>%s</comment></info>', $name));


### PR DESCRIPTION
`listDatabases()` returns the unquoted database names and therefore
the command must use the unquoted database name for comparison