### PR TITLE
Close connection after database drop

### DIFF
--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -96,7 +96,9 @@ EOT
                 } else {
                     $output->writeln(sprintf('<info>Database for connection named <comment>%s</comment> doesn\'t exist. Skipped.</info>', $name));
                 }
+                $connection->close();
             } catch (\Exception $e) {
+                $connection->close();
                 $output->writeln(sprintf('<error>Could not drop database for connection named <comment>%s</comment></error>', $name));
                 $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
 

--- a/Tests/Command/DropDatabaseDoctrineTest.php
+++ b/Tests/Command/DropDatabaseDoctrineTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
+
+use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DropDatabaseDoctrineTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExecuteWithoutForce()
+    {
+        $connectionName = 'default';
+        $dbName = 'test';
+        $params = array(
+            'dbname' => $dbName,
+            'memory' => true,
+            'driver' => 'pdo_sqlite'
+        );
+
+        $application = new Application();
+        $application->add(new DropDatabaseDoctrineCommand());
+
+        $command = $application->find('doctrine:database:drop');
+        $command->setContainer($this->getMockContainer($connectionName, $params));
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            array_merge(array('command' => $command->getName()))
+        );
+
+        $this->assertContains("Please run the operation with --force to execute", $commandTester->getDisplay());
+    }
+
+    public function testExecute()
+    {
+        $connectionName = 'default';
+        $dbName = 'test';
+        $params = array(
+            'dbname' => $dbName,
+            'memory' => true,
+            'driver' => 'pdo_sqlite'
+        );
+
+        $application = new Application();
+        $application->add(new DropDatabaseDoctrineCommand());
+
+        $command = $application->find('doctrine:database:drop');
+        $command->setContainer($this->getMockContainer($connectionName, $params));
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            array_merge(array('command' => $command->getName(), '--force' => true))
+        );
+
+        $this->assertContains("Dropped database for connection named \"$dbName\"", $commandTester->getDisplay());
+    }
+
+
+    /**
+     * @param $connectionName
+     * @param null $params Connection parameters
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockContainer($connectionName, $params=null)
+    {
+        // Mock the container and everything you'll need here
+        $mockDoctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ConnectionRegistry')
+            ->getMock();
+
+        $mockDoctrine->expects($this->any())
+            ->method('getDefaultConnectionName')
+            ->withAnyParameters()
+            ->willReturn($connectionName)
+        ;
+
+
+        $mockConnection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getParams'))
+            ->getMockForAbstractClass();
+
+        $mockConnection->expects($this->any())
+            ->method('getParams')
+            ->withAnyParameters()
+            ->willReturn($params);
+
+        
+        $mockDoctrine->expects($this->any())
+            ->method('getConnection')
+            ->withAnyParameters()
+            ->willReturn($mockConnection);
+        ;
+
+
+        $mockContainer = $this->getMockBuilder('Symfony\Component\DependencyInjection\Container')
+            ->setMethods(array('get'))
+            ->getMock();
+
+        $mockContainer->expects($this->any())
+            ->method('get')
+            ->with('doctrine')
+            ->willReturn($mockDoctrine);
+
+        return $mockContainer;
+    }
+}


### PR DESCRIPTION

Database connection is not closed after database is being dropped. This causes issues when subsequent commands are being executed in certain DBMS (fe: postgresql fails on it, as after database drop connection to database is still active and new database can not be created as resource is still in use).

Provided fix would fixes such scenario:

```php
protected function execute(InputInterface $input, OutputInterface $output)
{
    $application = $this->getApplication()->find('doctrine:database:drop');
    $application->run(new ArrayInput(array(
        'command' => 'doctrine:database:drop',
        '--force'   => true,
        '--if-exists'   => true
    )), $output);

    $application = $this->getApplication()->find('doctrine:database:create');
    $application->run(new ArrayInput(array(
        'command' => 'doctrine:database:create',
        '--if-not-exists'   => true
    )), $output);
}
```