### PR TITLE
Fix twig requirement constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/validator": "~2.7|~3.0",
         "symfony/property-info": "~2.8|~3.0",
         "symfony/phpunit-bridge": "~2.7|~3.0",
-        "twig/twig": "~1.10|~2.0",
+        "twig/twig": "~1.12|~2.0",
         "satooshi/php-coveralls": "^1.0",
         "phpunit/phpunit": "~4"
     },


### PR DESCRIPTION
Since https://github.com/doctrine/DoctrineBundle/commit/e2ca576ce35a16a0cf4e300068a4a5a5b54e36c7 the Twig extension makes use of `\Twig_SimpleFilter`, but the class does not exist before Twig 1.12 (not 1.10 nor 1.11).