### PR TITLE
Add ability to group similar queries in Profiler.

### DIFF
--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -192,6 +192,12 @@ class DoctrineDataCollector extends BaseCollector
 
     public function getGroupedQueries()
     {
+        static $groupedQueries = null;
+
+        if ($groupedQueries !== null) {
+            return $groupedQueries;
+        }
+
         $groupedQueries = array();
         $totalExecutionMS = 0;
         foreach ($this->data['queries'] as $connection => $queries) {
@@ -223,5 +229,15 @@ class DoctrineDataCollector extends BaseCollector
         }
 
         return $groupedQueries;
+    }
+
+    public function getGroupedQueryCount()
+    {
+        $count = 0;
+        foreach ($this->getGroupedQueries() as $connectionGroupedQueries) {
+            $count += count($connectionGroupedQueries);
+        }
+
+        return $count;
     }
 }

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -136,33 +136,10 @@ class DoctrineDataCollector extends BaseCollector
             }
         }
 
-        $groupedQueries = array();
-        foreach ($this->data['queries'] as $connection => $queries) {
-            $connectionGroupedQueries = array();
-            foreach ($queries as $i => $query) {
-                $key = $query['sql'];
-                if (!isset($connectionGroupedQueries[$key])) {
-                    $connectionGroupedQueries[$key] = $query;
-                    $connectionGroupedQueries[$key]['executionMS'] = 0;
-                    $connectionGroupedQueries[$key]['count'] = 0;
-                    $connectionGroupedQueries[$key]['index'] = $i; // "Explain query" relies on query index in 'queries'.
-                }
-                $connectionGroupedQueries[$key]['executionMS'] += $query['executionMS'];
-                $connectionGroupedQueries[$key]['count']++;
-            }
-            usort($connectionGroupedQueries, function ($a, $b) {
-                if ($a['executionMS'] === $b['executionMS']) {
-                    return 0;
-                }
-                return ($a['executionMS'] < $b['executionMS']) ? 1 : -1;
-            });
-            $groupedQueries[$connection] = $connectionGroupedQueries;
-        }
-
         $this->data['entities'] = $entities;
         $this->data['errors'] = $errors;
         $this->data['caches'] = $caches;
-        $this->data['groupedQueries'] = $groupedQueries;
+        $this->data['groupedQueries'] = $this->getGroupedQueries();
     }
 
     public function getEntities()
@@ -216,6 +193,29 @@ class DoctrineDataCollector extends BaseCollector
 
     public function getGroupedQueries()
     {
-        return $this->data['groupedQueries'];
+        $groupedQueries = array();
+        foreach ($this->data['queries'] as $connection => $queries) {
+            $connectionGroupedQueries = array();
+            foreach ($queries as $i => $query) {
+                $key = $query['sql'];
+                if (!isset($connectionGroupedQueries[$key])) {
+                    $connectionGroupedQueries[$key] = $query;
+                    $connectionGroupedQueries[$key]['executionMS'] = 0;
+                    $connectionGroupedQueries[$key]['count'] = 0;
+                    $connectionGroupedQueries[$key]['index'] = $i; // "Explain query" relies on query index in 'queries'.
+                }
+                $connectionGroupedQueries[$key]['executionMS'] += $query['executionMS'];
+                $connectionGroupedQueries[$key]['count']++;
+            }
+            usort($connectionGroupedQueries, function ($a, $b) {
+                if ($a['executionMS'] === $b['executionMS']) {
+                    return 0;
+                }
+                return ($a['executionMS'] < $b['executionMS']) ? 1 : -1;
+            });
+            $groupedQueries[$connection] = $connectionGroupedQueries;
+        }
+
+        return $groupedQueries;
     }
 }

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -139,7 +139,6 @@ class DoctrineDataCollector extends BaseCollector
         $this->data['entities'] = $entities;
         $this->data['errors'] = $errors;
         $this->data['caches'] = $caches;
