### PR TITLE
Fix exception "A non-numeric value encountered" in PHP 7.1

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -129,8 +129,8 @@ EOT
 
             return 0;
         } else {
-            $output->writeln('Database does not have any mapping information.', 'ERROR');
-            $output->writeln('', 'ERROR');
+            $output->writeln('Database does not have any mapping information.');
+            $output->writeln('');
 
             return 1;
         }


### PR DESCRIPTION
Passing a string (Specifically 'ERROR') to the method writeln, which accepting int.
This causes exception "A non-numeric value encountered" in PHP 7.1