### PR TITLE
Marking new types as commented event if no custom type mappings are present.

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -64,7 +64,7 @@ class ConnectionFactory
             }
         }
         if (!empty($this->commentedTypes)) {
-            if (!$platform) {
+            if (empty($platform)) {
                 $platform = $connection->getDatabasePlatform();
             }
             foreach ($this->commentedTypes as $type) {

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -62,6 +62,11 @@ class ConnectionFactory
             foreach ($mappingTypes as $dbType => $doctrineType) {
                 $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
             }
+        }
+        if (!empty($this->commentedTypes)) {
+            if (!$platform) {
+                $platform = $connection->getDatabasePlatform();
+            }
             foreach ($this->commentedTypes as $type) {
                 $platform->markDoctrineTypeCommented(Type::getType($type));
             }

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -513,7 +513,7 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $container = $this->loadContainer('dbal_types');
 
         $this->assertEquals(
-            array('test' => array('class' => 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType', 'commented' => true)),
+            array('test' => array('class' => 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType', 'commented' => true)),
             $container->getParameter('doctrine.dbal.connection_factory.types')
         );
         $this->assertEquals('%doctrine.dbal.connection_factory.types%', $container->getDefinition('doctrine.dbal.connection_factory')->getArgument(0));

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
@@ -8,7 +8,7 @@
 
     <config>
         <dbal default-connection="default">
-            <type name="test">Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType</type>
+            <type name="test">Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType</type>
             <connection name="default" />
         </dbal>
     </config>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_types.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_types.yml
@@ -2,6 +2,6 @@ doctrine:
     dbal:
         default_connection: default
         types:
-            test: Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType
+            test: Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType
         connections:
             default: ~

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -53,7 +53,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
                 ),
                 'default_connection' => 'default',
                 'types' => array(
-                    'test' => 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType',
+                    'test' => 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType',
                 ),
             ), 'orm' => array(
                 'default_entity_manager' => 'default',


### PR DESCRIPTION
I have found an issue in ConnectionManager, wchich relates marking new custom types as commented with existence of custom type mappings. These two things are unrelated of each other.

Explanation. ConnectionManager is being constructed with $typesConfig argument (passed from bundle configuration), containing new types added by user via config.yml. Then, during connection creation, it calls $this->initializeTypes(); function, which adds these types to Type registry.

Then, something strange happens. If the type has 'commented' parameter set to true, it should have been mark as commented in database platform. But this operation only happened, when in addition of custom type, there was custom mapping type (any) passed to createConnection function.

When user defines a custom Type, it does not have to (and in most cases, he will not) define custom type **MAPPING**, as custom type definition already has a mapping to a standard Doctrine field type. Also, in most cases, he wants to have his new type commented, and relating this action of existence of type mapping makers no sense.

This PR corrects this behavior, relating marking type as commented solely with the existence of marked type.
