### PR TITLE
Require PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,14 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.0
   - 7.1
   - nightly
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.1
       env: deps=low SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.0
+    - php: 7.1
       env: deps=dev
   allow_failures:
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,15 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - nightly
-  - hhvm
 
 matrix:
   include:
-    - php: 5.5
+    - php: 7.0
       env: deps=low SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 5.6
-      env: SYMFONY_VERSION="2.8.*@dev"
-    - php: 5.6
+    - php: 7.0
       env: deps=dev
   allow_failures:
     - php: nightly

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -86,20 +86,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
             $this->ormLoad($config['orm'], $container);
         }
-
-        if (PHP_VERSION_ID < 70000) {
-            $this->addClassesToCompile(array(
-                'Doctrine\\Common\\Annotations\\DocLexer',
-                'Doctrine\\Common\\Annotations\\FileCacheReader',
-                'Doctrine\\Common\\Annotations\\PhpParser',
-                'Doctrine\\Common\\Annotations\\Reader',
-                'Doctrine\\Common\\Lexer',
-                'Doctrine\\Common\\Persistence\\ConnectionRegistry',
-                'Doctrine\\Common\\Persistence\\Proxy',
-                'Doctrine\\Common\\Util\\ClassUtils',
-                'Doctrine\\Bundle\\DoctrineBundle\\Registry',
-            ));
-        }
     }
 
     /**

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Component\Config\FileLocator;
@@ -139,7 +140,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
     protected function loadDbalConnection($name, array $connection, ContainerBuilder $container)
     {
         // configuration
-        $configuration = $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name), new DefinitionDecorator('doctrine.dbal.connection.configuration'));
+        $defitionClassname = $this->getDefinitionClassname();
+
+        $configuration = $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name), new $defitionClassname('doctrine.dbal.connection.configuration'));
         $logger = null;
         if ($connection['logging']) {
             $logger = new Reference('doctrine.dbal.logger');
@@ -147,12 +150,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
         unset ($connection['logging']);
         if ($connection['profiling']) {
             $profilingLoggerId = 'doctrine.dbal.logger.profiling.'.$name;
-            $container->setDefinition($profilingLoggerId, new DefinitionDecorator('doctrine.dbal.logger.profiling'));
+            $container->setDefinition($profilingLoggerId, new $defitionClassname('doctrine.dbal.logger.profiling'));
             $profilingLogger = new Reference($profilingLoggerId);
             $container->getDefinition('data_collector.doctrine')->addMethodCall('addLogger', array($name, $profilingLogger));
 
             if (null !== $logger) {
-                $chainLogger = new DefinitionDecorator('doctrine.dbal.logger.chain');
+                $chainLogger = new $defitionClassname('doctrine.dbal.logger.chain');
                 $chainLogger->addMethodCall('addLogger', array($profilingLogger));
 
                 $loggerId = 'doctrine.dbal.logger.chain.'.$name;
@@ -181,13 +184,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         // event manager
-        $container->setDefinition(sprintf('doctrine.dbal.%s_connection.event_manager', $name), new DefinitionDecorator('doctrine.dbal.connection.event_manager'));
+        $container->setDefinition(sprintf('doctrine.dbal.%s_connection.event_manager', $name), new $defitionClassname('doctrine.dbal.connection.event_manager'));
 
         // connection
         $options = $this->getConnectionOptions($connection);
 
         $def = $container
-            ->setDefinition(sprintf('doctrine.dbal.%s_connection', $name), new DefinitionDecorator('doctrine.dbal.connection'))
+            ->setDefinition(sprintf('doctrine.dbal.%s_connection', $name), new $defitionClassname('doctrine.dbal.connection'))
             ->setArguments(array(
                 $options,
                 new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name)),
@@ -373,7 +376,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function loadOrmEntityManager(array $entityManager, ContainerBuilder $container)
     {
-        $ormConfigDef = $container->setDefinition(sprintf('doctrine.orm.%s_configuration', $entityManager['name']), new DefinitionDecorator('doctrine.orm.configuration'));
+        $definitionClassname = $this->getDefinitionClassname();
+        $ormConfigDef = $container->setDefinition(sprintf('doctrine.orm.%s_configuration', $entityManager['name']), new $definitionClassname('doctrine.orm.configuration'));
 
         $this->loadOrmEntityManagerMappingInformation($entityManager, $ormConfigDef, $container);
         $this->loadOrmCacheDrivers($entityManager, $container);
@@ -463,7 +467,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $managerConfiguratorName = sprintf('doctrine.orm.%s_manager_configurator', $entityManager['name']);
         $container
-            ->setDefinition($managerConfiguratorName, new DefinitionDecorator('doctrine.orm.manager_configurator.abstract'))
+            ->setDefinition($managerConfiguratorName, new $definitionClassname('doctrine.orm.manager_configurator.abstract'))
             ->replaceArgument(0, $enabledFilters)
             ->replaceArgument(1, $filtersParameters)
         ;
@@ -473,7 +477,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         $container
-            ->setDefinition(sprintf('doctrine.orm.%s_entity_manager', $entityManager['name']), new DefinitionDecorator('doctrine.orm.entity_manager.abstract'))
+            ->setDefinition(sprintf('doctrine.orm.%s_entity_manager', $entityManager['name']), new $definitionClassname('doctrine.orm.entity_manager.abstract'))
             ->setArguments(array(
                 new Reference(sprintf('doctrine.dbal.%s_connection', $entityManager['connection'])),
                 new Reference(sprintf('doctrine.orm.%s_configuration', $entityManager['name'])),
@@ -789,5 +793,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
         return new Configuration($container->getParameter('kernel.debug'));
+    }
+
+    /**
+     * @return string
+     */
+    private function getDefinitionClassname(): string
+    {
+        return class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
     }
 }

