### PR TITLE
Remove the `url` Configuration Parameter in Commands

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -71,6 +71,7 @@ EOT
         if (!$name) {
             throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
         }
+        unset($params['url']);
         unset($params['dbname']);
 
         $tmpConnection = DriverManager::getConnection($params);

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -75,6 +75,7 @@ EOT
         if (!$name) {
             throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
         }
+        unset($params['url']);
         unset($params['dbname']);
 
         if ($input->getOption('force')) {


### PR DESCRIPTION
When present, `DriverManager::getConnection` parses `url` out into the
appropriate config parameters (like path -> dbname, etc). When the
Create/Drop commands do their thing, they look for `dbname` (or path)
then unset the value. If URL is present, it just goes right back into
`DriverManager::getConnection` and gets re-parsed.

Which means something like the create database command would fail if the
database does not exist (because the connection cannot be made).

Remove the URL, just like what is done with the `dbname` parameter.

Closes #464

Wasn't really sure what to test here. There is only a single command test and very artificial. reproduction this bug relies on `DriverManager::getConnection` having parsed the URL already when the connection is pulled out of the container.