### PR TITLE
Throw error in drop command if dbname is refilled

### DIFF
--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -99,6 +99,13 @@ EOT
             // as some vendors do not allow dropping the database connected to.
             $connection->close();
             $connection = DriverManager::getConnection($params);
+            
+            if (isset($connection->getParams()['dbname'])) {
+                $output->writeln('<error>To use this command make sure that dbname is configured as separate parameter and not in the url.</error>');
+
+                return self::RETURN_CODE_NOT_DROP;
+            }
+            
             $shouldDropDatabase = !$ifExists || in_array($name, $connection->getSchemaManager()->listDatabases());
 
             // Only quote if we don't have a path


### PR DESCRIPTION
Fix for #678.

Should I add a separate return code?

Also this could be a BC break for databases that do not require the database to not be opened. Not sure what to do about that. Maybe not throw the error here, try to run it but add a message to the later fail?

The current behavior is a real WTF on postgres - it throws `cannot drop the currently open database` because the code that should prevent it is not working correctly as described in #678.