### PR TITLE
Fix a test that wasn't mocking enough

### DIFF
--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -119,6 +119,10 @@ class RegistryTest extends TestCase
     public function testResetDefaultEntityManager()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->any())
+            ->method('initialized')
+            ->with($this->equalTo('doctrine.orm.default_entity_manager'))
+            ->willReturn(true);
         $container->expects($this->once())
                   ->method('set')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'), $this->equalTo(null));
@@ -130,6 +134,10 @@ class RegistryTest extends TestCase
     public function testResetEntityManager()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->any())
+            ->method('initialized')
+            ->with($this->equalTo('doctrine.orm.default_entity_manager'))
+            ->willReturn(true);
         $container->expects($this->once())
                   ->method('set')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'), $this->equalTo(null));


### PR DESCRIPTION
The implementation of the ManagerRegistry resetService started
using another method of the Container interface that wasn't mocked
and it broke the tests. The initialized method.
This PR just mock that method in the relevant tests.