### PR TITLE
Fix count break on queries list for profiler

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -163,7 +163,7 @@
                 <tbody id="queries-{{ loop.index }}">
                     {% for i, query in queries %}
                         <tr id="queryNo-{{ i }}-{{ loop.parent.loop.index }}">
-                            <td>{{ loop.index }}</td>
+                            <td class="nowrap">{{ loop.index }}</td>
                             <td class="nowrap">{{ '%0.2f'|format(query.executionMS * 1000) }}&nbsp;ms</td>
                             <td>
                                 {{ query.sql|doctrine_pretty_query(highlight_only = true) }}


### PR DESCRIPTION
Hi,

This PR fix the count break on the query list for count > 100.

*Before*

![screen shot 2016-02-23 at 16 41 22](https://cloud.githubusercontent.com/assets/1443312/13256866/ab38767e-da4c-11e5-9f2a-08a71d932445.png)

*After*

![screen shot 2016-02-23 at 16 44 38](https://cloud.githubusercontent.com/assets/1443312/13256883/c10f04a4-da4c-11e5-9e6c-595e1b9284e4.png)

