### PR TITLE
Fix the controller reference to explain queries

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -108,7 +108,7 @@
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
     {% if 'explain' == page %}
-        {{ render(controller('@Doctrine/Profiler/explain', {
+        {{ render(controller('DoctrineBundle:Profiler:explain', {
             token: token,
             panel: 'db',
             connectionName: app.request.query.get('connection'),


### PR DESCRIPTION
there was a mistake I missed in #468. One of the changed reference was not a template name, but a controller reference /cc @fabpot 