### PR TITLE
remove old and unnecessary preamble from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 Doctrine DBAL & ORM Bundle for the Symfony Framework.
 
-Because Symfony 2 does not want to force or suggest a specific persistence solutions on the users
-this bundle was removed from the core of the Symfony 2 framework. Doctrine2 will still be a major player
-in the Symfony world and the bundle is maintained by developers in the Doctrine and Symfony communities.
-
-    IMPORTANT: This bundle is developed for Symfony 2.1 and up. For Symfony 2.0 applications the DoctrineBundle
-    is still shipped with the core Symfony repository.
-
 Build Status: [![Build Status](https://secure.travis-ci.org/doctrine/DoctrineBundle.png?branch=master)](http://travis-ci.org/doctrine/DoctrineBundle)
 
 ## What is Doctrine?


### PR DESCRIPTION
I'm pretty sure information about Symfony 2.0 and 2.1 is unnecessary anymore. Nor do i think we need to explain why the DoctrineBundle was pulled out of core.