### PR TITLE
Fix division by 0 when total execution ms = 0ms

### DIFF
--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -224,7 +224,7 @@ class DoctrineDataCollector extends BaseCollector
         }
         foreach ($groupedQueries as $connection => $queries) {
             foreach ($queries as $i => $query) {
-                $groupedQueries[$connection][$i]['executionPercent'] = $query['executionMS'] / $totalExecutionMS * 100;
+                $groupedQueries[$connection][$i]['executionPercent'] = $totalExecutionMS === 0 ? 100 : $query['executionMS'] / $totalExecutionMS * 100;
             }
         }
 


### PR DESCRIPTION
Hello,

When you want to go to the profiler and you total request time is < 0.005ms, total execution time = 0ms.

<img width="1081" alt="screen shot 2017-04-01 at 12 00 40" src="https://cloud.githubusercontent.com/assets/617780/24577707/17dbe7de-16d3-11e7-95c5-54ae27ce00e8.png">
<img width="933" alt="screen shot 2017-04-01 at 11 55 33" src="https://cloud.githubusercontent.com/assets/617780/24577708/17f0931e-16d3-11e7-9078-35cc1c87f92d.png">
