### PR TITLE
Fix an issue were some commented type

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -62,6 +62,9 @@ class ConnectionFactory
             foreach ($mappingTypes as $dbType => $doctrineType) {
                 $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
             }
+        }
+        if (!empty($this->commentedTypes)) {
+            $platform = $connection->getDatabasePlatform();
             foreach ($this->commentedTypes as $type) {
                 $platform->markDoctrineTypeCommented(Type::getType($type));
             }

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -531,7 +531,7 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $container = $this->loadContainer('dbal_types');
 
         $this->assertEquals(
-            array('test' => array('class' => 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType', 'commented' => true)),
+            array('test' => array('class' => TestType::class, 'commented' => true)),
             $container->getParameter('doctrine.dbal.connection_factory.types')
         );
         $this->assertEquals('%doctrine.dbal.connection_factory.types%', $container->getDefinition('doctrine.dbal.connection_factory')->getArgument(0));

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
@@ -8,7 +8,7 @@
 
     <config>
         <dbal default-connection="default">
-            <type name="test">Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType</type>
+            <type name="test">Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType</type>
             <connection name="default" />
         </dbal>
     </config>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_types.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_types.yml
@@ -2,6 +2,6 @@ doctrine:
     dbal:
         default_connection: default
         types:
-            test: Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType
+            test: Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType
         connections:
             default: ~

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -14,6 +14,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -53,7 +54,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
                 ),
                 'default_connection' => 'default',
                 'types' => array(
-                    'test' => 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType',
+                    'test' => TestType::class,
                 ),
             ), 'orm' => array(
                 'default_entity_manager' => 'default',


### PR DESCRIPTION
They were not marked as such if the mappingType array was
empty.

Sadly I don't see any way to test this right now.