### PR TITLE
Update the deprecation warning convention

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -52,7 +52,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getDefaultEntityManagerName()
     {
-        trigger_error('getDefaultEntityManagerName is deprecated since Symfony 2.1. Use getDefaultManagerName instead', E_USER_DEPRECATED);
+        @trigger_error('getDefaultEntityManagerName is deprecated since Symfony 2.1. Use getDefaultManagerName instead', E_USER_DEPRECATED);
 
         return $this->getDefaultManagerName();
     }
@@ -68,7 +68,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getEntityManager($name = null)
     {
-        trigger_error('getEntityManager is deprecated since Symfony 2.1. Use getManager instead', E_USER_DEPRECATED);
+        @trigger_error('getEntityManager is deprecated since Symfony 2.1. Use getManager instead', E_USER_DEPRECATED);
 
         return $this->getManager($name);
     }
@@ -82,7 +82,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getEntityManagers()
     {
-        trigger_error('getEntityManagers is deprecated since Symfony 2.1. Use getManagers instead', E_USER_DEPRECATED);
+        @trigger_error('getEntityManagers is deprecated since Symfony 2.1. Use getManagers instead', E_USER_DEPRECATED);
 
         return $this->getManagers();
     }
@@ -95,7 +95,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      * it makes sense to get a new one to replace the closed one.
      *
      * Be warned that you will get a brand new entity manager as
-     * the existing one is not useable anymore. This means that any
+     * the existing one is not usable anymore. This means that any
      * other object with a dependency on this entity manager will
      * hold an obsolete reference. You can inject the registry instead
      * to avoid this problem.
@@ -108,7 +108,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function resetEntityManager($name = null)
     {
-        trigger_error('resetEntityManager is deprecated since Symfony 2.1. Use resetManager instead', E_USER_DEPRECATED);
+        @trigger_error('resetEntityManager is deprecated since Symfony 2.1. Use resetManager instead', E_USER_DEPRECATED);
 
         $this->resetManager($name);
     }
@@ -126,7 +126,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getEntityNamespace($alias)
     {
-        trigger_error('getEntityNamespace is deprecated since Symfony 2.1. Use getAliasNamespace instead', E_USER_DEPRECATED);
+        @trigger_error('getEntityNamespace is deprecated since Symfony 2.1. Use getAliasNamespace instead', E_USER_DEPRECATED);
 
         return $this->getAliasNamespace($alias);
     }
@@ -163,7 +163,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getEntityManagerNames()
     {
-        trigger_error('getEntityManagerNames is deprecated since Symfony 2.1. Use getManagerNames instead', E_USER_DEPRECATED);
+        @trigger_error('getEntityManagerNames is deprecated since Symfony 2.1. Use getManagerNames instead', E_USER_DEPRECATED);
 
         return $this->getManagerNames();
     }
@@ -179,7 +179,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getEntityManagerForClass($class)
     {
-        trigger_error('getEntityManagerForClass is deprecated since Symfony 2.1. Use getManagerForClass instead', E_USER_DEPRECATED);
+        @trigger_error('getEntityManagerForClass is deprecated since Symfony 2.1. Use getManagerForClass instead', E_USER_DEPRECATED);
 
         return $this->getManagerForClass($class);
     }


### PR DESCRIPTION
The Symfony convention is to silence the deprecations to avoid issues with error handlers turning PHP errors into exceptions. But these deprecations were written before Symfony decided to use silenced warnings, and were not updated after that.