### PR TITLE
Fix deprecation with Symfony 3.4

### DIFF
--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -55,10 +55,6 @@ class EntityListenerPass implements CompilerPassInterface
                 if (isset($attributes['lazy']) && $attributes['lazy']) {
                     $listener = $container->findDefinition($id);
 
-                    if (!$listener->isPublic()) {
-                        throw new InvalidArgumentException(sprintf('The service "%s" must be public as this entity listener is lazy-loaded.', $id));
-                    }
-
                     if ($listener->isAbstract()) {
                         throw new InvalidArgumentException(sprintf('The service "%s" must not be abstract as this entity listener is lazy-loaded.', $id));
                     }
@@ -76,6 +72,8 @@ class EntityListenerPass implements CompilerPassInterface
                             sprintf('Lazy-loaded entity listeners can only be resolved by a resolver implementing %s.', $interface)
                         );
                     }
+
+                    $listener->setPublic(true);
 
                     $resolver->addMethodCall('registerService', array($listener->getClass(), $id));
                 } else {

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -47,11 +47,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
     private $defaultConnection;
 
     /**
-     * @var array
-     */
-    private $entityManagers;
-
-    /**
      * @var SymfonyBridgeAdapter
      */
     private $adapter;
@@ -338,14 +333,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $container->getDefinition('form.type.entity')->addTag('kernel.reset', array('method' => 'reset'));
         }
 
-        $this->entityManagers = array();
+        $entityManagers = array();
         foreach (array_keys($config['entity_managers']) as $name) {
-            $this->entityManagers[$name] = sprintf('doctrine.orm.%s_entity_manager', $name);
+            $entityManagers[$name] = sprintf('doctrine.orm.%s_entity_manager', $name);
         }
-        $container->setParameter('doctrine.entity_managers', $this->entityManagers);
+        $container->setParameter('doctrine.entity_managers', $entityManagers);
 
         if (empty($config['default_entity_manager'])) {
-            $tmp = array_keys($this->entityManagers);
+            $tmp = array_keys($entityManagers);
             $config['default_entity_manager'] = reset($tmp);
         }
         $container->setParameter('doctrine.default_entity_manager', $config['default_entity_manager']);

--- a/Registry.php
+++ b/Registry.php
@@ -14,6 +14,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
@@ -38,7 +39,14 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function __construct(ContainerInterface $container, array $connections, array $entityManagers, $defaultConnection, $defaultEntityManager)
     {
-        $this->setContainer($container);
+        $parentTraits = class_uses(parent::class);
+        if (isset($parentTraits[ContainerAwareTrait::class])) {
+            // this case should be removed when Symfony 3.4 becomes the lowest supported version
+            // and then also, the constructor should type-hint Psr\Container\ContainerInterface
+            $this->setContainer($container);
+        } else {
+            $this->container = $container;
+        }
 
         parent::__construct('ORM', $connections, $entityManagers, $defaultConnection, $defaultEntityManager, 'Doctrine\ORM\Proxy\Proxy');
     }

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -891,10 +891,6 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->compileContainer($container);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The service ".*" must be public as this entity listener is lazy-loaded/
-     */
     public function testPrivateLazyEntityListener()
     {
         if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
@@ -909,6 +905,8 @@ abstract class AbstractDoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         $this->loadFromFile($container, 'orm_entity_listener_lazy_private');
 
         $this->compileContainer($container);
+
+        $this->assertTrue($container->getDefinition('doctrine.orm.em1_entity_listener_resolver')->isPublic());
     }
 
     /**


### PR DESCRIPTION
Sibling to https://github.com/symfony/symfony/pull/24409
I chose to made as less changes as possible and not create a PSR-11 service locator in a patch release.