### PR TITLE
Avoid duplication of AttachEntityListeners

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -474,7 +474,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if (version_compare(Version::VERSION, "2.5.0-DEV") >= 0) {
             $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
             $listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
-            $listenerDef->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+            $listenerTagParams = array('event' => 'loadClassMetadata');
+            if (isset($entityManager['connection'])) {
+                $listenerTagParams['connection'] = $entityManager['connection'];
+            }
+            $listenerDef->addTag('doctrine.event_listener', $listenerTagParams);
         }
 
         if (isset($entityManager['second_level_cache'])) {

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listeners_two_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listeners_two_connections.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <doctrine:config>
+        <doctrine:dbal default-connection="default">
+            <doctrine:connection name="default" dbname="db" />
+            <doctrine:connection name="foobar" dbname="foobar" />
+        </doctrine:dbal>
+
+        <doctrine:orm default-entity-manager="em1">
+            <doctrine:entity-manager name="em1" connection="default" />
+            <doctrine:entity-manager name="em2" connection="foobar" />
+        </doctrine:orm>
+    </doctrine:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listeners_two_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listeners_two_connections.yml
@@ -1,0 +1,16 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+            foobar:
+                dbname: foobar
+
+    orm:
+        default_entity_manager: em1
+        entity_managers:
+            em1:
+                connection: default
+            em2:
+                connection: foobar


### PR DESCRIPTION
With multiple connections in `config.yml`

```
doctrine:
    dbal:
        default_connection: default
        connections:
            default:
               ...
            foobar:
                ...
    orm:
        default_entity_manager: default
        entity_managers:
            default:
                connection: default
            foobar:
                connection: foobar
```

each `EntityManager` will have multiple instances of `AttachEntityListeners` subscribed to the same event.
