### PR TITLE
Allow database entry for orm cache driver node config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -640,6 +640,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('type')->defaultValue('array')->end()
                 ->scalarNode('host')->end()
                 ->scalarNode('port')->end()
+                ->scalarNode('database')->end()
                 ->scalarNode('instance_class')->end()
                 ->scalarNode('class')->end()
                 ->scalarNode('id')->end()

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -154,6 +154,7 @@
             <xsd:element name="class" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="host" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="port" type="xsd:string" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="database" type="xsd:integer" minOccurs="0" maxOccurs="1" />
             <xsd:element name="instance-class" type="xsd:string" minOccurs="0" maxOccurs="1" />
         </xsd:all>
 

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -399,6 +399,22 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testEntityManagerRedisMetadataCacheDriverConfigurationWithDatabaseKey()
+    {
+        $container = $this->loadContainer('orm_service_simple_single_entity_manager_redis');
+
+        $definition = $container->getDefinition($container->getAlias('doctrine.orm.default_metadata_cache'));
+        $this->assertDICDefinitionClass($definition, '%doctrine_cache.redis.class%');
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setRedis',
+            array(new Reference('doctrine_cache.services.doctrine.orm.default_metadata_cache_redis.connection'))
+        );
+
+        $definition = $container->getDefinition('doctrine_cache.services.doctrine.orm.default_metadata_cache_redis.connection');
+        $this->assertDICDefinitionClass($definition, '%doctrine_cache.redis.connection.class%');
+        $this->assertDICDefinitionMethodCallOnce($definition, 'connect', array('localhost', '6379'));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'select', array(1));
+    }
+
     public function testDependencyInjectionImportsOverrideDefaults()
     {
         $container = $this->loadContainer('orm_imports');

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager_redis.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager_redis.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm default-entity-manager="default">
+            <entity-manager name="default">
+                <metadata-cache-driver type="redis">
+                    <class>Doctrine\Common\Cache\RedisCache</class>
+                    <host>localhost</host>
+                    <port>6379</port>
+                    <database>1</database>
+                    <instance-class>Memcache</instance-class>
+                </metadata-cache-driver>
+                <mapping name="YamlBundle" />
+            </entity-manager>
+        </orm>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager_redis.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager_redis.yml
@@ -1,0 +1,20 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        default_entity_manager: default
+        entity_managers:
+            default:
+                mappings:
+                    YamlBundle: ~
+                metadata_cache_driver:
+                    type: redis
+                    class: Doctrine\Common\Cache\RedisCache
+                    host: localhost
+                    port: 6379
+                    database: 1
+                    instance_class: Redis

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/dbal": "~2.3",
         "jdorn/sql-formatter": "~1.1",
         "symfony/doctrine-bridge": "~2.7|~3.0",
-        "doctrine/doctrine-cache-bundle": "~1.0"
+        "doctrine/doctrine-cache-bundle": "~1.2"
     },
     "require-dev": {
         "doctrine/orm": "~2.3",


### PR DESCRIPTION
This work allow to select database configuration for redis cache driver for instance.
It completes https://github.com/doctrine/DoctrineCacheBundle/issues/46 and "finish" started work https://github.com/doctrine/DoctrineBundle/pull/393