### PR TITLE
Add support to set PostgreSQL sslrootcert

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -230,6 +230,12 @@ class Configuration implements ConfigurationInterface
                         'the server for PostgreSQL.'
                     )
                 ->end()
+                ->scalarNode('sslrootcert')
+                    ->info(
+                        'The name of a file containing SSL certificate authority (CA) certificate(s). '.
+                        'If the file exists, the server\'s certificate will be verified to be signed by one of these authorities.'
+                    )
+                ->end()
                 ->booleanNode('pooled')->info('True to use a pooled server with the oci8/pdo_oracle driver')->end()
                 ->booleanNode('MultipleActiveResultSets')->info('Configuring MultipleActiveResultSets for the pdo_sqlsrv driver')->end()
                 ->booleanNode('use_savepoints')->info('Use savepoints for nested transactions')->end()

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -59,6 +59,7 @@
         <xsd:attribute name="servicename" type="xsd:string" />
         <xsd:attribute name="session-mode" type="xsd:string" />
         <xsd:attribute name="sslmode" type="xsd:string" />
+        <xsd:attribute name="sslrootcert" type="xsd:string" />
         <xsd:attribute name="pooled" type="xsd:string" />
         <xsd:attribute name="multiple-active-result-sets" type="xsd:string" />
     </xsd:attributeGroup>

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -62,6 +62,11 @@ Configuration Reference
                         # Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
                         sslmode:              ~
 
+                        # PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT).
+                        # The name of a file containing SSL certificate authority (CA) certificate(s).
+                        # If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+                        sslrootcert:          ~
+
                         # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                         pooled:               ~
 
@@ -145,6 +150,11 @@ Configuration Reference
                                 # Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
                                 sslmode:              ~
 
+                                # PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT).
+                                # The name of a file containing SSL certificate authority (CA) certificate(s).
+                                # If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+                                sslrootcert:          ~
+
                                 # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                                 pooled:               ~
 
@@ -187,6 +197,11 @@ Configuration Reference
                             # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE).
                             # Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
                             sslmode:              ~
+
+                            # PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT).
+                            # The name of a file containing SSL certificate authority (CA) certificate(s).
+                            # If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+                            sslrootcert:          ~
 
                             # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                             pooled:               ~
@@ -383,6 +398,7 @@ Configuration Reference
                     <!-- sessionMode: The session mode to use for the oci8 driver -->
                     <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
                     <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
+                    <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                     <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                     <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                     <!-- use-savepoints: Enable savepoints for nested transactions -->
@@ -404,6 +420,7 @@ Configuration Reference
                         sessionMode=""
                         server=""
                         sslmode=""
+                        sslrootcert=""
                         pooled=""
                         MultipleActiveResultSets=""
                         use-savepoints="true"
@@ -441,6 +458,7 @@ Configuration Reference
                         <!-- sessionMode: The session mode to use for the oci8 driver -->
                         <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
                         <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
+                        <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                         <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                         <doctrine:slave
@@ -461,6 +479,7 @@ Configuration Reference
                             sessionMode=""
                             server=""
                             sslmode=""
+                            sslrootcert=""
                             pooled=""
                             MultipleActiveResultSets=""
                         />
@@ -475,6 +494,7 @@ Configuration Reference
                         <!-- sessionMode: The session mode to use for the oci8 driver -->
                         <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
                         <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
+                        <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                         <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                         <doctrine:shard
@@ -495,6 +515,7 @@ Configuration Reference
                             sessionMode=""
                             server=""
                             sslmode=""
+                            sslrootcert=""
                             pooled=""
                             MultipleActiveResultSets=""
                         />
@@ -848,6 +869,7 @@ can configure. The following block shows all possible configuration keys:
                 servicename:              MyOracleServiceName # Oracle specific (SERVICE_NAME)
                 sessionMode:              2                   # oci8 driver specific (session_mode)
                 sslmode:                  require             # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE)
+                sslrootcert:              postgresql-ca.pem   # PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT)
                 wrapper_class:            MyDoctrineDbalConnectionWrapper
                 charset:                  UTF8
                 logging:                  %kernel.debug%
@@ -893,6 +915,7 @@ can configure. The following block shows all possible configuration keys:
                 servicename="MyOracleServiceName"  <!-- Oracle specific (SERVICE_NAME) -->
                 sessionMode"2"                     <!-- oci8 driver specific (session_mode) -->
                 sslmode="require"                  <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLMODE) -->
+                sslrootcert="postgresql-ca.pem"    <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT) -->
                 wrapper-class="MyDoctrineDbalConnectionWrapper"
                 charset="UTF8"
                 logging="%kernel.debug%"

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -75,6 +75,7 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('pgsql_user', $config['user']);
         $this->assertSame('pgsql_s3cr3t', $config['password']);
         $this->assertSame('require', $config['sslmode']);
+        $this->assertSame('postgresql-ca.pem', $config['sslrootcert']);
         $this->assertSame('utf8', $config['charset']);
 
         // doctrine.dbal.sqlanywhere_connection

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -46,6 +46,7 @@
                 user="pgsql_user"
                 password="pgsql_s3cr3t"
                 sslmode="require"
+                sslrootcert="postgresql-ca.pem"
                 charset="utf8" />
             <connection
                 name="sqlanywhere"

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -35,6 +35,7 @@ doctrine:
                 user: pgsql_user
                 password: pgsql_s3cr3t
                 sslmode: require
+                sslrootcert: postgresql-ca.pem
                 charset: utf8
             sqlanywhere:
                 driver: sqlanywhere


### PR DESCRIPTION
This PR is dependant upon doctrine/dbal#919.
PostgreSQL allows the user to set the sslrootcert is connecting
to database.