### PR TITLE
Fix interpolate query paramters if starting with index 1

### DIFF
--- a/Tests/Twig/DoctrineExtensionTest.php
+++ b/Tests/Twig/DoctrineExtensionTest.php
@@ -26,4 +26,43 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $result = $extension->replaceQueryParameters($query, $parameters, false);
         $this->assertEquals('a=1 OR (1)::string OR b=2', $result);
     }
+
+    public function testReplaceQueryParametersWithStartingIndexAtOne()
+    {
+        $extension = new DoctrineExtension();
+        $query = 'a=? OR b=?';
+        $parameters = array(
+            1 => 1,
+            2 => 2
+        );
+
+        $result = $extension->replaceQueryParameters($query, $parameters, false);
+        $this->assertEquals('a=1 OR b=2', $result);
+    }
+
+    public function testReplaceQueryParameters()
+    {
+        $extension = new DoctrineExtension();
+        $query = 'a=? OR b=?';
+        $parameters = array(
+            1,
+            2
+        );
+
+        $result = $extension->replaceQueryParameters($query, $parameters, false);
+        $this->assertEquals('a=1 OR b=2', $result);
+    }
+
+    public function testReplaceQueryParametersWithNamedIndex()
+    {
+        $extension = new DoctrineExtension();
+        $query = 'a=:a OR b=:b';
+        $parameters = array(
+            'a' => 1,
+            'b' => 2
+        );
+
+        $result = $extension->replaceQueryParameters($query, $parameters, false);
+        $this->assertEquals('a=1 OR b=2', $result);
+    }
 }

--- a/Twig/DoctrineExtension.php
+++ b/Twig/DoctrineExtension.php
@@ -287,6 +287,10 @@ class DoctrineExtension extends \Twig_Extension
     {
         $i = 0;
 
+        if (!array_key_exists(0, $parameters) && array_key_exists(1, $parameters)) {
+            $i = 1;
+        }
+
         $result = preg_replace_callback(
             '/\?|((?<!:):[a-z0-9_]+)/i',
             function ($matches) use ($parameters, &$i) {


### PR DESCRIPTION
If paramters start with index 1 (as for sqlserver) the parameters should be interpolated correctly as well.
I am not absolutly shure, but i think they start always with index 1.