### PR TITLE
Tweaked collector priority

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -35,7 +35,7 @@
         </service>
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
-            <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" priority="260" />
+            <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" priority="265" />
             <argument type="service" id="doctrine" />
         </service>
 

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -35,7 +35,7 @@
         </service>
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
-            <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" />
+            <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" priority="260" />
             <argument type="service" id="doctrine" />
         </service>
 

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -35,7 +35,7 @@
         </service>
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
-            <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" priority="265" />
+            <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" priority="250" />
             <argument type="service" id="doctrine" />
         </service>
 


### PR DESCRIPTION
In https://github.com/symfony/symfony/pull/16023 we're tweaking the priorities of the toolbar/profiler panels. The `265` value is the right number for Doctrine ... but maybe you don't want to merge it yet because this will change a lot the position of the Doctrine panel in the profiler/toolbar of Symfony versions older than 2.8.