### PR TITLE
Avoid loading of all manager services on getAliasNamespace function call

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -144,7 +144,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getAliasNamespace($alias)
     {
-        foreach (array_keys($this->getManagers()) as $name) {
+        foreach ($this->getManagerNames() as $name => $id) {
             try {
                 return $this->getManager($name)->getConfiguration()->getEntityNamespace($alias);
             } catch (ORMException $e) {


### PR DESCRIPTION
Every time someone writes AcmeDemoBundle:SomeEntity instead of Acme\DemoBundle\Entity\SomeEntity the function getAliasNamespace is called witch loads all entity manager services currently configured which initializes a connection to the database even if it is not necessary.