### PR TITLE
Add apcu configuration option in docs

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -725,7 +725,7 @@ certain classes, but those are for very advanced use-cases only.
 Caching Drivers
 ~~~~~~~~~~~~~~~
 
-For the caching drivers you can specify the values ``array``, ``apc``, ``memcache``,
+For the caching drivers you can specify the values ``array``, ``apc``, ``apcu``, ``memcache``,
 ``memcached`` or ``xcache``.
 
 The following example shows an overview of the caching configurations:
@@ -735,7 +735,7 @@ The following example shows an overview of the caching configurations:
     doctrine:
         orm:
             auto_mapping: true
-            metadata_cache_driver: apc
+            metadata_cache_driver: apcu
             query_cache_driver: xcache
             result_cache_driver:
                 type: memcache


### PR DESCRIPTION
If I'm reading https://github.com/doctrine/cache/pull/115 correctly apcu is now fully supported.  I updated the listing of provider to indicate this.

Since the default configuration of apcu in PHP 7 no longer provides backwards compatibility with apc API I also changed the example `metadata_cache_driver` to be `apcu` to be copy / paste ready for new deployments.
