### PR TITLE
Changed default naming strategy to underscore

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -453,7 +453,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('class_metadata_factory_name')->defaultValue('Doctrine\ORM\Mapping\ClassMetadataFactory')->end()
                     ->scalarNode('default_repository_class')->defaultValue('Doctrine\ORM\EntityRepository')->end()
                     ->scalarNode('auto_mapping')->defaultFalse()->end()
-                    ->scalarNode('naming_strategy')->defaultValue('doctrine.orm.naming_strategy.default')->end()
+                    ->scalarNode('naming_strategy')->defaultValue('doctrine.orm.naming_strategy.underscore')->end()
                     ->scalarNode('entity_listener_resolver')->defaultNull()->end()
                     ->scalarNode('repository_factory')->defaultNull()->end()
                 ->end()

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -252,7 +252,7 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('doctrine.orm.default_result_cache', (string) $calls[3][1][0]);
 
         if (version_compare(Version::VERSION, "2.3.0-DEV") >= 0) {
-            $this->assertEquals('doctrine.orm.naming_strategy.default', (string) $calls[10][1][0]);
+            $this->assertEquals('doctrine.orm.naming_strategy.underscore', (string) $calls[10][1][0]);
         }
         if (version_compare(Version::VERSION, "2.4.0-DEV") >= 0) {
             $this->assertEquals('doctrine.orm.default_entity_listener_resolver', (string) $calls[11][1][0]);


### PR DESCRIPTION
This PR partially fixes the problem with case-sensitive identifiers http://dev.mysql.com/doc/refman/5.0/en/identifier-case-sensitivity.html