### PR TITLE
Allow PHP 5.5 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,16 @@ cache:
     - $HOME/.composer/cache
 
 php:
+  - 5.5
+  - 5.6
+  - 7.0
   - 7.1
   - nightly
 
 matrix:
   include:
+    - php: 5.6
+      env: SYMFONY_VERSION="2.8.*@dev"
     - php: 7.1
       env: deps=low SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.1
@@ -33,7 +38,7 @@ install:
   - if [ "$deps" = "low" ]; then composer --prefer-lowest --prefer-stable update; else composer update; fi;
 
 script:
-  - ./vendor/bin/phpunit -v --coverage-clover ./build/logs/clover.xml
+  - ./vendor/bin/simple-phpunit -v --coverage-clover ./build/logs/clover.xml
 
 after_script:
     - php ./vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^5.5.9|^7.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/console": "~2.7|~3.0|~4.0",
         "symfony/dependency-injection": "~2.7|~3.0|~4.0",
@@ -40,8 +40,7 @@
         "symfony/property-info": "~2.8|~3.0|~4.0",
         "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
         "twig/twig": "~1.12|~2.0",
-        "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^6.1"
+        "satooshi/php-coveralls": "^1.0"
     },
     "suggest": {
         "symfony/web-profiler-bundle": "To use the data collector.",


### PR DESCRIPTION
Not allowing php 5.5 for no real reason doesn't play well with Symfony 3.4 LTS, which still supports 5.5.
All Symfony 3.4 users should be allowed to benefit from Symfony 3.4 features that the doctrine bundle could leverage.