### PR TITLE
`doctrine` service is public

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -123,6 +123,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $this->defaultConnection = $config['default_connection'];
 
         $container->setAlias('database_connection', sprintf('doctrine.dbal.%s_connection', $this->defaultConnection));
+        $container->getAlias('database_connection')->setPublic(true);
         $container->setAlias('doctrine.dbal.event_manager', new Alias(sprintf('doctrine.dbal.%s_connection.event_manager', $this->defaultConnection), false));
 
         $container->setParameter('doctrine.dbal.connection_factory.types', $config['types']);
@@ -351,6 +352,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         $container->setAlias('doctrine.orm.entity_manager', sprintf('doctrine.orm.%s_entity_manager', $config['default_entity_manager']));
+        $container->getAlias('doctrine.orm.entity_manager')->setPublic(true);
 
         $config['entity_managers'] = $this->fixManagersAutoMappings($config['entity_managers'], $container->getParameter('kernel.bundles'));
 

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -56,7 +56,7 @@
 
         <service id="doctrine.dbal.connection.configuration" class="%doctrine.dbal.configuration.class%" public="false" abstract="true" />
 
-        <service id="doctrine" class="%doctrine.class%">
+        <service id="doctrine" class="%doctrine.class%" public="true">
             <argument type="service" id="service_container" />
             <argument>%doctrine.connections%</argument>
             <argument>%doctrine.entity_managers%</argument>

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -56,6 +56,19 @@ class DoctrineExtensionTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testPublicServicesAndAliases()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+        $config = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
+
+        $extension->load(array($config), $container);
+
+        $this->assertTrue($container->getDefinition('doctrine')->isPublic());
+        $this->assertTrue($container->getAlias('doctrine.orm.entity_manager')->isPublic());
+        $this->assertTrue($container->getAlias('database_connection')->isPublic());
+    }
+
     public function testDbalGenerateDefaultConnectionConfiguration()
     {
         $container = $this->getContainer();


### PR DESCRIPTION
As used by [Symfony's `ControllerTrait`](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php#L418-L422), make the `doctrine` service public.