### PR TITLE
fixed hardcoded app/console

### DIFF
--- a/Command/GenerateEntitiesDoctrineCommand.php
+++ b/Command/GenerateEntitiesDoctrineCommand.php
@@ -49,28 +49,28 @@ You have to limit generation of entities:
 
 * To a bundle:
 
-  <info>php app/console doctrine:generate:entities MyCustomBundle</info>
+  <info>php %command.full_name% doctrine:generate:entities MyCustomBundle</info>
 
 * To a single entity:
 
-  <info>php app/console doctrine:generate:entities MyCustomBundle:User</info>
-  <info>php app/console doctrine:generate:entities MyCustomBundle/Entity/User</info>
+  <info>php %command.full_name% doctrine:generate:entities MyCustomBundle:User</info>
+  <info>php %command.full_name% doctrine:generate:entities MyCustomBundle/Entity/User</info>
 
 * To a namespace
 
-  <info>php app/console doctrine:generate:entities MyCustomBundle/Entity</info>
+  <info>php %command.full_name% doctrine:generate:entities MyCustomBundle/Entity</info>
 
 If the entities are not stored in a bundle, and if the classes do not exist,
 the command has no way to guess where they should be generated. In this case,
 you must provide the <comment>--path</comment> option:
 
-  <info>php app/console doctrine:generate:entities Blog/Entity --path=src/</info>
+  <info>php %command.full_name% doctrine:generate:entities Blog/Entity --path=src/</info>
 
 By default, the unmodified version of each entity is backed up and saved
 (e.g. Product.php~). To prevent this task from creating the backup file,
 pass the <comment>--no-backup</comment> option:
 
-  <info>php app/console doctrine:generate:entities Blog/Entity --no-backup</info>
+  <info>php %command.full_name% doctrine:generate:entities Blog/Entity --no-backup</info>
 
 <error>Important:</error> Even if you specified Inheritance options in your
 XML or YAML Mapping files the generator cannot generate the base and

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -48,22 +48,22 @@ class ImportMappingDoctrineCommand extends DoctrineCommand
 The <info>doctrine:mapping:import</info> command imports mapping information
 from an existing database:
 
-<info>php app/console doctrine:mapping:import "MyCustomBundle" xml</info>
+<info>php %command.full_name% doctrine:mapping:import "MyCustomBundle" xml</info>
 
 You can also optionally specify which entity manager to import from with the
 <info>--em</info> option:
 
-<info>php app/console doctrine:mapping:import "MyCustomBundle" xml --em=default</info>
+<info>php %command.full_name% doctrine:mapping:import "MyCustomBundle" xml --em=default</info>
 
 If you don't want to map every entity that can be found in the database, use the
 <info>--filter</info> option. It will try to match the targeted mapped entity with the
 provided pattern string.
 
-<info>php app/console doctrine:mapping:import "MyCustomBundle" xml --filter=MyMatchedEntity</info>
+<info>php %command.full_name% doctrine:mapping:import "MyCustomBundle" xml --filter=MyMatchedEntity</info>
 
 Use the <info>--force</info> option, if you want to override existing mapping files:
 
-<info>php app/console doctrine:mapping:import "MyCustomBundle" xml --force</info>
+<info>php %command.full_name% doctrine:mapping:import "MyCustomBundle" xml --force</info>
 EOT
         );
     }

--- a/Command/Proxy/RunDqlDoctrineCommand.php
+++ b/Command/Proxy/RunDqlDoctrineCommand.php
@@ -41,17 +41,17 @@ class RunDqlDoctrineCommand extends RunDqlCommand
 The <info>doctrine:query:dql</info> command executes the given DQL query and
 outputs the results:
 
-<info>php app/console doctrine:query:dql "SELECT u FROM UserBundle:User u"</info>
+<info>php %command.full_name% doctrine:query:dql "SELECT u FROM UserBundle:User u"</info>
 
 You can also optional specify some additional options like what type of
 hydration to use when executing the query:
 
-<info>php app/console doctrine:query:dql "SELECT u FROM UserBundle:User u" --hydrate=array</info>
+<info>php %command.full_name% doctrine:query:dql "SELECT u FROM UserBundle:User u" --hydrate=array</info>
 
 Additionally you can specify the first result and maximum amount of results to
 show:
 
-<info>php app/console doctrine:query:dql "SELECT u FROM UserBundle:User u" --first-result=0 --max-result=30</info>
+<info>php %command.full_name% doctrine:query:dql "SELECT u FROM UserBundle:User u" --first-result=0 --max-result=30</info>
 EOT
         );
     }

--- a/Command/Proxy/RunSqlDoctrineCommand.php
+++ b/Command/Proxy/RunSqlDoctrineCommand.php
@@ -41,7 +41,7 @@ class RunSqlDoctrineCommand extends RunSqlCommand
 The <info>doctrine:query:sql</info> command executes the given SQL query and
 outputs the results:
 
-<info>php app/console doctrine:query:sql "SELECT * from user"</info>
+<info>php %command.full_name% doctrine:query:sql "SELECT * from user"</info>
 EOT
         );
     }


### PR DESCRIPTION
Important for Symfony 3.0 where the console is not in `app/` anymore.