### PR TITLE
Register commands using PSR-4 based Service Discovery

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -72,6 +72,20 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $this->adapter->loadServicesConfiguration($container);
 
+        // Use a prototype when the ORM is available.
+        // This avoids listing all ORM commands by hand.
+        if (class_exists(Version::class)) {
+            $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+
+            $prototype = new Definition();
+            $prototype
+                ->setPublic(false)
+                ->addTag('console.command')
+            ;
+
+            $loader->registerClasses($prototype, 'Doctrine\Bundle\DoctrineBundle\Command\\', __DIR__.'/../Command/*');
+        }
+
         if (!empty($config['dbal'])) {
             $this->dbalLoad($config['dbal'], $container);
         }

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -21,6 +21,7 @@ use Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\ORM\Proxy\Autoloader;
+use Doctrine\ORM\Version;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -140,11 +141,8 @@ class DoctrineBundle extends Bundle
      */
     public function registerCommands(Application $application)
     {
-        // Use the default logic when the ORM is available.
-        // This avoids listing all ORM commands by hand.
-        if (class_exists('Doctrine\\ORM\\Version')) {
-            parent::registerCommands($application);
-
+        if (class_exists(Version::class)) {
+            // Commands are registered in the extension
             return;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^7.1",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/console": "~2.7|~3.0|~4.0",
-        "symfony/dependency-injection": "~2.7|~3.0|~4.0",
+        "symfony/dependency-injection": "~3.3|~4.0",
         "doctrine/dbal": "^2.5.12",
         "jdorn/sql-formatter": "~1.1",
         "symfony/doctrine-bridge": "~2.7|~3.0|~4.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+        "symfony/framework-bundle": "~3.0|~4.0",
         "symfony/console": "~2.7|~3.0|~4.0",
         "symfony/dependency-injection": "~3.3|~4.0",
         "doctrine/dbal": "^2.5.12",
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "doctrine/orm": "~2.3",
-        "symfony/yaml": "~2.7|~3.0|~4.0",
+        "symfony/yaml": "~3.3|~4.0",
         "symfony/validator": "~2.7|~3.0|~4.0",
         "symfony/property-info": "~2.8|~3.0|~4.0",
         "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",


### PR DESCRIPTION
Commands auto-registration will be deprecated soon (see https://github.com/symfony/symfony/pull/23805) so we need to stop using it.