### PR TITLE
Custom repository service compiler pass

### DIFF
--- a/DependencyInjection/Compiler/RepositoryAliasPass.php
+++ b/DependencyInjection/Compiler/RepositoryAliasPass.php
@@ -47,6 +47,10 @@ class RepositoryAliasPass implements CompilerPassInterface
             }
 
             foreach ($customRepositories as $repositoryClass => $entities) {
+                if ($container->has($repositoryClass)) {
+                    continue;
+                }
+
                 if (count($entities) === 1) {
                     $definition = new Definition($repositoryClass);
                     $definition->setFactory(array(

--- a/DependencyInjection/Compiler/RepositoryAliasPass.php
+++ b/DependencyInjection/Compiler/RepositoryAliasPass.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RepositoryAliasPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('doctrine.entity_managers')) {
+            return;
+        }
+
+        $entityManagers = $container->getParameter('doctrine.entity_managers');
+        $customRepositories = [];
+
+        foreach ($entityManagers as $name => $serviceName) {
+            $metadataDriverService = sprintf('doctrine.orm.%s_metadata_driver', $name);
+
+            if (!$container->has($metadataDriverService)) {
+                continue;
+            }
+
+            /** @var MappingDriver $metadataDriver */
+            $metadataDriver = $container->get($metadataDriverService);
+            $entityClassNames = $metadataDriver->getAllClassNames();
+
+            foreach ($entityClassNames as $entityClassName) {
+                $classMetadata = new ClassMetadata($entityClassName);
+                $metadataDriver->loadMetadataForClass($entityClassName, $classMetadata);
+
+                if ($classMetadata->customRepositoryClassName) {
+                    $customRepositories[$classMetadata->customRepositoryClassName][] = [
+                        0 => $entityClassName,
+                        1 => $name,
+                    ];
+                }
+            }
+
+            foreach ($customRepositories as $repositoryClass => $entities) {
+                if (count($entities) === 1) {
+                    $definition = new Definition($repositoryClass);
+                    $definition->setFactory(array(
+                        new Reference('doctrine'),
+                        'getRepository'
+                    ));
+                    $definition->setArguments($entities[0]);
+                    $definition->setShared(false);
+
+                    $container->setDefinition($repositoryClass, $definition);
+                }
+            }
+        }
+    }
+}

--- a/DependencyInjection/Compiler/RepositoryAliasPass.php
+++ b/DependencyInjection/Compiler/RepositoryAliasPass.php
@@ -52,15 +52,11 @@ class RepositoryAliasPass implements CompilerPassInterface
                 }
 
                 if (count($entities) === 1) {
-                    $definition = new Definition($repositoryClass);
-                    $definition->setFactory(array(
-                        new Reference('doctrine'),
-                        'getRepository'
-                    ));
-                    $definition->setArguments($entities[0]);
-                    $definition->setShared(false);
-
-                    $container->setDefinition($repositoryClass, $definition);
+                    $container->register($repositoryClass, $repositoryClass)
+                        ->setFactory([new Reference('doctrine'), 'getRepository'])
+                        ->setArguments($entities[0])
+                        ->setShared(false)
+                    ;
                 }
             }
         }

--- a/DependencyInjection/Compiler/RepositoryAliasPass.php
+++ b/DependencyInjection/Compiler/RepositoryAliasPass.php
@@ -81,7 +81,7 @@ class RepositoryAliasPass implements CompilerPassInterface
             if (Kernel::MAJOR_VERSION <= 2 && Kernel::MINOR_VERSION <= 7) {
                 $definition->setScope('prototype');
             } else {
-                $definition->setShared(true);
+                $definition->setShared(false);
             }
         }
 

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -20,6 +20,7 @@ use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RepositoryAliasPass;
 use Doctrine\ORM\Proxy\Autoloader;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -55,6 +56,7 @@ class DoctrineBundle extends Bundle
 
         $container->addCompilerPass(new DoctrineValidationPass('orm'));
         $container->addCompilerPass(new EntityListenerPass());
