### PR TITLE
Fix profiler query explaining without the templating component

### DIFF
--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -79,10 +79,10 @@ class ProfilerController implements ContainerAwareInterface
             return new Response('This query cannot be explained.');
         }
 
-        return $this->container->get('templating')->renderResponse('@Doctrine/Collector/explain.html.twig', array(
+        return new Response($this->container->get('twig')->render('@Doctrine/Collector/explain.html.twig', array(
             'data' => $results,
             'query' => $query,
-        ));
+        )));
     }
 
     private function explainSQLServerPlatform(Connection $connection, $query)


### PR DESCRIPTION
Fixes #707

Should be backported to 1.6.x too.