### PR TITLE
Add --shard option to doctrine commands

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -35,6 +35,7 @@ class CreateDatabaseDoctrineCommand extends DoctrineCommand
         $this
             ->setName('doctrine:database:create')
             ->setDescription('Creates the configured database')
+            ->addOption('shard', null, InputOption::VALUE_OPTIONAL, 'The shard connection to use for this command')
             ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'The connection to use for this command')
             ->addOption('if-not-exists', null, InputOption::VALUE_NONE, 'Don\'t trigger an error, when the database already exists')
             ->setHelp(<<<EOT
@@ -65,6 +66,21 @@ EOT
         $params = $connection->getParams();
         if (isset($params['master'])) {
             $params = $params['master'];
+        }
+        if (isset($params['shards'])) {
+            $shards = $params['shards'];
+            // Default select global
+            $params = $params['global'];
+            if ($input->getOption('shard')) {
+                foreach ($shards as $shard) {
+                    if ($shard['id'] === (int)$input->getOption('shard')) {
+                        // Select sharded database
+                        $params = $shard;
+                        unset($params['id']);
+                        break;
+                    }
+                }
+            }
         }
 
         $hasPath = isset($params['path']);

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -40,7 +40,7 @@ class DropDatabaseDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:database:drop')
             ->setDescription('Drops the configured database')
             ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'The connection to use for this command')
-            ->addOption('shard', null, InputOption::VALUE_OPTIONAL, 'The shard connection to use for this command')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command')
             ->addOption('if-exists', null, InputOption::VALUE_NONE, 'Don\'t trigger an error, when the database doesn\'t exist')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Set this parameter to execute this action')
             ->setHelp(<<<EOT
@@ -71,10 +71,11 @@ EOT
         if (isset($params['master'])) {
             $params = $params['master'];
         }
+
         if (isset($params['shards'])) {
             $shards = $params['shards'];
             // Default select global
-            $params = $params['global'];
+            $params = array_merge($params, $params['global']);
             if ($input->getOption('shard')) {
                 foreach ($shards as $shard) {
                     if ($shard['id'] === (int)$input->getOption('shard')) {

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -40,6 +40,7 @@ class DropDatabaseDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:database:drop')
             ->setDescription('Drops the configured database')
             ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'The connection to use for this command')
+            ->addOption('shard', null, InputOption::VALUE_OPTIONAL, 'The shard connection to use for this command')
             ->addOption('if-exists', null, InputOption::VALUE_NONE, 'Don\'t trigger an error, when the database doesn\'t exist')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Set this parameter to execute this action')
             ->setHelp(<<<EOT
@@ -69,6 +70,21 @@ EOT
         $params = $connection->getParams();
         if (isset($params['master'])) {
             $params = $params['master'];
+        }
+        if (isset($params['shards'])) {
+            $shards = $params['shards'];
+            // Default select global
+            $params = $params['global'];
+            if ($input->getOption('shard')) {
+                foreach ($shards as $shard) {
+                    if ($shard['id'] === (int)$input->getOption('shard')) {
+                        // Select sharded database
+                        $params = $shard;
+                        unset($params['id']);
+                        break;
+                    }
+                }
+            }
         }
 
         $name = isset($params['path']) ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -41,6 +41,7 @@ class ImportMappingDoctrineCommand extends DoctrineCommand
             ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to import the mapping information to')
             ->addArgument('mapping-type', InputArgument::OPTIONAL, 'The mapping type to export the imported mapping information to')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command')
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be mapped.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force to overwrite existing mapping files.')
             ->setDescription('Imports mapping information from an existing database')
@@ -95,7 +96,7 @@ EOT
             $exporter->setEntityGenerator($entityGenerator);
         }
 
-        $em = $this->getEntityManager($input->getOption('em'));
+        $em = $this->getEntityManager($input->getOption('em'), $input->getOption('shard'));
 
         $databaseDriver = new DatabaseDriver($em->getConnection()->getSchemaManager());
         $em->getConfiguration()->setMetadataDriverImpl($databaseDriver);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -143,6 +143,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('server_version')->end()
                 ->scalarNode('driver_class')->end()
                 ->scalarNode('wrapper_class')->end()
+                ->scalarNode('shard_manager_class')->end()
                 ->scalarNode('shard_choser')->end()
                 ->scalarNode('shard_choser_service')->end()
                 ->booleanNode('keep_slave')->end()

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -234,6 +234,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if (!empty($connection['use_savepoints'])) {
             $def->addMethodCall('setNestTransactionsWithSavepoints', array($connection['use_savepoints']));
         }
+
+        // Create a shard_manager for this connection
+        if (isset($options['shards'])) {
+            $shardManagerDefinition = new Definition($options['shardManagerClass'], array(
+                new Reference(sprintf('doctrine.dbal.%s_connection', $name))
+            ));
+            $container->setDefinition(sprintf('doctrine.dbal.%s_shard_manager', $name), $shardManagerDefinition);
+        }
     }
 
     protected function getConnectionOptions($connection)
@@ -257,6 +265,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             'wrapper_class' => 'wrapperClass',
             'keep_slave' => 'keepSlave',
             'shard_choser' => 'shardChoser',
+            'shard_manager_class' => 'shardManagerClass',
             'server_version' => 'serverVersion',
             'default_table_options' => 'defaultTableOptions',
         ) as $old => $new) {
@@ -299,6 +308,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'driver' => true, 'driverOptions' => true, 'driverClass' => true,
                 'wrapperClass' => true, 'keepSlave' => true, 'shardChoser' => true,
                 'platform' => true, 'slaves' => true, 'global' => true, 'shards' => true,
+                'serverVersion' => true,
                 // included by safety but should have been unset already
                 'logging' => true, 'profiling' => true, 'mapping_types' => true, 'platform_service' => true,
             );
@@ -309,17 +319,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $options['global'][$key] = $value;
                 unset($options[$key]);
             }
