### PR TITLE
[Fix] Doctrine profiler "Expand all queries" action.

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -258,12 +258,12 @@
 
         function expandAllQueries(button) {
             var conn = button.getAttribute('data-connection'),
-                queries = document.getElementById('queries-' + conn).getElementsByClassName('query-section'),
+                queries = document.querySelectorAll('#queries-' + conn + ' .query-section'),
                 i = queries.length,
                 action = button.getAttribute('data-action');
 
             if (action == 'expand') {
-                button.getElementsByClassName('btn-bg')[0].innerHTML = 'Collapse all queries';
+                button.querySelector('.btn-bg').innerHTML = 'Collapse all queries';
 
                 while (i--) {
                     if (queries[i].getAttribute('data-state') == 'collapsed') {
@@ -271,7 +271,7 @@
                     }
                 }
             } else {
-                button.getElementsByClassName('btn-bg')[0].innerHTML = 'Expand all queries';
+                button.querySelector('.btn-bg').innerHTML = 'Expand all queries';
 
                 while (i--) {
                     if (queries[i].getAttribute('data-state') == 'expanded') {

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -92,7 +92,7 @@
             </p>
         {% else %}
             <p>
-                <button type="button" class="sf-button" onclick="expandAllQueries(this);" data-action="expand">
+                <button type="button" class="sf-button" onclick="expandAllQueries(this);" data-action="expand" data-connection="{{ loop.index }}">
                     <span class="border-l">
                         <span class="border-r">
                             <span class="btn-bg">Expand all queries</span>
@@ -257,7 +257,8 @@
         }
 
         function expandAllQueries(button) {
-            var queries = document.getElementsByClassName('query-section'),
+            var conn = button.getAttribute('data-connection'),
+                queries = document.getElementById('queries-' + conn).getElementsByClassName('query-section'),
                 i = queries.length,
                 action = button.getAttribute('data-action');
 


### PR DESCRIPTION
The "Expand all queries" button is expanding the queries from all the connections that are present in the application. However, there is a button for each connection.

This pull request fixes the issue by separating the action for each button.
