### PR TITLE
fixes #317 #441 Changed filtering method when importing mappings

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -105,8 +105,11 @@ EOT
 
         $cmf = new DisconnectedClassMetadataFactory();
         $cmf->setEntityManager($em);
+        if($filters = $input->getOption('filter')){
+        	$regExpFilter = '/'.implode('|',$filters).'/';
+        	$em->getConnection()->getConfiguration()->setFilterSchemaAssetsExpression($regExpFilter);
+        }
         $metadata = $cmf->getAllMetadata();
-        $metadata = MetadataFilter::filter($metadata, $input->getOption('filter'));
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {


### PR DESCRIPTION
The MetadataFilter filtered table names containing any of the —filter arguments. We have to avoid getting all metadata with the Filter Schema Assets Expression which uses regular expressions.