-        $this->data['groupedQueries'] = $this->getGroupedQueries();
     }
 
     public function getEntities()

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -145,7 +145,7 @@ class DoctrineDataCollector extends BaseCollector
                     $connectionGroupedQueries[$key] = $query;
                     $connectionGroupedQueries[$key]['executionMS'] = 0;
                     $connectionGroupedQueries[$key]['count'] = 0;
-                    $connectionGroupedQueries[$key]['i'] = $i; // "Explain query" relies on query index in 'queries'.
+                    $connectionGroupedQueries[$key]['index'] = $i; // "Explain query" relies on query index in 'queries'.
                 }
                 $connectionGroupedQueries[$key]['executionMS'] += $query['executionMS'];
                 $connectionGroupedQueries[$key]['count']++;

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -193,6 +193,7 @@ class DoctrineDataCollector extends BaseCollector
     public function getGroupedQueries()
     {
         $groupedQueries = array();
+        $totalExecutionMS = 0;
         foreach ($this->data['queries'] as $connection => $queries) {
             $connectionGroupedQueries = array();
             foreach ($queries as $i => $query) {
@@ -205,6 +206,7 @@ class DoctrineDataCollector extends BaseCollector
                 }
                 $connectionGroupedQueries[$key]['executionMS'] += $query['executionMS'];
                 $connectionGroupedQueries[$key]['count']++;
+                $totalExecutionMS += $query['executionMS'];
             }
             usort($connectionGroupedQueries, function ($a, $b) {
                 if ($a['executionMS'] === $b['executionMS']) {
@@ -213,6 +215,11 @@ class DoctrineDataCollector extends BaseCollector
                 return ($a['executionMS'] < $b['executionMS']) ? 1 : -1;
             });
             $groupedQueries[$connection] = $connectionGroupedQueries;
+        }
+        foreach ($groupedQueries as $connection => $queries) {
+            foreach ($queries as $i => $query) {
+                $groupedQueries[$connection][$i]['executionPercent'] = $query['executionMS'] / $totalExecutionMS * 100;
+            }
         }
 
         return $groupedQueries;

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -136,9 +136,33 @@ class DoctrineDataCollector extends BaseCollector
             }
         }
 
+        $groupedQueries = array();
+        foreach ($this->data['queries'] as $connection => $queries) {
+            $connectionGroupedQueries = array();
+            foreach ($queries as $i => $query) {
+                $key = $query['sql'];
+                if (!isset($connectionGroupedQueries[$key])) {
+                    $connectionGroupedQueries[$key] = $query;
+                    $connectionGroupedQueries[$key]['executionMS'] = 0;
+                    $connectionGroupedQueries[$key]['count'] = 0;
+                    $connectionGroupedQueries[$key]['i'] = $i; // "Explain query" relies on query index in 'queries'.
+                }
+                $connectionGroupedQueries[$key]['executionMS'] += $query['executionMS'];
+                $connectionGroupedQueries[$key]['count']++;
+            }
+            usort($connectionGroupedQueries, function ($a, $b) {
+                if ($a['executionMS'] === $b['executionMS']) {
+                    return 0;
+                }
+                return ($a['executionMS'] < $b['executionMS']) ? 1 : -1;
+            });
+            $groupedQueries[$connection] = $connectionGroupedQueries;
+        }
+
         $this->data['entities'] = $entities;
         $this->data['errors'] = $errors;
         $this->data['caches'] = $caches;
+        $this->data['groupedQueries'] = $groupedQueries;
     }
 
     public function getEntities()
@@ -188,5 +212,10 @@ class DoctrineDataCollector extends BaseCollector
         }
 
         return $this->invalidEntityCount;
+    }
+
+    public function getGroupedQueries()
+    {
+        return $this->data['groupedQueries'];
     }
 }

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -189,13 +189,14 @@
             </div>
         {% else %}
             {% set group_queries = false %}
-            {% if collector.groupedQueries[connection]|length < queries|length %}
+            {% set grouped_queries = collector.groupedQueries[connection] %}
+            {% if grouped_queries|length < queries|length %}
                 {% set group_queries = request.query.has('group') %}
                 {% if group_queries %}