--- a/Tests/BundleTest.php
+++ b/Tests/BundleTest.php
@@ -14,12 +14,13 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 
-class BundleTest extends \PHPUnit_Framework_TestCase
+class BundleTest extends TestCase
 {
     public function testBuildCompilerPasses()
     {

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -15,10 +15,11 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class CreateDatabaseDoctrineTest extends \PHPUnit_Framework_TestCase
+class CreateDatabaseDoctrineTest extends TestCase
 {
     public function testExecute()
     {

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -55,11 +55,7 @@ class ContainerTest extends TestCase
 
         $this->assertTrue(Type::hasType('test'));
 
-        if (version_compare(PHP_VERSION, '5.3.6', '<')) {
-            $this->assertInstanceOf('Doctrine\DBAL\Event\Listeners\MysqlSessionInit', $container->get('doctrine.dbal.default_connection.events.mysqlsessioninit'));
-        } else {
-            $this->assertFalse($container->has('doctrine.dbal.default_connection.events.mysqlsessioninit'));
-        }
+        $this->assertFalse($container->has('doctrine.dbal.default_connection.events.mysqlsessioninit'));
 
         if (interface_exists('Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface') && class_exists('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor')) {
             $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory', $container->get('doctrine.orm.default_entity_manager.metadata_factory'));

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -14,12 +14,13 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DataCollector;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 
-class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
+class DoctrineDataCollectorTest extends TestCase
 {
     const FIRST_ENTITY = 'TestBundle\Test\Entity\Test1';
     const SECOND_ENTITY = 'TestBundle\Test\Entity\Test2';
@@ -27,7 +28,7 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
     public function testCollectEntities()
     {
         $manager = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
-        $config = $this->getMock('Doctrine\ORM\Configuration');
+        $config = $this->createMock('Doctrine\ORM\Configuration');
         $factory = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory')
             ->setMethods(array('getLoadedMetadata'))->getMockForAbstractClass();
         $collector = $this->createCollector(array('default' => $manager));
@@ -82,7 +83,7 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
      */
     private function createCollector(array $managers)
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry
             ->expects($this->any())
             ->method('getConnectionNames')

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -17,6 +17,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\ORM\Version;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,7 +26,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 
-abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractDoctrineExtensionTest extends TestCase
 {
     abstract protected function loadFromFile(ContainerBuilder $container, $file);
 

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -18,13 +18,14 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\ORM\Version;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 
-class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
+class DoctrineExtensionTest extends TestCase
 {
 
     public function testDbalGenerateDefaultConnectionConfiguration()

--- a/Tests/DependencyInjection/XMLSchemaTest.php
+++ b/Tests/DependencyInjection/XMLSchemaTest.php
@@ -14,7 +14,9 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
-class XMLSchemaTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class XMLSchemaTest extends TestCase
 {
     public static function dataValidateSchemaFiles()
     {

--- a/Tests/Mapping/ContainerAwareEntityListenerResolverTest.php
+++ b/Tests/Mapping/ContainerAwareEntityListenerResolverTest.php
@@ -3,9 +3,10 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Mapping;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerAwareEntityListenerResolver;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ContainerAwareEntityListenerResolverTest extends \PHPUnit_Framework_TestCase
+class ContainerAwareEntityListenerResolverTest extends TestCase
 {
     /**
      * @var ContainerAwareEntityListenerResolver

--- a/Tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/Tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -32,10 +32,11 @@ class DisconnectedMetadataFactoryTest extends TestCase
         $class = new ClassMetadataInfo(__CLASS__);
         $collection = new ClassMetadataCollection(array($class));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $factory = new DisconnectedMetadataFactory($registry);
 
-        $this->setExpectedException('RuntimeException', 'Can\'t find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Can\'t find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest');
         $factory->findNamespaceAndPathForMetadata($collection);
     }
 
@@ -44,7 +45,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
         $class = new ClassMetadataInfo('\Vendor\Package\Class');
         $collection = new ClassMetadataCollection(array($class));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $factory = new DisconnectedMetadataFactory($registry);
 
         $factory->findNamespaceAndPathForMetadata($collection, '/path/to/code');

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -20,7 +20,7 @@ class RegistryTest extends TestCase
 {
     public function testGetDefaultConnectionName()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
         $this->assertEquals('default', $registry->getDefaultConnectionName());
@@ -28,7 +28,7 @@ class RegistryTest extends TestCase
 
     public function testGetDefaultEntityManagerName()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
         $this->assertEquals('default', $registry->getDefaultManagerName());
@@ -36,8 +36,8 @@ class RegistryTest extends TestCase
 
     public function testGetDefaultConnection()
     {
-        $conn = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $conn = $this->createMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.dbal.default_connection'))
@@ -50,8 +50,8 @@ class RegistryTest extends TestCase
 
     public function testGetConnection()
     {
-        $conn = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $conn = $this->createMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.dbal.default_connection'))
@@ -64,16 +64,17 @@ class RegistryTest extends TestCase
 
     public function testGetUnknownConnection()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->setExpectedException('InvalidArgumentException', 'Doctrine ORM Connection named "default" does not exist.');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Doctrine ORM Connection named "default" does not exist.');
         $registry->getConnection('default');
     }
 
     public function testGetConnectionNames()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array('default' => 'doctrine.dbal.default_connection'), array(), 'default', 'default');
 
         $this->assertEquals(array('default' => 'doctrine.dbal.default_connection'), $registry->getConnectionNames());
@@ -82,7 +83,7 @@ class RegistryTest extends TestCase
     public function testGetDefaultEntityManager()
     {
         $em = new \stdClass();
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))
@@ -96,7 +97,7 @@ class RegistryTest extends TestCase
     public function testGetEntityManager()
     {
         $em = new \stdClass();
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))
@@ -109,19 +110,21 @@ class RegistryTest extends TestCase
 
     public function testGetUnknownEntityManager()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->setExpectedException('InvalidArgumentException', 'Doctrine ORM Manager named "default" does not exist.');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Doctrine ORM Manager named "default" does not exist.');
         $registry->getManager('default');
     }
 
     public function testResetUnknownEntityManager()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->setExpectedException('InvalidArgumentException', 'Doctrine ORM Manager named "default" does not exist.');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Doctrine ORM Manager named "default" does not exist.');
         $registry->resetManager('default');
     }
 }

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -17,12 +17,13 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     protected function setUp()
     {

--- a/Tests/Twig/DoctrineExtensionTest.php
+++ b/Tests/Twig/DoctrineExtensionTest.php
@@ -14,8 +14,9 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Twig;
 
 use Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension;
+use PHPUnit\Framework\TestCase;
 
-class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
+class DoctrineExtensionTest extends TestCase
 {
     public function testReplaceQueryParametersWithPostgresCasting()
     {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/console": "~2.7|~3.0|~4.0",
         "symfony/dependency-injection": "~2.7|~3.0|~4.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/console": "~2.7|~3.0|~4.0",
         "symfony/dependency-injection": "~2.7|~3.0|~4.0",
@@ -41,7 +41,7 @@
         "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
         "twig/twig": "~1.12|~2.0",
         "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "~4"
+        "phpunit/phpunit": "^6.1"
     },
     "suggest": {
         "symfony/web-profiler-bundle": "To use the data collector.",


### PR DESCRIPTION
As with ORM itself, the bundle will require PHP 7 in the future. Older Symfony versions may be removed in a separate pull request. I haven't made the effort to use the `::class` constant and short array syntax throughout, I'll leave that for a separate pull request.