### PR TITLE
Fix DisconnectedMetadataFactory::findNamespaceAndPathForMetadata

### DIFF
--- a/Mapping/DisconnectedMetadataFactory.php
+++ b/Mapping/DisconnectedMetadataFactory.php
@@ -122,12 +122,20 @@ class DisconnectedMetadataFactory
         if (class_exists($all[0]->name)) {
             $r = new \ReflectionClass($all[0]->name);
             $path = $this->getBasePathForClass($r->getName(), $r->getNamespaceName(), dirname($r->getFilename()));
-        } elseif (!$path) {
+            $ns = $r->getNamespaceName();
+
+        } elseif ($path) {
+            // Get namespace by removing the last component of the FQCN
+            $nsParts = explode('\\', $all[0]->name);
+            array_pop($nsParts);
+            $ns = implode('\\', $nsParts);
+
+        } else {
             throw new \RuntimeException(sprintf('Unable to determine where to save the "%s" class (use the --path option).', $all[0]->name));
         }
 
         $metadata->setPath($path);
-        $metadata->setNamespace(isset($r) ? $r->getNamespaceName() : $all[0]->name);
+        $metadata->setNamespace($ns);
     }
 
     /**

--- a/Tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/Tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -27,7 +27,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
         }
     }
 
-    public function testFindNamespaceAndPathForMetadata()
+    public function testCannotFindNamespaceAndPathForMetadata()
     {
         $class = new ClassMetadataInfo(__CLASS__);
         $collection = new ClassMetadataCollection(array($class));
@@ -37,5 +37,18 @@ class DisconnectedMetadataFactoryTest extends TestCase
 
         $this->setExpectedException('RuntimeException', 'Can\'t find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest');
         $factory->findNamespaceAndPathForMetadata($collection);
+    }
+
+    public function testFindNamespaceAndPathForMetadata()
+    {
+        $class = new ClassMetadataInfo('\Vendor\Package\Class');
+        $collection = new ClassMetadataCollection(array($class));
+
+        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $factory = new DisconnectedMetadataFactory($registry);
+
+        $factory->findNamespaceAndPathForMetadata($collection, '/path/to/code');
+
+        $this->assertEquals('\Vendor\Package', $collection->getNamespace());
     }
 }


### PR DESCRIPTION
In cases where the class did not already exist the FQCN was being returned, it should now always return the namespace of the class.

This was causing me problems with a custom mapping driver & file locator I'm building - hopefully this is the correct fix, all tests are passing at least. 

I couldn't figure out a workable way to introduce a new test for these behaviours - any suggestions would be welcome.