### PR TITLE
Add "Show Results" link in "Queries" section in Profiler

### DIFF
--- a/Resources/views/Collector/_toggle_column.html.twig
+++ b/Resources/views/Collector/_toggle_column.html.twig
@@ -1,0 +1,12 @@
+<script>
+    function toggleColumn(button, tableId, n) {
+        Sfjs.toggleClass(button.getElementsByTagName("span")[0], "text-muted")
+        var rows = document.getElementById(tableId).getElementsByClassName("col" + n)
+        if (rows && rows.length > 0) {
+            for (var i = 0; i < rows.length; i++) {
+                Sfjs.toggleClass(rows[i], "hidden")
+            }
+        }
+    }
+</script>
+

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -109,8 +109,8 @@
 {% block panel %}
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
-    {% if 'explain' == page %}
-        {{ render(controller('DoctrineBundle:Profiler:explain', {
+    {% if ('explain' == page or 'execute' == page) %}
+        {{ render(controller(('DoctrineBundle:Profiler:' ~ page), {
             token: token,
             panel: 'db',
             connectionName: app.request.query.get('connection'),
@@ -173,15 +173,19 @@
                                 </div>
 
                                 <div class="text-small font-normal">
-                                    <a href="#" {{ profiler_markup_version == 1 ? 'onclick="return toggleRunnableQuery(this);"' }} class="sf-toggle link-inverse" data-toggle-selector="#formatted-query-{{ i }}-{{ loop.parent.loop.index }}" data-toggle-alt-content="Hide formatted query">View formatted query</a>
+                                    <a href="#" {{ profiler_markup_version == 1 ? 'onclick="return expand(this);"' }} class="sf-toggle link-inverse" data-toggle-selector="#formatted-query-{{ i }}-{{ loop.parent.loop.index }}" data-toggle-alt-content="Hide formatted query">View formatted query</a>
 
                                     &nbsp;&nbsp;
 
-                                    <a href="#" {{ profiler_markup_version == 1 ? 'onclick="return toggleRunnableQuery(this);"' }} class="sf-toggle link-inverse" data-toggle-selector="#original-query-{{ i }}-{{ loop.parent.loop.index }}" data-toggle-alt-content="Hide runnable query">View runnable query</a>
+                                    <a href="#" {{ profiler_markup_version == 1 ? 'onclick="return expand(this);"' }} class="sf-toggle link-inverse" data-toggle-selector="#original-query-{{ i }}-{{ loop.parent.loop.index }}" data-toggle-alt-content="Hide runnable query">View runnable query</a>
+
+                                    &nbsp;&nbsp;
+
+                                    <a href="{{ path('_profiler', { panel: 'db', token: token, page: 'execute', connection: connection, query: i }) }}" class="link-inverse" onclick="return expand(this);" data-toggle-selector="#execute-{{ i }}-{{ loop.parent.loop.index }}" data-toggle-alt-content="Hide results">Show results</a>
 
                                     {% if query.explainable %}
                                         &nbsp;&nbsp;
-                                        <a class="link-inverse" href="{{ path('_profiler', { panel: 'db', token: token, page: 'explain', connection: connection, query: i }) }}" onclick="return explain(this);" data-target-id="explain-{{ i }}-{{ loop.parent.loop.index }}">Explain query</a>
+                                        <a href="{{ path('_profiler', { panel: 'db', token: token, page: 'explain', connection: connection, query: i }) }}" class="link-inverse" onclick="return expand(this);" data-toggle-selector="#explain-{{ i }}-{{ loop.parent.loop.index }}" data-toggle-alt-content="Hide explain query">Explain query</a>
                                     {% endif %}
                                 </div>
 
@@ -193,8 +197,14 @@
                                     {{ (query.sql ~ ';')|doctrine_replace_query_parameters(query.params)|doctrine_pretty_query(highlight_only = true) }}
                                 </div>
 
+                                <div id="execute-{{ i }}-{{ loop.parent.loop.index }}" class="sql-runnable hidden">
+                                    Loading ...
+                                </div>
+
                                 {% if query.explainable %}
-                                    <div id="explain-{{ i }}-{{ loop.parent.loop.index }}"></div>
+                                    <div id="explain-{{ i }}-{{ loop.parent.loop.index }}" class="sql-runnable hidden">
+                                        Loading ...
+                                    </div>
                                 {% endif %}
                             </td>
                         </tr>
@@ -317,27 +327,6 @@
     {% endfor %}
 
     <script type="text/javascript">//<![CDATA[
-        function explain(link) {
-            "use strict";
-
-            var targetId = link.getAttribute('data-target-id');
-            var targetElement = document.getElementById(targetId);
-
-            if (targetElement.style.display != 'block') {
-                Sfjs.load(targetId, link.href, null, function(xhr, el) {
-                    el.innerHTML = 'An error occurred while loading the query explanation.';
-                });
-
-                targetElement.style.display = 'block';
-                link.innerHTML = 'Hide query explanation';
-            } else {
-                targetElement.style.display = 'none';
-                link.innerHTML = 'Explain query';
-            }
-
-            return false;
-        }
-
         function sortTable(header, column, targetId) {
             "use strict";
 
@@ -373,24 +362,30 @@
             }
         }
 
-        {% if profiler_markup_version == 1 %}
-            function toggleRunnableQuery(target) {
-                var targetSelector = target.getAttribute('data-toggle-selector');
-                var targetDataAltContent = target.getAttribute('data-toggle-alt-content');
-                var targetElement = document.querySelector(targetSelector);
-                target.setAttribute('data-toggle-alt-content', target.innerHTML);
+        function expand(target) {
+            var targetSelector = target.getAttribute('data-toggle-selector');
+            var targetDataAltContent = target.getAttribute('data-toggle-alt-content');
+            var targetElement = document.querySelector(targetSelector);
+            target.setAttribute('data-toggle-alt-content', target.innerHTML);
 
-                if (targetElement.style.display != 'block') {
-                    targetElement.style.display = 'block';
-                    target.innerHTML = targetDataAltContent;
-                } else {
-                    targetElement.style.display = 'none';
-                    target.innerHTML = targetDataAltContent;
+            if (targetElement.style.display != 'block') {
+
+                if(target.href != "#") {
+                    Sfjs.load(targetElement.id, target.href, null, function (xhr, el) {
+                        el.innerHTML = 'An error occurred while loading the data.';
+                    });
                 }
 
-                return false;
+                targetElement.style.display = 'block';
+                target.innerHTML = targetDataAltContent;
+            } else {
+                targetElement.style.display = 'none';
+                target.innerHTML = targetDataAltContent;
             }
-        {% endif %}
+
+            return false;
+        }
 
         //]]></script>
+    {% include '@Doctrine/Collector/_toggle_column.html.twig' %}
 {% endblock %}

--- a/Resources/views/Collector/execute.html.twig
+++ b/Resources/views/Collector/execute.html.twig
@@ -1,0 +1,43 @@
+{% set nbVisibleCols = 6 %}
+<p>
+{% for label in data[0]|keys %}
+    <a class="btn btn-sm" style="padding: 3px; margin-bottom: 3px;" onclick="toggleColumn(this, 'query-results-{{ id }}', '{{ loop.index }}')">
+        <span class="{{ loop.index <= nbVisibleCols ? "" : "text-muted" }}">
+            {{ label }}
+        </span>
+    </a>
+{% endfor %}
+</p>
+
+{% if data[0]|length > 1 %}
+    <table style="margin: 5px 0;" id="query-results-{{ id }}">
+        <thead>
+        <tr>
+            {% for label in data[0]|keys %}
+                <th class="col col{{ loop.index }} {{ loop.index <= nbVisibleCols ? "" : "hidden" }}">{{ label }}</th>
+            {% endfor %}
+        </tr>
+        </thead>
+        <tbody>
+        {% for row in data %}
+            <tr>
+                {% for key, item in row %}
+                    <td class="col col{{ loop.index }} {{ loop.index <= nbVisibleCols ? "" : "hidden" }}">{{ item }}</td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <pre style="margin: 5px 0;">
+        {%- for row in data -%}
+            {{ row|first }}{{ "\n" }}
+        {%- endfor -%}
+    </pre>
+{% endif %}
+
+{% if not app.request.isXmlHttpRequest %}
+    {% include '@Doctrine/Collector/_toggle_column.html.twig' %}
+{% endif %}
+
+


### PR DESCRIPTION
It's been bothering me for a while the fact that sometimes I want to see the results coming back from a query. In those cases, I have to copy the query from the profiler, either use a command line tool or a UI to connect to the database (which usually means copying and pasting the username/password), and finally see the results.

Wouldn't it be great if I could do that from the Web Profiler?! WAIT NO MORE!

![captura de pantalla 2016-03-01 a la s 17 14 20](https://cloud.githubusercontent.com/assets/337904/13433203/20b814e8-dfd1-11e5-9a9f-7da4878f8e3c.png)

This PR adds a "Show Results" link, when clicked it shows the results.

![captura de pantalla 2016-03-01 a la s 17 15 42](https://cloud.githubusercontent.com/assets/337904/13433297/842016fc-dfd1-11e5-8069-08cec5f0245f.png)

It might be the case that there are a lot of columns in the results, in those cases this PR also takes care of this just showing the first six columns and providing buttons to hide/show the columns as you wish. That way, you can focus on the data you are really interested into.

![captura de pantalla 2016-03-01 a la s 17 18 24](https://cloud.githubusercontent.com/assets/337904/13433338/adf9e08e-dfd1-11e5-9351-38549e621365.png)
