### PR TITLE
Updating DoctrineExtension.php

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -658,9 +658,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $regionsDef = $container->setDefinition($regionsId, new Definition('%doctrine.orm.second_level_cache.regions_configuration.class%'));
 
         $slcFactoryId = sprintf('doctrine.orm.%s_second_level_cache.default_cache_factory', $entityManager['name']);
+        $factoryClass = isset($entityManager['second_level_cache']['factory']) ? $entityManager['second_level_cache']['factory'] : '%doctrine.orm.second_level_cache.default_cache_factory.class%';
+
+        $definition = new Definition($factoryClass, array(new Reference($regionsId), new Reference($driverId)));
+
         $slcFactoryDef = $container
-            ->setDefinition($slcFactoryId, new Definition('%doctrine.orm.second_level_cache.default_cache_factory.class%'))
-            ->setArguments(array(new Reference($regionsId), new Reference($driverId)));
+            ->setDefinition($slcFactoryId, $definition);
 
         if (isset($entityManager['second_level_cache']['regions'])) {
             foreach ($entityManager['second_level_cache']['regions'] as $name => $region) {

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -330,7 +330,7 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         
         if (version_compare(Version::VERSION, "2.5.0-DEV") >= 0) {
             // default factory
-            $configurationArray['orm']['entity_managers']['default']['second_level_cache'] = array('region_cache_driver' => array('type' => 'memcache'), 'regions' => array('hour_region' => array('lifetime' => 3600)));
+            $configurationArray[0]['orm']['entity_managers']['default']['second_level_cache'] = array('region_cache_driver' => array('type' => 'memcache'), 'regions' => array('hour_region' => array('lifetime' => 3600)));
             $extension->load($configurationArray, $container);
             $this->compileContainer($container);
             $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
@@ -338,7 +338,7 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
 
             // custom factory
             $customCacheFactory = 'AppBundle\Cache\MyCacheFactory';
-            $configurationArray['orm']['entity_managers']['default']['second_level_cache']['factory'] = $customCacheFactory;
+            $configurationArray[0]['orm']['entity_managers']['default']['second_level_cache']['factory'] = $customCacheFactory;
             $extension->load($configurationArray, $container);
             $this->compileContainer($container);
             $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -330,6 +330,7 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         
         if (version_compare(Version::VERSION, "2.5.0-DEV") >= 0) {
             // default factory
+            $container = $this->getContainer();
             $configurationArray[0]['orm']['entity_managers']['default']['second_level_cache'] = array('region_cache_driver' => array('type' => 'memcache'), 'regions' => array('hour_region' => array('lifetime' => 3600)));
             $extension->load($configurationArray, $container);
             $this->compileContainer($container);
@@ -337,7 +338,8 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('%doctrine.orm.second_level_cache.default_cache_factory.class%', $slcDefinition->getClass());
 
             // custom factory
-            $customCacheFactory = 'AppBundle\Cache\MyCacheFactory';
+            $container = $this->getContainer();
+            $customCacheFactory = 'YamlBundle\Cache\MyCacheFactory';
             $configurationArray[0]['orm']['entity_managers']['default']['second_level_cache']['factory'] = $customCacheFactory;
             $extension->load($configurationArray, $container);
             $this->compileContainer($container);

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -311,7 +311,8 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
-        $extension->load(array(array('dbal' => array('connections' => array('default' => array('password' => 'foo'))), 'orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array())))))), $container);
+        $configurationArray = array(array('dbal' => array('connections' => array('default' => array('password' => 'foo'))), 'orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('second_level_cache' => array('region_cache_driver' => array('type' => 'memcache'), 'regions' => array('hour_region' => array('lifetime' => 3600))), 'mappings' => array('YamlBundle' => array()))))));
+        $extension->load($configurationArray, $container);
         $this->compileContainer($container);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
@@ -326,6 +327,18 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertDICConstructorArguments($definition, array(
             new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
         ));
+
+        // default factory
+        $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
+        $this->assertEquals('%doctrine.orm.second_level_cache.default_cache_factory.class%', $slcDefinition->getClass());
+
+        // custom factory
+        $customCacheFactory = 'AppBundle\Cache\MyCacheFactory';
+        $configurationArray['orm']['entity_managers']['default']['second_level_cache']['factory'] = $customCacheFactory;
+        $extension->load($configurationArray, $container);
+        $this->compileContainer($container);
+        $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
+        $this->assertEquals($customCacheFactory, $slcDefinition->getClass());
     }
 
     public function testBundleEntityAliases()


### PR DESCRIPTION
Making entity manager's second_level_cache.factory option work.

Simplified my fork compared to [initial attempt](https://github.com/doctrine/DoctrineBundle/pull/596). Not doing anything extra now, just factory parameter in the old place.

Longer explanation as requested by @stof:

Some pre-history in stackoverflow (no answers received): [SO link](http://stackoverflow.com/questions/40386291/provide-doctrine-with-custom-cache-factory-for-second-level-cache)
We have found no sensible way to set a custom factory via configuration. I may be blind, but I could not find any handling of manager's second_level_cache.factory option in extension class. So I am trying to make it work via changes requested.

I can see a possible issue that it won't work if someone's implementation of CacheFactory will require other parameters for constructor, though.