### PR TITLE
Fix ghost item in toolbar when no query

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -1,23 +1,24 @@
 {% extends app.request.isXmlHttpRequest ? '@WebProfiler/Profiler/ajax_layout.html.twig' : '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
-    {% set profiler_markup_version = profiler_markup_version|default(1) %}
+    {% if collector.querycount > 0 or collector.invalidEntityCount > 0 %}
 
-    {% set icon %}
-        {% if profiler_markup_version == 1 %}
+        {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
-            <img width="20" height="28" alt="Database" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAcCAYAAABh2p9gAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAQRJREFUeNpi/P//PwM1ARMDlcGogZQDlpMnT7pxc3NbA9nhQKxOpL5rQLwJiPeBsI6Ozl+YBOOOHTv+AOllQNwtLS39F2owKYZ/gRq8G4i3ggxEToggWzvc3d2Pk+1lNL4fFAs6ODi8JzdS7mMRVyDVoAMHDsANdAPiOCC+jCQvQKqBQB/BDbwBxK5AHA3E/kB8nKJkA8TMQBwLxaBIKQbi70AvTADSBiSadwFXpCikpKQU8PDwkGTaly9fHFigkaKIJid4584dkiMFFI6jkTJII0WVmpHCAixZQEXWYhDeuXMnyLsVlEQKI45qFBQZ8eRECi4DBaAlDqle/8A48ip6gAADANdQY88Uc0oGAAAAAElFTkSuQmCC" />
-                <span class="sf-toolbar-value sf-toolbar-status {% if collector.querycount > 50 %}sf-toolbar-status-yellow{% endif %}">{{ collector.querycount }}</span>
-                {% if collector.querycount > 0 %}
-                    <span class="sf-toolbar-info-piece-additional-detail">in {{ '%0.2f'|format(collector.time * 1000) }} ms</span>
-                {% endif %}
-                {% if collector.invalidEntityCount > 0 %}
-                    <span class="sf-toolbar-info-piece-additional sf-toolbar-status sf-toolbar-status-red">{{ collector.invalidEntityCount }}</span>
-                {% endif %}
+        {% set icon %}
+            {% if profiler_markup_version == 1 %}
 
-        {% else %}
+                <img width="20" height="28" alt="Database" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAcCAYAAABh2p9gAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAQRJREFUeNpi/P//PwM1ARMDlcGogZQDlpMnT7pxc3NbA9nhQKxOpL5rQLwJiPeBsI6Ozl+YBOOOHTv+AOllQNwtLS39F2owKYZ/gRq8G4i3ggxEToggWzvc3d2Pk+1lNL4fFAs6ODi8JzdS7mMRVyDVoAMHDsANdAPiOCC+jCQvQKqBQB/BDbwBxK5AHA3E/kB8nKJkA8TMQBwLxaBIKQbi70AvTADSBiSadwFXpCikpKQU8PDwkGTaly9fHFigkaKIJid4584dkiMFFI6jkTJII0WVmpHCAixZQEXWYhDeuXMnyLsVlEQKI45qFBQZ8eRECi4DBaAlDqle/8A48ip6gAADANdQY88Uc0oGAAAAAElFTkSuQmCC" />
+                    <span class="sf-toolbar-value sf-toolbar-status {% if collector.querycount > 50 %}sf-toolbar-status-yellow{% endif %}">{{ collector.querycount }}</span>
+                    {% if collector.querycount > 0 %}
+                        <span class="sf-toolbar-info-piece-additional-detail">in {{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+                    {% endif %}
+                    {% if collector.invalidEntityCount > 0 %}
+                        <span class="sf-toolbar-info-piece-additional sf-toolbar-status sf-toolbar-status-red">{{ collector.invalidEntityCount }}</span>
+                    {% endif %}
 
-            {% if collector.querycount > 0 or collector.invalidEntityCount > 0 %}
+            {% else %}
+
                 {% set status = collector.invalidEntityCount > 0 ? 'red' : collector.querycount > 50 ? 'yellow' %}
 
                 {{ include('@Doctrine/Collector/icon.svg') }}
@@ -33,46 +34,47 @@
                         <span class="sf-toolbar-label">ms</span>
                     </span>
                 {% endif %}
+
             {% endif %}
+        {% endset %}
 
-        {% endif %}
-    {% endset %}
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                <b>Database Queries</b>
+                <span class="sf-toolbar-status">{{ collector.querycount }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Query time</b>
+                <span>{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Invalid entities</b>
+                <span class="sf-toolbar-status {{ collector.invalidEntityCount > 0 ? 'sf-toolbar-status-red' : '' }}">{{ collector.invalidEntityCount }}</span>
+            </div>
+            {% if collector.cacheEnabled %}
+                <div class="sf-toolbar-info-piece">
+                    <b>Cache hits</b>
+                    <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.cacheHitsCount }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b>Cache misses</b>
+                    <span class="sf-toolbar-status {{ collector.cacheMissesCount > 0 ? 'sf-toolbar-status-yellow' : '' }}">{{ collector.cacheMissesCount }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b>Cache puts</b>
+                    <span class="sf-toolbar-status {{ collector.cachePutsCount > 0 ? 'sf-toolbar-status-yellow' : '' }}">{{ collector.cachePutsCount }}</span>
+                </div>
+            {% else %}
+                <div class="sf-toolbar-info-piece">
+                    <b>Second Level Cache</b>
+                    <span class="sf-toolbar-status">disabled</span>
+                </div>
+            {% endif %}
+        {% endset %}
 
-    {% set text %}
-        <div class="sf-toolbar-info-piece">
-            <b>Database Queries</b>
-            <span class="sf-toolbar-status">{{ collector.querycount }}</span>
-        </div>
-        <div class="sf-toolbar-info-piece">
-            <b>Query time</b>
-            <span>{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
-        </div>
-        <div class="sf-toolbar-info-piece">
-            <b>Invalid entities</b>
-            <span class="sf-toolbar-status {{ collector.invalidEntityCount > 0 ? 'sf-toolbar-status-red' : '' }}">{{ collector.invalidEntityCount }}</span>
-        </div>
-        {% if collector.cacheEnabled %}
-            <div class="sf-toolbar-info-piece">
-                <b>Cache hits</b>
-                <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.cacheHitsCount }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b>Cache misses</b>
-                <span class="sf-toolbar-status {{ collector.cacheMissesCount > 0 ? 'sf-toolbar-status-yellow' : '' }}">{{ collector.cacheMissesCount }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b>Cache puts</b>
-                <span class="sf-toolbar-status {{ collector.cachePutsCount > 0 ? 'sf-toolbar-status-yellow' : '' }}">{{ collector.cachePutsCount }}</span>
-            </div>
-        {% else %}
-            <div class="sf-toolbar-info-piece">
-                <b>Second Level Cache</b>
-                <span class="sf-toolbar-status">disabled</span>
-            </div>
-        {% endif %}
-    {% endset %}
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: status|default('') }) }}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: status|default('') }) }}
+    {% endif %}
 {% endblock %}
 
 {% block menu %}


### PR DESCRIPTION
Fix https://github.com/symfony/symfony/issues/16976.

However, the item will also be hidden from the toolbar when using the old profiler/toolbar theme. 
I don't think it matters, but tell me if I'm wrong.