### PR TITLE
Add "kernel.reset" tag to "form.type.entity"

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
+use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\Config\FileLocator;
 use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\SymfonyBridgeAdapter;
 use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\CacheProviderLoader;
@@ -321,6 +322,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('orm.xml');
+
+        if (method_exists(DoctrineType::class, 'reset')) {
+            $container->getDefinition('form.type.entity')->addTag('kernel.reset', array('method' => 'reset'));
+        }
 
         $this->entityManagers = array();
         foreach (array_keys($config['entity_managers']) as $name) {

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     },
     "require-dev": {
         "doctrine/orm": "~2.3",
+        "symfony/form": "~2.7|~3.0|~4.0",
         "symfony/yaml": "~2.7|~3.0|~4.0",
         "symfony/validator": "~2.7|~3.0|~4.0",
         "symfony/property-info": "~2.8|~3.0|~4.0",


### PR DESCRIPTION
Not sure if master is the correct branch as this will prevent any non-7.1 user from benefiting from this.
This will leverage the new 3.4 "kernel.reset" tag to reset the cache in DoctrineEntity (parent of EntityClass).
Thus making kernel-in-a-loop better (see https://github.com/symfony/symfony/issues/23984).
Works with https://github.com/symfony/symfony/pull/24232