### PR TITLE
Register ResolveTargetEntityListener as subscriber

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -383,7 +383,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 ));
             }
 
-            $def->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+            // BC: ResolveTargetEntityListener implements the subscriber interface since
+            // v2.5.0-beta1 (Commit 437f812)
+            if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
+                $def->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+            } else {
+                $def->addTag('doctrine.event_subscriber');
+            }
         }
     }
 

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -614,7 +614,12 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
 
         $definition = $container->getDefinition('doctrine.orm.listeners.resolve_target_entity');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addResolveTargetEntity', array('Symfony\Component\Security\Core\User\UserInterface', 'MyUserClass', array()));
-        $this->assertEquals(array('doctrine.event_listener' => array( array('event' => 'loadClassMetadata') ) ), $definition->getTags());
+
+        if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
+            $this->assertEquals(array('doctrine.event_listener' => array(array('event' => 'loadClassMetadata'))), $definition->getTags());
+        } else {
+            $this->assertEquals(array('doctrine.event_subscriber' => array(array())), $definition->getTags());
+        }
     }
 
     public function testAttachEntityListeners()


### PR DESCRIPTION
[Since january](https://github.com/doctrine/doctrine2/commit/437f812) the `ResolveTargetEntityListener` implements the `EventSubscriber`-interface, but the concrete listener instance is still registered as simple listener listening on `loadClassMetadata`. This makes the listener miss the `onClassMetadataNotFound`. 

The concrete problem I have is, that I want setup all repositories in my DIC like this

```xml
<?xml version="1.0" ?>
<container xmlns="http://symfony.com/schema/dic/services"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">

    <services>
        <service" id="user.manager" class="Doctrine\Common\Persistence\ObjectManager" public="false>
            <factory service="doctrine" method="getManagerForClass" />
            <argument>Acme\UserInterface</argument>
        </service>
        <service id="user.repository" class="User\Doctrine\UserRepsitory">
            <factory service="user.manager" method="getRepository" />
            <argument>Acme\UserInterface</argument>
        </service>
    </services>
</container>
```

Currently using `Acme\UserInterface` as entity classname leads to `getManagerForClass()` returning `null` and (when I bypass the `getManagerForClass()`-issue) `getRepository()` throwing an exception "class not found". I expected to use the interfaces as kind of aliases for the concrete entity implementations. 