### PR TITLE
Allow Symfony 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,20 +25,20 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/framework-bundle": "~2.7|~3.0",
-        "symfony/console": "~2.7|~3.0",
-        "symfony/dependency-injection": "~2.7|~3.0",
+        "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+        "symfony/console": "~2.7|~3.0|~4.0",
+        "symfony/dependency-injection": "~2.7|~3.0|~4.0",
         "doctrine/dbal": "~2.3",
         "jdorn/sql-formatter": "~1.1",
-        "symfony/doctrine-bridge": "~2.7|~3.0",
+        "symfony/doctrine-bridge": "~2.7|~3.0|~4.0",
         "doctrine/doctrine-cache-bundle": "~1.2"
     },
     "require-dev": {
         "doctrine/orm": "~2.3",
-        "symfony/yaml": "~2.7|~3.0",
-        "symfony/validator": "~2.7|~3.0",
-        "symfony/property-info": "~2.8|~3.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/yaml": "~2.7|~3.0|~4.0",
+        "symfony/validator": "~2.7|~3.0|~4.0",
+        "symfony/property-info": "~2.8|~3.0|~4.0",
+        "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
         "twig/twig": "~1.12|~2.0",
         "satooshi/php-coveralls": "^1.0",
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
Symfony master is now 4.0. This PR upgrades `composer.json` accordingly.