### PR TITLE
Fixed for SF > 3.0 on shutdown container create and close connections

### DIFF
--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -119,7 +119,7 @@ class DoctrineBundle extends Bundle
         // Clear all entity managers to clear references to entities for GC
         if ($this->container->hasParameter('doctrine.entity_managers')) {
             foreach ($this->container->getParameter('doctrine.entity_managers') as $id) {
-                if (!$this->container instanceof IntrospectableContainerInterface || $this->container->initialized($id)) {
+                if (!method_exists($this->container, 'initialized') || $this->container->initialized($id)) {
                     $this->container->get($id)->clear();
                 }
             }
@@ -128,7 +128,7 @@ class DoctrineBundle extends Bundle
         // Close all connections to avoid reaching too many connections in the process when booting again later (tests)
         if ($this->container->hasParameter('doctrine.connections')) {
             foreach ($this->container->getParameter('doctrine.connections') as $id) {
-                if (!$this->container instanceof IntrospectableContainerInterface || $this->container->initialized($id)) {
+                if (!method_exists($this->container, 'initialized') || $this->container->initialized($id)) {
                     $this->container->get($id)->close();
                 }
             }


### PR DESCRIPTION
Form SF 3.0 IntrospectableContainerInterface merged with ContainerInterface
SF < 3.0 `initialized` in IntrospectableContainerInterface
SF > 3.0 `initialized` in ContainerInterface