### PR TITLE
Add autowiring for Doctrine\DBAL\Connection

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -21,6 +21,7 @@
 
     <services>
         <service id="Doctrine\DBAL\Driver\Connection" alias="database_connection" public="false" />
+        <service id="Doctrine\DBAL\Connection" alias="database_connection" public="false" />
 
         <service id="doctrine.dbal.logger.chain" class="%doctrine.dbal.logger.chain.class%" public="false" abstract="true">
             <call method="addLogger">

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -16,8 +16,12 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Version;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
@@ -28,6 +32,30 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DoctrineExtensionTest extends TestCase
 {
+    public function testAutowiringAlias()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+        $config = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
+
+        $extension->load(array($config), $container);
+
+        $expectedAliases = array(
+            DriverConnection::class => 'database_connection',
+            Connection::class => 'database_connection',
+            ManagerRegistry::class => 'doctrine',
+            ObjectManager::class => 'doctrine.orm.entity_manager',
+            EntityManagerInterface::class => 'doctrine.orm.entity_manager',
+        );
+
+        foreach ($expectedAliases as $id => $target) {
+            $this->assertTrue($container->hasAlias($id), sprintf('The container should have a `%s` alias for autowiring support.', $id));
+
+            $alias = $container->getAlias($id);
+            $this->assertEquals($target, (string) $alias, sprintf('The autowiring for `%s` should use `%s`.', $id, $target));
+            $this->assertFalse($alias->isPublic(), sprintf('The autowiring alias for `%s` should be private.', $id, $target));
+        }
+    }
 
     public function testDbalGenerateDefaultConnectionConfiguration()
     {


### PR DESCRIPTION
Although this is a class rather than an interface, it is the main API of Doctrine DBAL, which has more helper methods than the driver connection interface. So using it in typehints make sense when using these helpers.