### PR TITLE
create:database fails, when dbname is set via URL

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -71,7 +71,8 @@ EOT
         if (!$name) {
             throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
         }
-        unset($params['dbname']);
+        // Need to get rid of _every_ occurrence of dbname from connection configuration and we have already extracted all relevant info from url
+        unset($params['dbname'], $params['path'], $params['url']);
 
         $tmpConnection = DriverManager::getConnection($params);
         $shouldNotCreateDatabase = $ifNotExists && in_array($name, $tmpConnection->getSchemaManager()->listDatabases());


### PR DESCRIPTION
First of all: This may be a [DBAL-issue](https://github.com/doctrine/dbal).

However, when I specify the database connection via URL like `mysql://foo:bar@localhost/dbname` the command `doctrine:data:create` fails with an exception. I was able to extract the original exception from the driver (see below). It works, when I omit `dbname` from the URL and set it directly with the `dbname` configuration key.

```
#0 /vagrant/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php(45): Doctrine\DBAL\Driver\PDOConnection::__construct('mysql:host=127....', 'root', 'root', Array)
#1 /vagrant/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(360): Doctrine\DBAL\Driver\PDOMySql\Driver->connect(Array, 'root', 'root', Array)
#2 /vagrant/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(973): Doctrine\DBAL\Connection->connect()
#3 /vagrant/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php(1017): Doctrine\DBAL\Connection->executeUpdate('CREATE DATABASE...')
#4 /vagrant/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php(430): Doctrine\DBAL\Schema\AbstractSchemaManager->_execSql('CREATE DATABASE...')
#5 /vagrant/vendor/doctrine/doctrine-bundle/Command/CreateDatabaseDoctrineCommand.php(89): Doctrine\DBAL\Schema\AbstractSchemaManager->createDatabase('`symfony`')
#6 /vagrant/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php(259): Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /vagrant/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(886): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /vagrant/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(195): Symfony\Component\Console\Application->doRunCommand(Object(Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /vagrant/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php(96): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /vagrant/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(126): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /vagrant/bin/symfony(20): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput))
#12 {main}
```