### PR TITLE
[POC][RFC] New repository factory able to inject dependencies in repositories

### DIFF
--- a/DependencyInjection/Compiler/DoctrineRepositoryPass.php
+++ b/DependencyInjection/Compiler/DoctrineRepositoryPass.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Configure DI Repository Factory with repositories with dependencies
+ *
+ * @author Miguel Angel Garzón <magarzon@gmail.com>
+ */
+class DoctrineRepositoryPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('doctrine.di_repository_factory')) {
+            $servicesId = $container->findTaggedServiceIds('doctrine.repository');
+
+            $definitions = [];
+
+            foreach ($servicesId as $serviceId => $parameters) {
+                $definition = $container->getDefinition($serviceId);
+                $definitions[] = $this->createFromServiceDefinition($definition);
+            }
+
+            $factory = $container->getDefinition('doctrine.di_repository_factory');
+            $factory->addArgument($definitions);
+        }
+    }
+
+    /**
+     * @param Definition $definition
+     * @return array
+     */
+    private function createFromServiceDefinition(Definition $definition)
+    {
+        $tag = $definition->getTag('doctrine.repository');
+        $entity = $tag[0]['entity'];
+        //Only setter injection by now
+        $calls = $definition->getMethodCalls();
+
+        return ['entity' => $entity, 'setters' => $calls];
+    }
+}

--- a/Repository/DIRepositoryFactory.php
+++ b/Repository/DIRepositoryFactory.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineBundle\Repository;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Repository\RepositoryFactory;
+
+/**
+ * Class RepositoryFactory
+ *
+ * @author Miguel Angel Garzón <magarzon@gmail.com>
+ */
+final class DIRepositoryFactory implements RepositoryFactory
+{
+    /**
+     * The list of EntityRepository instances.
+     *
+     * @var \Doctrine\Common\Persistence\ObjectRepository[]
+     */
+    private $repositoryList = [];
+
+    /**
+     * @var array
+     */
+    private $repositoryDefinitions = [];
+
+    /**
+     * DIRepositoryFactory constructor.
+     * @param array $repositoryDefinitions
+     */
+    public function __construct(array $repositoryDefinitions = [])
+    {
+        $this->repositoryDefinitions = $repositoryDefinitions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    {
+        $repositoryHash = $entityManager->getClassMetadata($entityName)->getName().spl_object_hash($entityManager);
+
+        if (isset($this->repositoryList[$repositoryHash])) {
+            return $this->repositoryList[$repositoryHash];
+        }
+
+        $repository = $this->createRepository($entityManager, $entityName);
+
+        $this->setterDependencies($repository, $entityName);
+
+        return $this->repositoryList[$repositoryHash] = $repository;
+    }
+
+    /**
+     * @param ObjectRepository $repository
+     * @param $entityName
+     */
+    private function setterDependencies(ObjectRepository $repository, $entityName)
+    {
+        foreach ($this->repositoryDefinitions as $definition) {
+            if ($definition['entity'] === $entityName) {
+                $setters = $definition['setters'];
+                foreach ($setters as $method) {
+                    list($setter, $parameters) = $method;
+                    call_user_func_array([$repository, $setter], $parameters);
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Create a new repository instance for an entity class.
+     *
+     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string                               $entityName    The name of the entity.
+     *
+     * @return \Doctrine\Common\Persistence\ObjectRepository
+     */
+    private function createRepository(EntityManagerInterface $entityManager, $entityName)
+    {
+        /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
+        $metadata            = $entityManager->getClassMetadata($entityName);
+        $repositoryClassName = $metadata->customRepositoryClassName
+            ?: $entityManager->getConfiguration()->getDefaultRepositoryClassName();
+
+        return new $repositoryClassName($entityManager, $metadata);
+    }
+}

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -72,6 +72,10 @@
         <parameter key="doctrine.orm.second_level_cache.logger_statistics.class">Doctrine\ORM\Cache\Logging\StatisticsCacheLogger</parameter>
         <parameter key="doctrine.orm.second_level_cache.cache_configuration.class">Doctrine\ORM\Cache\CacheConfiguration</parameter>
         <parameter key="doctrine.orm.second_level_cache.regions_configuration.class">Doctrine\ORM\Cache\RegionsConfiguration</parameter>
+
+        <!-- repository factory that handle dependency injection -->
+        <parameter key="doctrine.orm.di_repository_factory.class">Doctrine\Repository\DIRepositoryFactory</parameter>
+
     </parameters>
 
     <services>
@@ -129,5 +133,8 @@
         <!-- quote strategy -->
         <service id="doctrine.orm.quote_strategy.default" class="%doctrine.orm.quote_strategy.default.class%" public="false" />
         <service id="doctrine.orm.quote_strategy.ansi" class="%doctrine.orm.quote_strategy.ansi.class%" public="false" />
+
+        <!-- repository factory that handle dependency injection -->
+        <service id="doctrine.orm.di_repository_factory" class="%doctrine.orm.di_repository_factory.class%" public="false" />
     </services>
 </container>


### PR DESCRIPTION
Sometimes we need our custom entity (object) repositories to have dependencies on other services and/or configuration parameters.

One way to get this done is to define the repository as a service, and inject the dependencies as any other service:

```
    app.doctrine.user_repository:
        class: AppBundle\Doctrine\Repository\UserRepository
        factory: ["@doctrine.orm.entity_manager", getRepository]
        arguments: [AppBundle\Entity\User]
        calls:
            - [setDependency, ['@example_service_dependency']]
            - [setParameter, ['%configuration_parameter%']]
```

And then inject this repository in another service, like a user manager or whatever.

But there are cases where third party and/or framework bundles use the doctrine service, or the entity manager service, to get the repository, and then is not used this service that we have defined, and the dependencies are not set.

My proposal is to have a tag, i.e. doctrine.repository to mark the repositories exposes as a service, and a repository factory that can create the repository and inject the dependencies.

That way, we only need to add this tag to this service:

```
    app.doctrine.user_repository:
        class: AppBundle\Doctrine\Repository\UserRepository
        factory: ["@doctrine.orm.entity_manager", getRepository]
        arguments: [AppBundle\Entity\User]
        calls:
            - [setDependency, ['@example_service_dependency']]
            - [setParameter, ['%configuration_parameter%']]
        tags:
            - {name: doctrine.repository, entity: AppBundle:User}
```
And the compiler pass that I have added get the calls (could be also other type of dependencies, properties, getter) and add the definitions (that are going to be transformed in actual instances) to the DIRepositoryFactory (yes, the naming could be enhanced).

The DIRepositoryFactory create the repository as de doctrine DefaultRepositoryFactory, but after repository creation, traverse the definitions, and if there is a match between the entity name and the included in the tag, it sets the dependencies in the repository instance.

Obviously, to activate this, the compiler pass should be added in the the DoctrineBundle build method (I haven't added this to not break anything) and the DIRepositoryFactory should replace the default one using doctrine configuration:

```
doctrine:
    orm:
        auto_generate_proxy_classes: "%kernel.debug%"
        naming_strategy: doctrine.orm.naming_strategy.underscore
        auto_mapping: true
        repository_factory: doctrine.orm.di_repository_factory
```

I know that the code can be improved and even there is a little bug (the name of the service is different in the compiler and the config file), but this only a POC, if the idea is good, we should fix that.