### PR TITLE
Add global metrics on top of Doctrine page

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -140,6 +140,40 @@
         </style>
     {% endif %}
 
+    <h2>Query Metrics</h2>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.querycount }}</span>
+            <span class="label">Database Queries</span>
+        </div>
+
+        <div class="metric">
+            <span class="value">{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+            <span class="label">Query time</span>
+        </div>
+
+        <div class="metric">
+            <span class="value">{{ collector.invalidEntityCount }}</span>
+            <span class="label">Invalid entities</span>
+        </div>
+
+        {% if collector.cacheEnabled %}
+            <div class="metric">
+            	<span class="value">{{ collector.cacheHitsCount }}</span>
+            	<span class="label">Cache hits</span>
+            </div>
+            <div class="metric">
+            	<span class="value">{{ collector.cacheMissesCount }}</span>
+            	<span class="label">Cache misses</span>
+            </div>
+            <div class="metric">
+            	<span class="value">{{ collector.cachePutsCount }}</span>
+            	<span class="label">Cache puts</span>
+            </div>
+        {% endif %}
+    </div>
+
     <h2>Queries</h2>
 
     {% for connection, queries in collector.queries %}

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -140,39 +140,41 @@
         </style>
     {% endif %}
 
-    <h2>Query Metrics</h2>
-
-    <div class="metrics">
-        <div class="metric">
-            <span class="value">{{ collector.querycount }}</span>
-            <span class="label">Database Queries</span>
-        </div>
-
-        <div class="metric">
-            <span class="value">{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
-            <span class="label">Query time</span>
-        </div>
-
-        <div class="metric">
-            <span class="value">{{ collector.invalidEntityCount }}</span>
-            <span class="label">Invalid entities</span>
-        </div>
-
-        {% if collector.cacheEnabled %}
+    {% if profiler_markup_version > 1 %}
+        <h2>Query Metrics</h2>
+    
+        <div class="metrics">
             <div class="metric">
-            	<span class="value">{{ collector.cacheHitsCount }}</span>
-            	<span class="label">Cache hits</span>
+                <span class="value">{{ collector.querycount }}</span>
+                <span class="label">Database Queries</span>
             </div>
+    
             <div class="metric">
-            	<span class="value">{{ collector.cacheMissesCount }}</span>
-            	<span class="label">Cache misses</span>
+                <span class="value">{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+                <span class="label">Query time</span>
             </div>
+    
             <div class="metric">
-            	<span class="value">{{ collector.cachePutsCount }}</span>
-            	<span class="label">Cache puts</span>
+                <span class="value">{{ collector.invalidEntityCount }}</span>
+                <span class="label">Invalid entities</span>
             </div>
-        {% endif %}
-    </div>
+    
+            {% if collector.cacheEnabled %}
+                <div class="metric">
+                	<span class="value">{{ collector.cacheHitsCount }}</span>
+                	<span class="label">Cache hits</span>
+                </div>
+                <div class="metric">
+                	<span class="value">{{ collector.cacheMissesCount }}</span>
+                	<span class="label">Cache misses</span>
+                </div>
+                <div class="metric">
+                	<span class="value">{{ collector.cachePutsCount }}</span>
+                	<span class="label">Cache puts</span>
+                </div>
+            {% endif %}
+        </div>
+    {% endif %}
 
     <h2>Queries</h2>
 


### PR DESCRIPTION
As the toolbar is not displayed any more on top of the profiler with Symfony 3.x, we don't have direct information about:
- the count of database queries
- the global query time
- the count of invalid entities

I think this information could be displayed on top of the page as global query metrics, like global metrics on other pages in the Web Profiler.