### PR TITLE
Fixed Division by zero when total execution time is 0ms

### DIFF
--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -222,6 +222,9 @@ class DoctrineDataCollector extends BaseCollector
             });
             $groupedQueries[$connection] = $connectionGroupedQueries;
         }
+        if ((float) $totalExecutionMS === 0.0) {
+            $totalExecutionMS = 1;
+        }
         foreach ($groupedQueries as $connection => $queries) {
             foreach ($queries as $i => $query) {
                 $groupedQueries[$connection][$i]['executionPercent'] = $query['executionMS'] / $totalExecutionMS * 100;


### PR DESCRIPTION
When you go to Symfony profiler -> Query Metrics and when Query time = 0ms there is an exception:
"An exception has been thrown during the rendering of a template ("Warning: Division by zero")."

[1/2] ContextErrorException: Warning: Division by zero 
in vendor\doctrine\doctrine-bundle\DataCollector\DoctrineDataCollector.php at line 232

[2/2] Twig_Error_Runtime: An exception has been thrown during the rendering of a template ("Warning: Division by zero")
in vendor\doctrine\doctrine-bundle\Resources\views\Collector\db.html.twig at line 157