### PR TITLE
[DoctrineBundle] Deprecated form types and guessers as services

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -86,11 +86,13 @@
         <service id="form.type_guesser.doctrine" class="%form.type_guesser.doctrine.class%">
             <tag name="form.type_guesser" />
             <argument type="service" id="doctrine" />
+            <deprecated>"The \"%service_id%\" service is deprecated since Symfony 3.1 and will be removed in 4.0."</deprecated>
         </service>
 
         <service id="form.type.entity" class="Symfony\Bridge\Doctrine\Form\Type\EntityType">
             <tag name="form.type" alias="entity" />
             <argument type="service" id="doctrine" />
+            <deprecated>"The \"%service_id%\" service is deprecated since Symfony 3.1 and will be removed in 4.0."</deprecated>
         </service>
 
         <service id="doctrine.orm.configuration" class="%doctrine.orm.configuration.class%" abstract="true" public="false" />


### PR DESCRIPTION
Core form types and guessers are not used as services as of symfony 3.0 and should be removed in 4.0 (ref symfony/symfony#15079).