### PR TITLE
Removed "Not quoting a scalar starting with the "%" indicator charact…

### DIFF
--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
@@ -19,5 +19,5 @@ doctrine:
                     manual:
                         type: xml
                         prefix: Fixtures\Bundles\XmlBundle
-                        dir: %kernel.root_dir%/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine
+                        dir: "%kernel.root_dir%/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine"
                         alias: TestAlias

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_second_level_cache.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_second_level_cache.yml
@@ -57,7 +57,7 @@ doctrine:
                         lifetime: 300
                         cache_driver: array
                         type: filelock
-                        lock_path: %kernel.cache_dir%/doctrine/orm/slc/filelock
+                        lock_path: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
 
                       my_entity_region:
                           lifetime: 600

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
@@ -14,5 +14,5 @@ doctrine:
             manual:
                 type: xml
                 prefix: Fixtures\Bundles\XmlBundle
-                dir: %kernel.root_dir%/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine
+                dir: "%kernel.root_dir%/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine"
                 alias: TestAlias

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_default_table_options.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_default_table_options.yml
@@ -18,5 +18,5 @@ doctrine:
             manual:
                 type: xml
                 prefix: Fixtures\Bundles\XmlBundle
-                dir: %kernel.root_dir%/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine
+                dir: "%kernel.root_dir%/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine"
                 alias: TestAlias


### PR DESCRIPTION
…er is deprecated since Symfony 3.1" deprecation warnings