### PR TITLE
Separating concerns

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -52,7 +52,6 @@ class ConnectionFactory
     {
         if (!$this->initialized) {
             $this->initializeTypes();
-            $this->initialized = true;
         }
 
         $connection = DriverManager::getConnection($params, $config, $eventManager);
@@ -85,5 +84,6 @@ class ConnectionFactory
                 $this->commentedTypes[] = $type;
             }
         }
+        $this->initialized = true;
     }
 }


### PR DESCRIPTION
The responsability of changing the value of the initialized
property shouldn't be on the user of the initializeType method.