### PR TITLE
[WIP] Add `--shard` option to doctrine commands

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -35,6 +35,7 @@ class CreateDatabaseDoctrineCommand extends DoctrineCommand
         $this
             ->setName('doctrine:database:create')
             ->setDescription('Creates the configured database')
+            ->addOption('shard', null, InputOption::VALUE_OPTIONAL, 'The shard connection to use for this command')
             ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'The connection to use for this command')
             ->addOption('if-not-exists', null, InputOption::VALUE_NONE, 'Don\'t trigger an error, when the database already exists')
             ->setHelp(<<<EOT
@@ -65,6 +66,21 @@ EOT
         $params = $connection->getParams();
         if (isset($params['master'])) {
             $params = $params['master'];
+        }
+        if (isset($params['shards'])) {
+            $shards = $params['shards'];
+            // Default select global
+            $params = $params['global'];
+            if ($input->getOption('shard')) {
+                foreach ($shards as $shard) {
+                    if ($shard['id'] === (int)$input->getOption('shard')) {
+                        // Select sharded database
+                        $params = $shard;
+                        unset($params['id']);
+                        break;
+                    }
+                }
+            }
         }
 
         $name = isset($params['path']) ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -40,6 +40,7 @@ class DropDatabaseDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:database:drop')
             ->setDescription('Drops the configured database')
             ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'The connection to use for this command')
+            ->addOption('shard', null, InputOption::VALUE_OPTIONAL, 'The shard connection to use for this command')
             ->addOption('if-exists', null, InputOption::VALUE_NONE, 'Don\'t trigger an error, when the database doesn\'t exist')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Set this parameter to execute this action')
             ->setHelp(<<<EOT
@@ -69,6 +70,21 @@ EOT
         $params = $connection->getParams();
         if (isset($params['master'])) {
             $params = $params['master'];
+        }
+        if (isset($params['shards'])) {
+            $shards = $params['shards'];
+            // Default select global
+            $params = $params['global'];
+            if ($input->getOption('shard')) {
+                foreach ($shards as $shard) {
+                    if ($shard['id'] === (int)$input->getOption('shard')) {
+                        // Select sharded database
+                        $params = $shard;
+                        unset($params['id']);
+                        break;
+                    }
+                }
+            }
         }
 
         $name = isset($params['path']) ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -142,6 +142,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('server_version')->end()
                 ->scalarNode('driver_class')->end()
                 ->scalarNode('wrapper_class')->end()
+                ->scalarNode('shard_manager')->end()
                 ->scalarNode('shard_choser')->end()
                 ->scalarNode('shard_choser_service')->end()
                 ->booleanNode('keep_slave')->end()

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -304,6 +304,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $options['global'][$key] = $value;
                 unset($options[$key]);
             }
+            if (!isset($options['global']['driver'])) {
+                $options['global']['driver'] = $options['driver'];
+            }
+            foreach ($options['shards'] as $i => $shard) {
+                if (!isset($shard['driver'])) {
+                    $options['shards'][$i]['driver'] = $options['driver'];
+                }
+            }
             if (empty($options['wrapperClass'])) {
                 // Change the wrapper class only if the user does not already forced using a custom one.
                 $options['wrapperClass'] = 'Doctrine\\DBAL\\Sharding\\PoolingShardConnection';

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -230,6 +230,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $connection['mapping_types'],
             ))
         ;
+
+        // Create a shard_manager for this connection
+        if (isset($options['shards'])) {
+            $shardManagerDefinition = new Definition($options['shardManagerClass'], [
+                new Reference(sprintf('doctrine.dbal.%s_connection', $name))
+            ]);
+            $container->setDefinition(sprintf('doctrine.dbal.%s_shard_manager', $name), $shardManagerDefinition);
+        }
     }
 
     protected function getConnectionOptions($connection)
@@ -253,6 +261,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             'wrapper_class' => 'wrapperClass',
             'keep_slave' => 'keepSlave',
             'shard_choser' => 'shardChoser',
+            'shard_manager_class' => 'shardManagerClass',
             'server_version' => 'serverVersion',
         ) as $old => $new) {
             if (isset($options[$old])) {
@@ -315,6 +324,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
             if (empty($options['wrapperClass'])) {
                 // Change the wrapper class only if the user does not already forced using a custom one.
                 $options['wrapperClass'] = 'Doctrine\\DBAL\\Sharding\\PoolingShardConnection';
+            }
+            if (empty($options['shardManagerClass'])) {
+                // Change the shard manager class only if the user does not already forced using a custom one.
+                $options['shardManagerClass'] = 'Doctrine\\DBAL\\Sharding\\PoolingShardManager';
             }
         } else {
             unset($options['shards']);

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -136,13 +136,13 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Doctrine\\DBAL\\Sharding\\PoolingShardConnection', $param['wrapperClass']);
         $this->assertEquals(new Reference('foo.shard_choser'), $param['shardChoser']);
         $this->assertEquals(
-            array('user' => 'mysql_user', 'password' => 'mysql_s3cr3t', 'port' => null, 'dbname' => 'mysql_db', 'host' => 'localhost', 'unix_socket' => '/path/to/mysqld.sock'),
+            array('user' => 'mysql_user', 'password' => 'mysql_s3cr3t', 'port' => null, 'dbname' => 'mysql_db', 'host' => 'localhost', 'driver' => 'pdo_mysql', 'unix_socket' => '/path/to/mysqld.sock'),
             $param['global']
         );
         $this->assertEquals(
             array(
                 'user' => 'shard_user', 'password' => 'shard_s3cr3t', 'port' => null, 'dbname' => 'shard_db',
-                'host' => 'localhost', 'unix_socket' => '/path/to/mysqld_shard.sock', 'id' => 1,
+                'host' => 'localhost', 'driver' => 'pdo_mysql', 'unix_socket' => '/path/to/mysqld_shard.sock', 'id' => 1,
             ),
             $param['shards'][0]
         );

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -482,6 +482,29 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('doctrine_cache.providers.result_cache', (string) $alias);
     }
 
+    public function testShardManager()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $config = $this->getConnectionConfig();
+        $config['dbal'] = array(
+            'connections' => array(
+                'foo' => array(
+                    'shards' => array(
+                        'test' => array('id' => 1)
+                    ),
+                ),
+                'bar' => array(),
+            ),
+        );
+
+        $extension->load(array($config), $container);
+
+        $this->assertTrue($container->hasDefinition('doctrine.dbal.foo_shard_manager'));
+        $this->assertFalse($container->hasDefinition('doctrine.dbal.bar_shard_manager'));
+    }
+
     private function getContainer($bundles = 'YamlBundle', $vendor = null)
     {
         $bundles = (array) $bundles;


### PR DESCRIPTION
I need to use shard connections in my project, but it seems that some code is not up to date with sharding. This PR add some compatibility & options with shard connections.

- [x] Add `--shard` option to `doctrine:database` commands
- [x] Switch to correct shard connection if exists, else select _global_ one
- [x] Update [PoolingShardConnection](http://www.doctrine-project.org/api/dbal/2.4/class-Doctrine.DBAL.Sharding.PoolingShardConnection.html) => https://github.com/doctrine/dbal/pull/896
- [x] Create dynamic service `doctrine.<connection name>_shard_manager` using [PoolingShardManager](http://www.doctrine-project.org/api/dbal/2.5/class-Doctrine.DBAL.Sharding.PoolingShardManager.html)
- [ ] Add `--shard` option to `doctrine:migrations` commands
- [ ] Add `--shard` option to `doctrine:fixtures` commands

Is there a need to implement this option on `doctrine:fixtures` & `doctrine:migrations` commands?