-            if (!isset($options['global']['driver'])) {
-                $options['global']['driver'] = $options['driver'];
-            }
-            foreach ($options['shards'] as $i => $shard) {
-                if (!isset($shard['driver'])) {
-                    $options['shards'][$i]['driver'] = $options['driver'];
-                }
-            }
             if (empty($options['wrapperClass'])) {
                 // Change the wrapper class only if the user does not already forced using a custom one.
                 $options['wrapperClass'] = 'Doctrine\\DBAL\\Sharding\\PoolingShardConnection';
+            }
+            if (empty($options['shardManagerClass'])) {
+                // Change the shard manager class only if the user does not already forced using a custom one.
+                $options['shardManagerClass'] = 'Doctrine\\DBAL\\Sharding\\PoolingShardManager';
             }
         } else {
             unset($options['shards']);

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -309,6 +309,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $options['global'][$key] = $value;
                 unset($options[$key]);
             }
+            if (!isset($options['global']['driver'])) {
+                $options['global']['driver'] = $options['driver'];
+            }
+            foreach ($options['shards'] as $i => $shard) {
+                if (!isset($shard['driver'])) {
+                    $options['shards'][$i]['driver'] = $options['driver'];
+                }
+            }
             if (empty($options['wrapperClass'])) {
                 // Change the wrapper class only if the user does not already forced using a custom one.
                 $options['wrapperClass'] = 'Doctrine\\DBAL\\Sharding\\PoolingShardConnection';

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -150,7 +150,7 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             array(
                 'user' => 'shard_user', 'password' => 'shard_s3cr3t', 'port' => null, 'dbname' => 'shard_db',
-                'host' => 'localhost', 'unix_socket' => '/path/to/mysqld_shard.sock', 'id' => 1,
+                'host' => 'localhost', 'driver' => 'pdo_mysql', 'unix_socket' => '/path/to/mysqld_shard.sock', 'id' => 1,
             ),
             $param['shards'][0]
         );

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -150,7 +150,7 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             array(
                 'user' => 'shard_user', 'password' => 'shard_s3cr3t', 'port' => null, 'dbname' => 'shard_db',
-                'host' => 'localhost', 'driver' => 'pdo_mysql', 'unix_socket' => '/path/to/mysqld_shard.sock', 'id' => 1,
+                'host' => 'localhost', 'unix_socket' => '/path/to/mysqld_shard.sock', 'id' => 1,
             ),
             $param['shards'][0]
         );

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -498,6 +498,29 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('doctrine_cache.providers.result_cache', (string) $alias);
     }
 
+    public function testShardManager()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $config = $this->getConnectionConfig();
+        $config['dbal'] = array(
+            'connections' => array(
+                'foo' => array(
+                    'shards' => array(
+                        'test' => array('id' => 1)
+                    ),
+                ),
+                'bar' => array(),
+            ),
+        );
+
+        $extension->load(array($config), $container);
+
+        $this->assertTrue($container->hasDefinition('doctrine.dbal.foo_shard_manager'));
+        $this->assertFalse($container->hasDefinition('doctrine.dbal.bar_shard_manager'));
+    }
+
     private function getContainer($bundles = 'YamlBundle', $vendor = null)
     {
         $bundles = (array) $bundles;


### PR DESCRIPTION
I need to use shard connections in my project, but it seems that some code is not up to date with sharding. This PR add some compatibility & options with shard connections.

- [x] Add `--shard` option to `doctrine:database` commands
- [x] Switch to correct shard connection if exists, else select _global_ one
- [x] Update [PoolingShardConnection](http://www.doctrine-project.org/api/dbal/2.4/class-Doctrine.DBAL.Sharding.PoolingShardConnection.html) => https://github.com/doctrine/dbal/pull/903 & https://github.com/doctrine/dbal/pull/912
- [x] Create dynamic service `doctrine.<connection name>_shard_manager` using [PoolingShardManager](http://www.doctrine-project.org/api/dbal/2.5/class-Doctrine.DBAL.Sharding.PoolingShardManager.html)
- [x] Add `--shard` option to `doctrine:migrations` commands => https://github.com/doctrine/DoctrineMigrationsBundle/pull/132
- [x] Add `--shard` option to `doctrine:fixtures` commands => https://github.com/doctrine/DoctrineFixturesBundle/pull/145
- [x] Update unit tests