### PR TITLE
Add a proper exception when Doctrine ORM is not installed

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -80,6 +80,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 throw new \LogicException('Configuring the ORM layer requires to configure the DBAL layer as well.');
             }
 
+            if (!class_exists('Doctrine\ORM\Version')) {
+                throw new \LogicException('To configure the ORM layer, you must first install the doctrine/orm package.');
+            }
+
             $this->ormLoad($config['orm'], $container);
         }
 


### PR DESCRIPTION
Without this change, and when doctrine/orm is not installed, you get a weird error message about the Version class that does not exist.