+        $container->addCompilerPass(new RepositoryAliasPass());
     }
 
     /**

--- a/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
+++ b/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
@@ -1,7 +1,16 @@
 <?php
 
-namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -11,7 +20,6 @@ use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpKernel\Kernel;
-
 
 class AutoregisterRepositoriesTest extends TestCase
 {
@@ -136,7 +144,7 @@ class AutoregisterRepositoriesTest extends TestCase
         $pass->process($containerBuilder->reveal());
     }
 
-    protected function prepPropheciesForOneEmAndClassA($containerBuilder, $metadataDriver, $parameterBag)
+    private function prepPropheciesForOneEmAndClassA($containerBuilder, $metadataDriver, $parameterBag)
     {
         $containerBuilder->hasParameter('doctrine.entity_managers')->willReturn(true);
         $containerBuilder->getParameter('doctrine.entity_managers')->willReturn([

--- a/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
+++ b/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
@@ -60,8 +60,8 @@ class AutoregisterRepositoriesTest extends TestCase
 
     public function testSingleEmRepoAlreadyRegisteredVanillaServiceOnSymfony3()
     {
-        if (Kernel::MAJOR_VERSION !== 3) {
-            $this->markTestSkipped("This test is only run with Symfony 3");
+        if (Kernel::MAJOR_VERSION > 3) {
+            $this->markTestSkipped("This test is only run with Symfony 3 or lower");
         }
 
         $pass = new RepositoryAliasPass();

--- a/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
+++ b/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RepositoryAliasPass;
@@ -12,7 +13,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpKernel\Kernel;
 
 
-class AutoregisterRepositoriesTest extends \PHPUnit_Framework_TestCase
+class AutoregisterRepositoriesTest extends TestCase
 {
     public function testSingleEmNoRegisteredRepositories()
     {
@@ -51,6 +52,7 @@ class AutoregisterRepositoriesTest extends \PHPUnit_Framework_TestCase
 
         $containerBuilder->getDefinitions()->willReturn([]);
         $containerBuilder->has(ClassARepository::class)->willReturn(true);
+        $containerBuilder->register(Argument::any(), Argument::any())->shouldNotBeCalled();
 
         $pass = new RepositoryAliasPass();
         $pass->process($containerBuilder->reveal());
@@ -79,6 +81,7 @@ class AutoregisterRepositoriesTest extends \PHPUnit_Framework_TestCase
         if (method_exists(ContainerBuilder::class, 'log')) {
             $containerBuilder->log($pass, Argument::any())->shouldBeCalled();
         }
+        $containerBuilder->register(Argument::any(), Argument::any())->shouldNotBeCalled();
 
         $pass->process($containerBuilder->reveal());
     }
@@ -128,6 +131,7 @@ class AutoregisterRepositoriesTest extends \PHPUnit_Framework_TestCase
         if (method_exists(ContainerBuilder::class, 'log')) {
             $containerBuilder->log($pass, Argument::any())->shouldBeCalled();
         }
+        $containerBuilder->register(Argument::any(), Argument::any())->shouldNotBeCalled();
 
         $pass->process($containerBuilder->reveal());
     }

--- a/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
+++ b/Tests/DependencyInjection/AutoregisterRepositoriesTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
+
+
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RepositoryAliasPass;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpKernel\Kernel;
+
+
+class AutoregisterRepositoriesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSingleEmNoRegisteredRepositories()
+    {
+        $containerBuilder = $this->prophesize(ContainerBuilder::class);
+        $metadataDriver = $this->prophesize(MappingDriver::class);
+        $parameterBag = $this->prophesize(ParameterBag::class);
+        $definition = $this->prophesize(Definition::class);
+
+        $this->prepPropheciesForOneEmAndClassA($containerBuilder, $metadataDriver, $parameterBag);
+
+        $containerBuilder->getDefinitions()->willReturn([]);
+        $containerBuilder->has(ClassARepository::class)->willReturn(false);
+        $containerBuilder->register(ClassARepository::class, ClassARepository::class)->shouldBeCalled()->willReturn($definition);
+        $definition->setFactory(Argument::any())->shouldBeCalled()->willReturn($definition);
+        $definition->setArguments(['ClassA', 'default'])->shouldBeCalled()->willReturn($definition);
+        $definition->setPublic(false)->shouldBeCalled()->willReturn($definition);
+
+        if (method_exists(Definition::class, 'setShared')) {
+            $definition->setShared(false)->shouldBeCalled()->willReturn($definition);
+        } else {
+            $definition->setScope('prototype')->shouldBeCalled()->willReturn($definition);
+        }
+
+
+        $pass = new RepositoryAliasPass();
+        $pass->process($containerBuilder->reveal());
+    }
+
+    public function testSingleEmRepoAlreadyRegisteredWithClassName()
+    {
+        $containerBuilder = $this->prophesize(ContainerBuilder::class);
+        $metadataDriver = $this->prophesize(MappingDriver::class);
+        $parameterBag = $this->prophesize(ParameterBag::class);
+
+        $this->prepPropheciesForOneEmAndClassA($containerBuilder, $metadataDriver, $parameterBag);
+
+        $containerBuilder->getDefinitions()->willReturn([]);
+        $containerBuilder->has(ClassARepository::class)->willReturn(true);
+
+        $pass = new RepositoryAliasPass();
+        $pass->process($containerBuilder->reveal());
+    }
+
+    public function testSingleEmRepoAlreadyRegisteredVanillaServiceOnSymfony3()
+    {
+        if (Kernel::MAJOR_VERSION !== 3) {
+            $this->markTestSkipped("This test is only run with Symfony 3");
+        }
+
+        $pass = new RepositoryAliasPass();
+
+        $containerBuilder = $this->prophesize(ContainerBuilder::class);
+        $metadataDriver = $this->prophesize(MappingDriver::class);
+        $parameterBag = $this->prophesize(ParameterBag::class);
+        $previousDefinition = $this->prophesize(Definition::class);
+
+        $this->prepPropheciesForOneEmAndClassA($containerBuilder, $metadataDriver, $parameterBag);
+
+        $containerBuilder->getDefinitions()->willReturn([
+            'app.class_a_repo' => $previousDefinition,
+        ]);
+        $previousDefinition->getClass()->willReturn(ClassARepository::class);
+        $containerBuilder->has(ClassARepository::class)->willReturn(false);
+        if (method_exists(ContainerBuilder::class, 'log')) {
+            $containerBuilder->log($pass, Argument::any())->shouldBeCalled();
+        }
+
+        $pass->process($containerBuilder->reveal());
+    }
+
+    public function testMultipleEms()
+    {
+        $pass = new RepositoryAliasPass();
+
+        $containerBuilder = $this->prophesize(ContainerBuilder::class);
+        $metadataDriver1 = $this->prophesize(MappingDriver::class);
+        $metadataDriver2 = $this->prophesize(MappingDriver::class);
+        $parameterBag = $this->prophesize(ParameterBag::class);
+
+        $containerBuilder->hasParameter('doctrine.entity_managers')->willReturn(true);
+        $containerBuilder->getParameter('doctrine.entity_managers')->willReturn([
+            'default' => 'doctrine.default',
+            'secondary' => 'doctrine.secondary',
+        ]);
+        $containerBuilder->has('doctrine.orm.default_metadata_driver')->willReturn(true);
+        $containerBuilder->get('doctrine.orm.default_metadata_driver')->willReturn($metadataDriver1);
+        $containerBuilder->has('doctrine.orm.secondary_metadata_driver')->willReturn(true);
+        $containerBuilder->get('doctrine.orm.secondary_metadata_driver')->willReturn($metadataDriver1);
+        $containerBuilder->getParameterBag()->willReturn($parameterBag);
+
+        $parameterBag->resolveValue(Argument::any())->will(function($args) {
+            return $args[0];
+        });
+
+        $metadataDriver1->getAllClassNames()->willReturn([
+            'ClassA',
+        ]);
+        $metadataDriver1->loadMetadataForClass('ClassA', Argument::which('getName', 'ClassA'))
+            ->will(function($args) {
+                $args[1]->customRepositoryClassName = ClassARepository::class;
+            });
+
+        $metadataDriver2->getAllClassNames()->willReturn([
+            'ClassA',
+        ]);
+        $metadataDriver2->loadMetadataForClass('ClassA', Argument::which('getName', 'ClassA'))
+            ->will(function($args) {
+                $args[1]->customRepositoryClassName = ClassARepository::class;
+            });
+
+        $containerBuilder->getDefinitions()->willReturn([]);
+        $containerBuilder->has(ClassARepository::class)->willReturn(false);
+        if (method_exists(ContainerBuilder::class, 'log')) {
+            $containerBuilder->log($pass, Argument::any())->shouldBeCalled();
+        }
+
+        $pass->process($containerBuilder->reveal());
+    }
+
+    protected function prepPropheciesForOneEmAndClassA($containerBuilder, $metadataDriver, $parameterBag)
+    {
+        $containerBuilder->hasParameter('doctrine.entity_managers')->willReturn(true);
+        $containerBuilder->getParameter('doctrine.entity_managers')->willReturn([
+            'default' => 'doctrine.default',
+        ]);
+        $containerBuilder->has('doctrine.orm.default_metadata_driver')->willReturn(true);
+        $containerBuilder->get('doctrine.orm.default_metadata_driver')->willReturn($metadataDriver);
+        $containerBuilder->getParameterBag()->willReturn($parameterBag);
+
+        $parameterBag->resolveValue(Argument::any())->will(function($args) {
+            return $args[0];
+        });
+
+        $metadataDriver->getAllClassNames()->willReturn([
+            'ClassA',
+        ]);
+        $metadataDriver->loadMetadataForClass('ClassA', Argument::which('getName', 'ClassA'))
+            ->will(function($args) {
+                $args[1]->customRepositoryClassName = ClassARepository::class;
+            });
+    }
+}
+
+
+class ClassAlphaRepository {}
+class ClassARepository extends ClassAlphaRepository {}


### PR DESCRIPTION
Added a compiler pass to register custom repositories as services, given they only belong only to one entity manager. 

In accordance with the upcoming Symfony 3.3 standards, and in order to make it easy to use with autowiring, the service name is the class name of the repository.

## Todo

- [x] Write some functional tests for the different scenarios in which repositories are registered or not.