### PR TITLE
Fix Symfony 3.4 auto-registration deprecation

### DIFF
--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -133,4 +133,11 @@ class DoctrineBundle extends Bundle
             }
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function registerCommands(Application $application)
+    {
+    }
 }

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -133,24 +133,4 @@ class DoctrineBundle extends Bundle
             }
         }
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function registerCommands(Application $application)
-    {
-        // Use the default logic when the ORM is available.
-        // This avoids listing all ORM commands by hand.
-        if (class_exists('Doctrine\\ORM\\Version')) {
-            parent::registerCommands($application);
-
-            return;
-        }
-
-        // Register only the DBAL commands if the ORM is not available.
-        $application->add(new CreateDatabaseDoctrineCommand());
-        $application->add(new DropDatabaseDoctrineCommand());
-        $application->add(new RunSqlDoctrineCommand());
-        $application->add(new ImportDoctrineCommand());
-    }
 }

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -70,19 +70,19 @@
         </service>
 
         <!-- commands -->
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
+        <service id="doctrine.database_create_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
             <tag name="console.command" command="doctrine:database:create" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
+        <service id="doctrine.database_drop_command" class="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
             <tag name="console.command" command="doctrine:database:drop" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\GenerateEntitiesDoctrineCommand">
+        <service id="doctrine.generate_entities_command" class="Doctrine\Bundle\DoctrineBundle\Command\GenerateEntitiesDoctrineCommand">
             <tag name="console.command" command="doctrine:generate:entities" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
+        <service id="doctrine.mapping_import_command" class="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
             <tag name="console.command" command="doctrine:mapping:import" />
         </service>
 

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -69,5 +69,22 @@
             <tag name="twig.extension" />
         </service>
 
+        <!-- commands -->
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
+            <tag name="console.command" command="doctrine:database:create" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
+            <tag name="console.command" command="doctrine:database:drop" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\GenerateEntitiesDoctrineCommand">
+            <tag name="console.command" command="doctrine:generate:entities" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
+            <tag name="console.command" command="doctrine:mapping:import" />
+        </service>
+
     </services>
 </container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -136,67 +136,67 @@
         <service id="doctrine.orm.quote_strategy.ansi" class="%doctrine.orm.quote_strategy.ansi.class%" public="false" />
 
         <!-- commands -->
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearMetadataCacheDoctrineCommand">
+        <service id="doctrine.cache_clear_metadata_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearMetadataCacheDoctrineCommand">
             <tag name="console.command" command="doctrine:cache:clear-metadata" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearQueryCacheDoctrineCommand">
+        <service id="doctrine.cache_clear_query_cache_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearQueryCacheDoctrineCommand">
             <tag name="console.command" command="doctrine:cache:clear-query" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearResultCacheDoctrineCommand">
+        <service id="doctrine.cache_clear_result_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearResultCacheDoctrineCommand">
             <tag name="console.command" command="doctrine:cache:clear-result" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CollectionRegionDoctrineCommand">
+        <service id="doctrine.cache_collection_region_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CollectionRegionDoctrineCommand">
             <tag name="console.command" command="doctrine:cache:clear-collection-region" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ConvertMappingDoctrineCommand">
+        <service id="doctrine.mapping_convert_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ConvertMappingDoctrineCommand">
             <tag name="console.command" command="doctrine:mapping:convert" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CreateSchemaDoctrineCommand">
+        <service id="doctrine.schema_create_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CreateSchemaDoctrineCommand">
             <tag name="console.command" command="doctrine:schema:create" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\DropSchemaDoctrineCommand">
+        <service id="doctrine.schema_drop_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\DropSchemaDoctrineCommand">
             <tag name="console.command" command="doctrine:schema:drop" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EnsureProductionSettingsDoctrineCommand">
+        <service id="doctrine.ensure_production_settings_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EnsureProductionSettingsDoctrineCommand">
             <tag name="console.command" command="doctrine:ensure-production-settings" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EntityRegionCacheDoctrineCommand">
+        <service id="doctrine.clear_entity_region_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EntityRegionCacheDoctrineCommand">
             <tag name="console.command" command="doctrine:cache:clear-entity-region" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand">
+        <service id="doctrine.database_import_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand">
             <tag name="console.command" command="doctrine:database:import" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand">
+        <service id="doctrine.mapping_info_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand">
             <tag name="console.command" command="doctrine:mapping:info" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\QueryRegionCacheDoctrineCommand">
+        <service id="doctrine.clear_query_region_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\QueryRegionCacheDoctrineCommand">
             <tag name="console.command" command="doctrine:cache:clear-query-region" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunDqlDoctrineCommand">
+        <service id="doctrine.query_dql_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunDqlDoctrineCommand">
             <tag name="console.command" command="doctrine:query:dql" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand">
+        <service id="doctrine.query_sql_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand">
             <tag name="console.command" command="doctrine:query:sql" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand">
+        <service id="doctrine.schema_update_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand">
             <tag name="console.command" command="doctrine:schema:update" />
         </service>
 
-        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ValidateSchemaCommand">
+        <service id="doctrine.schema_validate_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ValidateSchemaCommand">
             <tag name="console.command" command="doctrine:schema:validate" />
         </service>
 

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -134,5 +134,71 @@
         <!-- quote strategy -->
         <service id="doctrine.orm.quote_strategy.default" class="%doctrine.orm.quote_strategy.default.class%" public="false" />
         <service id="doctrine.orm.quote_strategy.ansi" class="%doctrine.orm.quote_strategy.ansi.class%" public="false" />
+
+        <!-- commands -->
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearMetadataCacheDoctrineCommand">
+            <tag name="console.command" command="doctrine:cache:clear-metadata" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearQueryCacheDoctrineCommand">
+            <tag name="console.command" command="doctrine:cache:clear-query" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearResultCacheDoctrineCommand">
+            <tag name="console.command" command="doctrine:cache:clear-result" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CollectionRegionDoctrineCommand">
+            <tag name="console.command" command="doctrine:cache:clear-collection-region" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ConvertMappingDoctrineCommand">
+            <tag name="console.command" command="doctrine:mapping:convert" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CreateSchemaDoctrineCommand">
+            <tag name="console.command" command="doctrine:schema:create" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\DropSchemaDoctrineCommand">
+            <tag name="console.command" command="doctrine:schema:drop" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EnsureProductionSettingsDoctrineCommand">
+            <tag name="console.command" command="doctrine:ensure-production-settings" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EntityRegionCacheDoctrineCommand">
+            <tag name="console.command" command="doctrine:cache:clear-entity-region" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand">
+            <tag name="console.command" command="doctrine:database:import" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand">
+            <tag name="console.command" command="doctrine:mapping:info" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\QueryRegionCacheDoctrineCommand">
+            <tag name="console.command" command="doctrine:cache:clear-query-region" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunDqlDoctrineCommand">
+            <tag name="console.command" command="doctrine:query:dql" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand">
+            <tag name="console.command" command="doctrine:query:sql" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand">
+            <tag name="console.command" command="doctrine:schema:update" />
+        </service>
+
+        <service id="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ValidateSchemaCommand">
+            <tag name="console.command" command="doctrine:schema:validate" />
+        </service>
+
     </services>
 </container>


### PR DESCRIPTION
Commands auto-registration is deprecated in Symfony 3.4. This PR will avoid `Auto-registration of the command "Doctrine\Bundle\DoctrineCacheBundle\Command\xxx" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead.` exceptions.