### PR TITLE
[Webprofiler] Improve SQL explain table display

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -263,7 +263,7 @@
                                 </div>
 
                                 {% if query.explainable %}
-                                    <div id="explain-{{ i }}-{{ loop.parent.loop.index }}"></div>
+                                    <div id="explain-{{ i }}-{{ loop.parent.loop.index }}" class="sql-explain"></div>
                                 {% endif %}
                             </td>
                         </tr>


### PR DESCRIPTION
Table which is shown in Weprofiler is not clean while values in sql explain table are long.
This PR adds horizontal scroll for long tables. 

**Related PR in Symfony Webprofiler:** https://github.com/symfony/symfony/pull/23706
_(It does not cause any backward compatibility problems)_

**Before:**
![before](https://user-images.githubusercontent.com/2659069/28733410-0ca76826-73ed-11e7-9fea-b3c49a5442ed.gif)


**After:**
![after](https://user-images.githubusercontent.com/2659069/28733415-11b76ae6-73ed-11e7-9e1a-ace661a1cd44.gif)
