### PR TITLE
Register the PropertyInfo extractor from the Symfony Bridge

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -771,7 +771,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      * @param string           $entityManagerName
      * @param ContainerBuilder $container
      */
-    protected function loadPropertyInfoExtractor($entityManagerName, ContainerBuilder $container)
+    private function loadPropertyInfoExtractor($entityManagerName, ContainerBuilder $container)
     {
         $metadataFactoryService = sprintf('doctrine.orm.%s_entity_manager.metadata_factory', $entityManagerName);
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -375,9 +375,16 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $def->setFactoryMethod('create');
         }
 
+        $loadPropertyInfoExtractor = interface_exists('Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface')
+            && class_exists('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor');
+
         foreach ($config['entity_managers'] as $name => $entityManager) {
             $entityManager['name'] = $name;
             $this->loadOrmEntityManager($entityManager, $container);
+
+            if ($loadPropertyInfoExtractor) {
+                $this->loadPropertyInfoExtractor($name, $container);
+            }
         }
 
         if ($config['resolve_target_entities']) {
@@ -395,14 +402,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
             } else {
                 $def->addTag('doctrine.event_subscriber');
             }
-        }
-
-        if (!class_exists('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor')) {
-            return;
-        }
-
-        foreach ($config['entity_managers'] as $name => $entityManager) {
-            $this->loadPropertyInfoExtractor($name, $container);
         }
     }
 

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -50,6 +50,8 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer', $container->get('doctrine.orm.proxy_cache_warmer'));
         $this->assertInstanceOf('Doctrine\Common\Persistence\ManagerRegistry', $container->get('doctrine'));
         $this->assertInstanceOf('Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator', $container->get('doctrine.orm.validator.unique'));
+        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory', $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
+        $this->assertInstanceOf('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor', $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
 
         $this->assertSame($container->get('my.platform'), $container->get('doctrine.dbal.default_connection')->getDatabasePlatform());
 

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -50,8 +50,6 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer', $container->get('doctrine.orm.proxy_cache_warmer'));
         $this->assertInstanceOf('Doctrine\Common\Persistence\ManagerRegistry', $container->get('doctrine'));
         $this->assertInstanceOf('Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator', $container->get('doctrine.orm.validator.unique'));
-        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory', $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
-        $this->assertInstanceOf('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor', $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
 
         $this->assertSame($container->get('my.platform'), $container->get('doctrine.dbal.default_connection')->getDatabasePlatform());
 
@@ -61,6 +59,14 @@ class ContainerTest extends TestCase
             $this->assertInstanceOf('Doctrine\DBAL\Event\Listeners\MysqlSessionInit', $container->get('doctrine.dbal.default_connection.events.mysqlsessioninit'));
         } else {
             $this->assertFalse($container->has('doctrine.dbal.default_connection.events.mysqlsessioninit'));
+        }
+
+        if (interface_exists('Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface') && class_exists('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor')) {
+            $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory', $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
+            $this->assertInstanceOf('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor', $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
+        } else {
+            $this->assertFalse($container->has('doctrine.orm.default_entity_manager.metadata_factory'));
+            $this->assertFalse($container->has('doctrine.orm.default_entity_manager.property_info_extractor'));
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "doctrine/orm": "~2.3",
         "symfony/yaml": "~2.2|~3.0",
         "symfony/validator": "~2.2|~3.0",
+        "symfony/property-info": "~2.8|~3.0",
         "symfony/phpunit-bridge": "~2.7|~3.0",
         "twig/twig": "~1.10",
         "satooshi/php-coveralls": "~0.6.1",

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,9 @@
         "phpunit/phpunit": "~4"
     },
     "suggest": {
-        "symfony/web-profiler-bundle": "to use the data collector",
-        "doctrine/orm": "The Doctrine ORM integration is optional in the bundle."
+        "symfony/web-profiler-bundle": "To use the data collector.",
+        "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
+        "symfony/property-info": "To use the PropertyInfo integration."
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\DoctrineBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
     },
     "suggest": {
         "symfony/web-profiler-bundle": "To use the data collector.",
-        "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
-        "symfony/property-info": "To use the PropertyInfo integration."
+        "doctrine/orm": "The Doctrine ORM integration is optional in the bundle."
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\DoctrineBundle\\": "" }


### PR DESCRIPTION
Allow to extract metadata about properties coming from Doctrine using the new PropertyInfo component of Symfony 2.8.