### PR TITLE
Add a Configuration Option to Use Savepoints

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -226,6 +226,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('pooled')->info('True to use a pooled server with the oci8/pdo_oracle driver')->end()
                 ->booleanNode('MultipleActiveResultSets')->info('Configuring MultipleActiveResultSets for the pdo_sqlsrv driver')->end()
+                ->booleanNode('use_savepoints')->info('Use savepoints for nested transactions')->end()
             ->end()
             ->beforeNormalization()
                 ->ifTrue(function ($v) {return !isset($v['sessionMode']) && isset($v['session_mode']);})

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -232,7 +232,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         ;
 
         if (!empty($connection['use_savepoints'])) {
-            $def->addMethodCall('setNestTransactionsWithSavepoints', array(true));
+            $def->addMethodCall('setNestTransactionsWithSavepoints', array($connection['use_savepoints']));
         }
     }
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -221,7 +221,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $options = $this->getConnectionOptions($connection);
 
-        $container
+        $def = $container
             ->setDefinition(sprintf('doctrine.dbal.%s_connection', $name), new DefinitionDecorator('doctrine.dbal.connection'))
             ->setArguments(array(
                 $options,
@@ -230,6 +230,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $connection['mapping_types'],
             ))
         ;
+
+        if (!empty($connection['use_savepoints'])) {
+            $def->addMethodCall('setNestTransactionsWithSavepoints', array(true));
+        }
     }
 
     protected function getConnectionOptions($connection)

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -37,6 +37,7 @@
         <xsd:attribute name="logging" type="xsd:string" default="false" />
         <xsd:attribute name="profiling" type="xsd:string" default="false" />
         <xsd:attribute name="server-version" type="xsd:string" />
+        <xsd:attribute name="use-savepoints" type="xsd:boolean" />
         <xsd:attributeGroup ref="driver-config" />
     </xsd:attributeGroup>
 

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -67,6 +67,10 @@ Configuration Reference
 
                         # pdo_sqlsrv driver specific. Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
                         MultipleActiveResultSets:  ~
+
+                        # Enable savepoints for nested transactions
+                        use_savepoints: true
+
                         driver:               pdo_mysql
                         platform_service:     ~
                         auto_commit:          ~
@@ -374,6 +378,7 @@ Configuration Reference
                     <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
                     <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                     <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
+                    <!-- use-savepoints: Enable savepoints for nested transactions -->
                     <doctrine:connection
                         name="default"
                         dbname=""
@@ -394,6 +399,7 @@ Configuration Reference
                         sslmode=""
                         pooled=""
                         MultipleActiveResultSets=""
+                        use-savepoints="true"
                         driver="pdo_mysql"
                         platform-service=""
                         auto-commit=""

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -148,6 +148,22 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDbalLoadSavepointsForNestedTransactions()
+    {
+        $container = $this->loadContainer('dbal_savepoints');
+
+        $calls = $container->getDefinition('doctrine.dbal.savepoints_connection')->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
+        $this->assertTrue($calls[0][1][0]);
+
+        $calls = $container->getDefinition('doctrine.dbal.nosavepoints_connection')->getMethodCalls();
+        $this->assertCount(0, $calls);
+
+        $calls = $container->getDefinition('doctrine.dbal.notset_connection')->getMethodCalls();
+        $this->assertCount(0, $calls);
+    }
+
     public function testLoadSimpleSingleConnection()
     {
         $container = $this->loadContainer('orm_service_simple_single_entity_manager');

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -225,6 +225,7 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('root', $args[0]['user']);
         $this->assertEquals('doctrine.dbal.default_connection.configuration', (string) $args[1]);
         $this->assertEquals('doctrine.dbal.default_connection.event_manager', (string) $args[2]);
+        $this->assertCount(0, $definition->getMethodCalls());
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -267,6 +268,21 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
 
         $definition = $container->getDefinition($container->getAlias('doctrine.orm.default_result_cache'));
         $this->assertEquals('%doctrine_cache.array.class%', $definition->getClass());
+    }
+
+    public function testUseSavePointsAddMethodCallToAddSavepointsToTheConnection()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $extension->load(array(array('dbal' => array('connections' => array(
+            'default' => array('password' => 'foo', 'use_savepoints' => true)
+        )))), $container);
+
+        $calls = $container->getDefinition('doctrine.dbal.default_connection')->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
+        $this->assertTrue($calls[0][1][0]);
     }
 
     public function testAutoGenerateProxyClasses()

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_savepoints.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_savepoints.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="mysql">
+            <connection
+                name="savepoints"
+                use-savepoints="true" />
+            <connection
+                name="nosavepoints"
+                use-savepoints="false" />
+            <connection
+                name="notset"
+                user="root" />
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_savepoints.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_savepoints.yml
@@ -1,0 +1,10 @@
+doctrine:
+    dbal:
+        default_connection: savepoints
+        connections:
+            savepoints:
+                use_savepoints: true
+            nosavepoints:
+                use_savepoints: false
+            notset:
+                user: root


### PR DESCRIPTION
Closes #450

This adds the `use_savepoints` option to connection configuration which
turns on savepoints for nested transactions.

This is a bit uglier than it could be since [`setNestTransactionsWithSavepoints` throws](https://github.com/doctrine/dbal/blob/3a698bd6fedbf684675ec0ecc471d07f77feea63/lib/Doctrine/DBAL/Connection.php#L1128-L1130) when called on database platforms without savepoint support regardless of whether savepoints are being enabled.

I may not have done the tests correctly here.
