### PR TITLE
Improve the rendering of the query explanation for Postgres

### DIFF
--- a/Resources/views/Collector/explain.html.twig
+++ b/Resources/views/Collector/explain.html.twig
@@ -1,20 +1,30 @@
 <strong>Explanation:</strong>
 
-<table style="margin: 5px 0;">
-    <thead>
-        <tr>
-            {% for label in data[0]|keys %}
-                <th>{{ label }}</th>
+{% if data[0]|length > 1 %}
+    {# The platform returns a table for the explanation (e.g. MySQL), display all columns #}
+    <table style="margin: 5px 0;">
+        <thead>
+            <tr>
+                {% for label in data[0]|keys %}
+                    <th>{{ label }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in data %}
+            <tr>
+                {% for key, item in row %}
+                    <td>{{ item|replace({',': ', '}) }}</td>
+                {% endfor %}
+            </tr>
             {% endfor %}
-        </tr>
-    </thead>
-    <tbody>
-        {% for row in data %}
-        <tr>
-            {% for key, item in row %}
-                <td>{{ 'possible_keys' == key ? item|replace({',': ', '}) : item }}</td>
-            {% endfor %}
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+        </tbody>
+    </table>
+{% else %}
+    {# The Platform returns a single column for a textual explanation (e.g. PostgreSQL), display all lines #}
+    <pre style="margin: 5px 0;">
+        {%- for row in data -%}
+            {{ row|first }}{{ "\n" }}
+        {%- endfor -%}
+    </pre>
+{% endif %}


### PR DESCRIPTION
Postgres does not return a table for the explanation but a list of lines displaying the explanation in a formatted text.

The switch between the formats is based on whether each result row contains several columns (table formatting) or a single column (text formatting)