### PR TITLE
Improvement to IDE-friendliness when 'wrapper_class' option is used

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -210,6 +210,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ))
         ;
 
+        // Set class in case "wrapper_class" option was used to assist IDEs
+        if (isset($options['wrapperClass'])) {
+            $def->setClass($options['wrapperClass']);
+        }
+
         if (!empty($connection['use_savepoints'])) {
             $def->addMethodCall('setNestTransactionsWithSavepoints', array($connection['use_savepoints']));
         }
@@ -220,11 +225,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 new Reference(sprintf('doctrine.dbal.%s_connection', $name))
             ));
             $container->setDefinition(sprintf('doctrine.dbal.%s_shard_manager', $name), $shardManagerDefinition);
-        }
-
-        // Set class in case "wrapper_class" option was used to assist IDEs
-        if (isset($options['wrapperClass'])) {
-            $def->setClass($options['wrapperClass']);
         }
     }
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -221,6 +221,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ));
             $container->setDefinition(sprintf('doctrine.dbal.%s_shard_manager', $name), $shardManagerDefinition);
         }
+
+        // Set class in case "wrapper_class" option was used to assist IDEs
+        if (isset($options['wrapperClass'])) {
+            $def->setClass($options['wrapperClass']);
+        }
     }
 
     protected function getConnectionOptions($connection)

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -216,7 +216,7 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(TestWrapperClass::class, $container->getDefinition('doctrine.dbal.default_connection')->getClass());
-        $this->assertEquals(null, $container->getDefinition('doctrine.dbal.second_connection')->getClass());
+        $this->assertNull($container->getDefinition('doctrine.dbal.second_connection')->getClass());
     }
 
     public function testDependencyInjectionConfigurationDefaults()


### PR DESCRIPTION
Sets the `class` property in service definition to assist IDEs in knowing what class the service really is. Since connection services use a factory, the `class` option doesn't affect anything. I've tested the logic with following "hack" and it works without any problems:

```php
class DataConnectionCompilerPass implements CompilerPassInterface
{
    public function process (ContainerBuilder $container)
    {
        $service = $container->findDefinition('doctrine.dbal.data_connection');
        $service->setClass(DataConnectionWrapper::class);
    }
}
```

P.S. Why so many `private`s in `\Doctrine\DBAL\Connection`? Makes extending it so hard....