-                    {% set queries = collector.groupedQueries[connection] %}
+                    {% set queries = grouped_queries %}
                     <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>
                 {% else %}
-                    <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a> ({{ collector.groupedQueries[connection]|length }} different)</p>
+                    <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a> ({{ grouped_queries|length }} different)</p>
                 {% endif %}
             {% endif %}
             <table class="alt queries-table">

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -122,8 +122,8 @@
 {% endblock %}
 
 {% block queries %}
-    {% if profiler_markup_version == 1 %}
-        <style>
+    <style>
+        {% if profiler_markup_version == 1 %}
             .hidden { display: none; }
             .queries-table td, .queries-table th { vertical-align: top; }
             .queries-table td > div { margin-bottom: 6px; }
@@ -137,8 +137,12 @@
             .highlight .string    { color: #718C00; }
             .highlight .number    { color: #F5871F; font-weight: bold; }
             .highlight .error     { color: #C82829; }
-        </style>
-    {% endif %}
+        {% endif %}
+
+        .time-container { position: relative; }
+        .time-container .nowrap { position: relative; z-index: 1; text-shadow: 0 0 2px #fff; }
+        .time-bar { display: block; position: absolute; top: 0; left: 0; bottom: 0; background: #e0e0e0; }
+    </style>
 
     {% if profiler_markup_version > 1 %}
         <h2>Query Metrics</h2>
@@ -148,7 +152,7 @@
                 <span class="value">{{ collector.querycount }}</span>
                 <span class="label">Database Queries</span>
             </div>
-    
+
             <div class="metric">
                 <span class="value">{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
                 <span class="label">Query time</span>
@@ -217,7 +221,10 @@
                         {% set i = group_queries ? query.index : i %}
                         <tr id="queryNo-{{ i }}-{{ loop.parent.loop.index }}">
                             {% if group_queries %}
-                                <td class="nowrap">{{ '%0.2f'|format(query.executionMS * 1000) }}&nbsp;ms</td>
+                                <td class="time-container">
+                                    <span class="time-bar" style="width:{{ '%0.2f'|format(query.executionPercent) }}%"></span>
+                                    <span class="nowrap">{{ '%0.2f'|format(query.executionMS * 1000) }}&nbsp;ms<br />({{ '%0.2f'|format(query.executionPercent) }}%)</span>
+                                </td>
                                 <td class="nowrap">{{ query.count }}</td>
                             {% else %}
                                 <td class="nowrap">{{ loop.index }}</td>

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -154,6 +154,11 @@
             </div>
 
             <div class="metric">
+                <span class="value">{{ collector.groupedQueryCount }}</span>
+                <span class="label">Different queries</span>
+            </div>
+    
+            <div class="metric">
                 <span class="value">{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
                 <span class="label">Query time</span>
             </div>

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -155,7 +155,7 @@
 
             <div class="metric">
                 <span class="value">{{ collector.groupedQueryCount }}</span>
-                <span class="label">Different queries</span>
+                <span class="label">Different statements</span>
             </div>
     
             <div class="metric">
@@ -185,12 +185,13 @@
         </div>
     {% endif %}
 
-    <h2>Queries</h2>
     {% set group_queries = request.query.getBoolean('group') %}
     {% if group_queries %}
-        <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>
+        <h2>Grouped Statements</h2>
+        <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Show all queries</a></p>
     {% else %}
-        <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a></p>
+        <h2>Queries</h2>
+        <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar statements</a></p>
     {% endif %}
 
     {% for connection, queries in collector.queries %}

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -186,6 +186,16 @@
     {% endif %}
 
     <h2>Queries</h2>
+    {% set group_queries = false %}
+    {% set can_group_queries = collector.groupedQueryCount < collector.queryCount %}
+    {% if can_group_queries %}
+        {% set group_queries = request.query.getBoolean('group') %}
+        {% if group_queries %}
+            <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>
+        {% else %}
+            <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a></p>
+        {% endif %}
+    {% endif %}
 
     {% for connection, queries in collector.queries %}
         {% if collector.connections|length > 1 %}
@@ -197,16 +207,8 @@
                 <p>No database queries were performed.</p>
             </div>
         {% else %}
-            {% set group_queries = false %}
-            {% set grouped_queries = collector.groupedQueries[connection] %}
-            {% if grouped_queries|length < queries|length %}
-                {% set group_queries = request.query.getBoolean('group') %}
-                {% if group_queries %}
-                    {% set queries = grouped_queries %}
-                    <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>
-                {% else %}
-                    <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a> ({{ grouped_queries|length }} different)</p>
-                {% endif %}
+            {% if group_queries %}
+                {% set queries = collector.groupedQueries[connection] %}
             {% endif %}
             <table class="alt queries-table">
                 <thead>

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -186,15 +186,11 @@
     {% endif %}
 
     <h2>Queries</h2>
-    {% set group_queries = false %}
-    {% set can_group_queries = collector.groupedQueryCount < collector.queryCount %}
-    {% if can_group_queries %}
-        {% set group_queries = request.query.getBoolean('group') %}
-        {% if group_queries %}
-            <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>
-        {% else %}
-            <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a></p>
-        {% endif %}
+    {% set group_queries = request.query.getBoolean('group') %}
+    {% if group_queries %}
+        <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>
+    {% else %}
+        <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a></p>
     {% endif %}
 
     {% for connection, queries in collector.queries %}

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -213,7 +213,7 @@
                 </thead>
                 <tbody id="queries-{{ loop.index }}">
                     {% for i, query in queries %}
-                        {% set i = group_queries ? query.i : i %}
+                        {% set i = group_queries ? query.index : i %}
                         <tr id="queryNo-{{ i }}-{{ loop.parent.loop.index }}">
                             {% if group_queries %}
                                 <td class="nowrap">{{ '%0.2f'|format(query.executionMS * 1000) }}&nbsp;ms</td>

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -188,19 +188,40 @@
                 <p>No database queries were performed.</p>
             </div>
         {% else %}
+            {% set group_queries = false %}
+            {% if collector.groupedQueries[connection]|length < queries|length %}
+                {% set group_queries = request.query.has('group') %}
+                {% if group_queries %}
+                    {% set queries = collector.groupedQueries[connection] %}
+                    <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>
+                {% else %}
+                    <p><a href="{{ path('_profiler', { panel: 'db', token: token, group: true }) }}">Group similar queries</a> ({{ collector.groupedQueries[connection]|length }} different)</p>
+                {% endif %}
+            {% endif %}
             <table class="alt queries-table">
                 <thead>
                 <tr>
-                    <th class="nowrap" onclick="javascript:sortTable(this, 0, 'queries-{{ loop.index }}')" data-sort-direction="-1" style="cursor: pointer;">#<span class="text-muted">&#9650;</span></th>
-                    <th class="nowrap" onclick="javascript:sortTable(this, 1, 'queries-{{ loop.index }}')" style="cursor: pointer;">Time<span></span></th>
+                    {% if group_queries %}
+                        <th class="nowrap" onclick="javascript:sortTable(this, 0, 'queries-{{ loop.index }}')" data-sort-direction="1" style="cursor: pointer;">Time<span class="text-muted">&#9660;</span></th>
+                        <th class="nowrap" onclick="javascript:sortTable(this, 1, 'queries-{{ loop.index }}')" style="cursor: pointer;">Count<span></span></th>
+                    {% else %}
+                        <th class="nowrap" onclick="javascript:sortTable(this, 0, 'queries-{{ loop.index }}')" data-sort-direction="-1" style="cursor: pointer;">#<span class="text-muted">&#9650;</span></th>
+                        <th class="nowrap" onclick="javascript:sortTable(this, 1, 'queries-{{ loop.index }}')" style="cursor: pointer;">Time<span></span></th>
+                    {% endif %}
                     <th style="width: 100%;">Info</th>
                 </tr>
                 </thead>
                 <tbody id="queries-{{ loop.index }}">
                     {% for i, query in queries %}
+                        {% set i = group_queries ? query.i : i %}
                         <tr id="queryNo-{{ i }}-{{ loop.parent.loop.index }}">
-                            <td class="nowrap">{{ loop.index }}</td>
-                            <td class="nowrap">{{ '%0.2f'|format(query.executionMS * 1000) }}&nbsp;ms</td>
+                            {% if group_queries %}
+                                <td class="nowrap">{{ '%0.2f'|format(query.executionMS * 1000) }}&nbsp;ms</td>
+                                <td class="nowrap">{{ query.count }}</td>
+                            {% else %}
+                                <td class="nowrap">{{ loop.index }}</td>
+                                <td class="nowrap">{{ '%0.2f'|format(query.executionMS * 1000) }}&nbsp;ms</td>
+                            {% endif %}
                             <td>
                                 {{ query.sql|doctrine_pretty_query(highlight_only = true) }}
 

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -191,7 +191,7 @@
             {% set group_queries = false %}
             {% set grouped_queries = collector.groupedQueries[connection] %}
             {% if grouped_queries|length < queries|length %}
-                {% set group_queries = request.query.has('group') %}
+                {% set group_queries = request.query.getBoolean('group') %}
                 {% if group_queries %}
                     {% set queries = grouped_queries %}
                     <p><a href="{{ path('_profiler', { panel: 'db', token: token }) }}">Ungroup similar queries</a></p>


### PR DESCRIPTION
DoctrineBundle is great at giving a quick heads-up when the application might benefit from optimizing the database queries.

<img width="187" alt="doctrine-profiler-blip" src="https://cloud.githubusercontent.com/assets/1241866/19744372/f8632d04-9bd5-11e6-8611-62a1f1b17451.png">

But sometimes _it isn't easy to find what exactly to optimize,_ as there may be hundreds of queries. Are there a few very slow queries, or is there a bunch of quick ones that just add up? It's not easy to check at a glance which ones are the most expensive.

![doctrine-profiler-default](https://cloud.githubusercontent.com/assets/1241866/19744391/08ec2a22-9bd6-11e6-9130-ba584472420e.png)

If only the profiler could group similar queries...

![doctrine-profiler-group-link](https://cloud.githubusercontent.com/assets/1241866/19744365/eec451ec-9bd5-11e6-8702-54f0b166a619.png)

...finding the culprits would be much easier:

![doctrine-profiler-group-queries](https://cloud.githubusercontent.com/assets/1241866/19744426/2b326c68-9bd6-11e6-84a4-74cd7b65eb1f.png)

There, it's much easier to see that 4 different queries take up 80% of execution time.

---

I've considered other alternatives for getting quick insights into which queries to optimize first, when there's a need for that.
1. There's the [sensiolabs/doctrine-query-statistics-bundle](https://github.com/sensiolabs/SensioLabsDoctrineQueryStatisticsBundle), but it's not supported since 2013, and some useful features are missing.
2. I could fork/update the `doctrine-query-statistics-bundle`, but having separate Profiler tab to do _almost_ the same as the DoctrineBundle tab doesn't feel quite right.
3. There are server-side products for insights into application performance, such as [New Relic](https://newrelic.com) or the excellent [Blackfire](https://blackfire.io), but they require separate installation, and raise the barrier to getting quick insights quite a bit higher.

So far, the option of adding this feature into the DoctrineBundle seems the best and most natural fit to me.

---

Though this PR does the job, the functionality and usability (and the code) could be improved further, of course. I'd love to add a quick summary (ex. _"4 queries take up 80% time"_) to encourage the users that stumble upon the Queries page to try to group the queries for a quick insight, but I haven't quite decided how to add it yet. And there may very well be something I missed.

If you think it may be useful but needs some more work, let me know, and I'll be happy to fix it.
