### PR TITLE
Adding a new option to pull your repositories from the service container

### DIFF
--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class ServiceRepositoryCompilerPass implements CompilerPassInterface
+{
+    const REPOSITORY_SERVICE_TAG = 'doctrine.repository_service';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('doctrine.orm.container_repository_factory')) {
+            return;
+        }
+
+        $locatorDef = $container->findDefinition($container->getDefinition('doctrine.orm.container_repository_factory')->getArgument(0));
+        $repoServiceIds = array_keys($container->findTaggedServiceIds('doctrine.repository_service'));
+        $repoReferences = array_map(function($id) {
+            return new Reference($id);
+        }, $repoServiceIds);
+        $locatorDef->replaceArgument(0, array_combine($repoServiceIds, $repoReferences));
+    }
+}

--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -15,6 +15,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -31,11 +32,13 @@ class ServiceRepositoryCompilerPass implements CompilerPassInterface
             return;
         }
 
-        $locatorDef = $container->findDefinition($container->getDefinition('doctrine.orm.container_repository_factory')->getArgument(0));
+        $locatorDef = $container->getDefinition('doctrine.orm.container_repository_factory');
         $repoServiceIds = array_keys($container->findTaggedServiceIds(self::REPOSITORY_SERVICE_TAG));
         $repoReferences = array_map(function($id) {
             return new Reference($id);
         }, $repoServiceIds);
-        $locatorDef->replaceArgument(0, array_combine($repoServiceIds, $repoReferences));
+
+        $ref = ServiceLocatorTagPass::register($container, array_combine($repoServiceIds, $repoReferences));
+        $locatorDef->replaceArgument(0, $ref);
     }
 }

--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -32,7 +32,7 @@ class ServiceRepositoryCompilerPass implements CompilerPassInterface
         }
 
         $locatorDef = $container->findDefinition($container->getDefinition('doctrine.orm.container_repository_factory')->getArgument(0));
-        $repoServiceIds = array_keys($container->findTaggedServiceIds('doctrine.repository_service'));
+        $repoServiceIds = array_keys($container->findTaggedServiceIds(self::REPOSITORY_SERVICE_TAG));
         $repoReferences = array_map(function($id) {
             return new Reference($id);
         }, $repoServiceIds);

--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -33,6 +33,12 @@ class ServiceRepositoryCompilerPass implements CompilerPassInterface
         }
 
         $locatorDef = $container->getDefinition('doctrine.orm.container_repository_factory');
+
+        if (!class_exists(ServiceLocatorTagPass::class)) {
+            // 3.2 and lower compatibility
+            $locatorDef->replaceArgument(0, new Reference('service_container'));
+        }
+
         $repoServiceIds = array_keys($container->findTaggedServiceIds(self::REPOSITORY_SERVICE_TAG));
         $repoReferences = array_map(function($id) {
             return new Reference($id);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -487,7 +487,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('quote_strategy')->defaultValue('doctrine.orm.quote_strategy.default')->end()
                     ->scalarNode('entity_listener_resolver')->defaultNull()->end()
                     ->scalarNode('repository_factory')->defaultNull()->end()
-                    ->booleanNode('use_service_repositories')->defaultValue(false)->end()
+                    ->booleanNode('use_service_repositories')->defaultFalse()->end()
                 ->end()
                 ->children()
                     ->arrayNode('second_level_cache')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -487,6 +487,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('quote_strategy')->defaultValue('doctrine.orm.quote_strategy.default')->end()
                     ->scalarNode('entity_listener_resolver')->defaultNull()->end()
                     ->scalarNode('repository_factory')->defaultNull()->end()
+                    ->booleanNode('use_service_repositories')->defaultValue(false)->end()
                 ->end()
                 ->children()
                     ->arrayNode('second_level_cache')

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -17,6 +17,7 @@ namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\Repository\EntityRepositoryInterface;
 use Doctrine\ORM\Version;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -446,6 +447,15 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if ($entityManager['use_service_repositories']) {
             if ($entityManager['repository_factory']) {
                 throw new InvalidArgumentException('The "repository_factory" option cannot be set when "use_service_repositories" is set to true.');
+            }
+
+            $serviceRepoFactoryDef = $container->getDefinition('doctrine.orm.container_repository_factory');
+            if (class_exists(ServiceLocatorTagPass::class)) {
+
+                $serviceRepoFactoryDef->replaceArgument(0, new Reference('service_container'));
+            } else {
+                // Symfony 3.2 and lower support
+                $serviceRepoFactoryDef->replaceArgument(0, new Reference('service_container'));
             }
 
             $methods['setRepositoryFactory'] = new Reference('doctrine.orm.container_repository_factory');

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -14,6 +14,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
@@ -54,6 +55,7 @@ class DoctrineBundle extends Bundle
 
         $container->addCompilerPass(new DoctrineValidationPass('orm'));
         $container->addCompilerPass(new EntityListenerPass());
+        $container->addCompilerPass(new ServiceRepositoryCompilerPass());
     }
 
     /**

--- a/Repository/AbstractServiceRepository.php
+++ b/Repository/AbstractServiceRepository.php
@@ -14,8 +14,6 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
-use Doctrine\ORM\EntityRepository;
-
 /**
  * Abstract helper class for creating custom service repository classes.
  *
@@ -24,9 +22,4 @@ use Doctrine\ORM\EntityRepository;
 abstract class AbstractServiceRepository implements EntityRepositoryInterface
 {
     use RepositoryTrait;
-
-    /**
-     * @return EntityRepository
-     */
-    abstract protected function getEntityRepository();
 }

--- a/Repository/AbstractServiceRepository.php
+++ b/Repository/AbstractServiceRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Abstract helper class for creating custom service repository classes.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+abstract class AbstractServiceRepository implements EntityRepositoryInterface
+{
+    use RepositoryTrait;
+
+    /**
+     * @return EntityRepository
+     */
+    abstract protected function getEntityRepository();
+}

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -17,8 +17,8 @@ namespace Doctrine\Bundle\DoctrineBundle\Repository;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Repository\RepositoryFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Psr\Container\ContainerInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * Returns repositories that are registered in the container, or a default implementation.
@@ -31,8 +31,24 @@ final class ContainerRepositoryFactory implements RepositoryFactory
 
     private $genericRepositories = array();
 
-    public function __construct(ContainerInterface $container)
+    /**
+     * @var ContainerInterface|SymfonyContainerInterface $container
+     */
+    public function __construct(/* ContainerInterface */ $container)
     {
+        /*
+         * Compatibility layer for Symfony 3.2 and lower.
+         * When DoctrineBundle requires 3.3 or higher, this can
+         * be removed and the above type-hint added.
+         */
+        if (interface_exists(ContainerInterface::class)) {
+            if (!$container instanceof ContainerInterface) {
+                throw new \InvalidArgumentException(sprintf('Argument 1 passed to %s::__construct() must be an instance of "%s"', self::class, ContainerInterface::class));
+            }
+        } elseif (!$container instanceof SymfonyContainerInterface) {
+            throw new \InvalidArgumentException(sprintf('Argument 1 passed to %s::__construct() must be an instance of "%s"', self::class, SymfonyContainerInterface::class));
+        }
+
         $this->container = $container;
     }
 

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Repository\RepositoryFactory;
+use Psr\Container\ContainerInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * Returns repositories that are registered in the container, or a default implementation.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class ContainerRepositoryFactory implements RepositoryFactory
+{
+    public $container;
+
+    private $registry;
+
+    private $genericRepositories = array();
+
+    public function __construct(ContainerInterface $container, RegistryInterface $registry)
+    {
+        $this->container = $container;
+        $this->registry = $registry;
+    }
+
+    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    {
+        /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
+        $metadata = $entityManager->getClassMetadata($entityName);
+        $entityClass = $metadata->name;
+        $repositoryServiceId = $metadata->customRepositoryClassName;
+
+        if (null !== $repositoryServiceId) {
+            if (!$this->container->has($repositoryServiceId)) {
+                throw new \RuntimeException(sprintf('Could not find the repository service for the "%s" entity. Make sure the "%s" service exists and is tagged with "%s"', $entityName, $repositoryServiceId, ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG));
+            }
+
+            return $this->container->get($repositoryServiceId);
+        }
+
+        $repositoryHash = $entityClass . spl_object_hash($entityManager);
+        if (!isset($this->genericRepositories[$repositoryHash])) {
+            $this->genericRepositories[$repositoryHash] = new DefaultServiceRepository($entityManager, $entityName);
+        }
+
+        return $this->genericRepositories[$repositoryHash];
+    }
+}

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
-class ContainerRepositoryFactory implements RepositoryFactory
+final class ContainerRepositoryFactory implements RepositoryFactory
 {
     public $container;
 

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -29,14 +29,11 @@ class ContainerRepositoryFactory implements RepositoryFactory
 {
     public $container;
 
-    private $registry;
-
     private $genericRepositories = array();
 
-    public function __construct(ContainerInterface $container, RegistryInterface $registry)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-        $this->registry = $registry;
     }
 
     public function getRepository(EntityManagerInterface $entityManager, $entityName)

--- a/Repository/DefaultServiceRepository.php
+++ b/Repository/DefaultServiceRepository.php
@@ -37,13 +37,16 @@ class DefaultServiceRepository implements EntityRepositoryInterface
     }
 
     /**
-     * @return EntityRepository
+     * {@inheritDoc}
      */
-    private function getEntityRepository()
+    protected function getEntityManager()
     {
-        return $this->entityManager->getRepository($this->className);
+        return $this->entityManager;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getClassName()
     {
         return $this->className;

--- a/Repository/DefaultServiceRepository.php
+++ b/Repository/DefaultServiceRepository.php
@@ -41,6 +41,11 @@ class DefaultServiceRepository implements EntityRepositoryInterface
      */
     private function getEntityRepository()
     {
-        return $this->entityManager->getRepository($this->getClassName());
+        return $this->entityManager->getRepository($this->className);
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
     }
 }

--- a/Repository/DefaultServiceRepository.php
+++ b/Repository/DefaultServiceRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Default repository that's used for service repositories.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class DefaultServiceRepository implements EntityRepositoryInterface
+{
+    use RepositoryTrait;
+
+    private $entityManager;
+
+    private $className;
+
+    public function __construct(EntityManagerInterface $entityManager, $className)
+    {
+        $this->entityManager = $entityManager;
+        $this->className = $className;
+    }
+
+    /**
+     * @return EntityRepository
+     */
+    private function getEntityRepository()
+    {
+        return $this->entityManager->getRepository($this->getClassName());
+    }
+}

--- a/Repository/EntityRepositoryInterface.php
+++ b/Repository/EntityRepositoryInterface.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\NativeQuery;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * An interface that all entity repositories should implement.
+ *
+ * This contains all of the public methods found in Doctrine\ORM\EntityRepository
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+interface EntityRepositoryInterface extends ObjectRepository
+{
+    /**
+     * Creates a new QueryBuilder instance that is prepopulated for this entity name.
+     *
+     * @param string $alias
+     * @param string $indexBy The index for the from.
+     *
+     * @return QueryBuilder
+     */
+    public function createQueryBuilder($alias, $indexBy = null);
+
+    /**
+     * Creates a new result set mapping builder for this entity.
+     *
+     * The column naming strategy is "INCREMENT".
+     *
+     * @param string $alias
+     *
+     * @return Query\ResultSetMappingBuilder
+     */
+    public function createResultSetMappingBuilder($alias);
+
+    /**
+     * Creates a new Query instance based on a predefined metadata named query.
+     *
+     * @param string $queryName
+     *
+     * @return Query
+     */
+    public function createNamedQuery($queryName);
+
+    /**
+     * Creates a native SQL query.
+     *
+     * @param string $queryName
+     *
+     * @return NativeQuery
+     */
+    public function createNativeNamedQuery($queryName);
+
+    /**
+     * Clears the repository, causing all managed entities to become detached.
+     *
+     * @return void
+     */
+    public function clear();
+
+    /**
+     * Select all elements from a selectable that match the expression and
+     * return a new collection containing these elements.
+     *
+     * @param \Doctrine\Common\Collections\Criteria $criteria
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function matching(Criteria $criteria);
+}

--- a/Repository/RepositoryTrait.php
+++ b/Repository/RepositoryTrait.php
@@ -15,6 +15,13 @@
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\LazyCriteriaCollection;
+use Doctrine\ORM\NativeQuery;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Doctrine\ORM\QueryBuilder;
 
 /**
  * A helpful trait when creating your own repository.
@@ -24,82 +31,228 @@ use Doctrine\Common\Collections\Criteria;
 trait RepositoryTrait
 {
     /**
-     * {@inheritDoc}
+     * @return EntityManager
+     */
+    abstract protected function getEntityManager();
+
+    /**
+     * Returns the class name for this entity.
+     *
+     * This method is public to more naturally match ObjectRepository.
+     *
+     * @return string
+     */
+    abstract public function getClassName();
+
+    /**
+     * Creates a new QueryBuilder instance that is prepopulated for this entity name.
+     *
+     * @param string $alias
+     * @param string $indexBy The index for the from.
+     *
+     * @return QueryBuilder
      */
     public function createQueryBuilder($alias, $indexBy = null)
     {
-        return $this->getEntityRepository()->createQueryBuilder($alias, $indexBy);
+        return $this->getEntityManager()->createQueryBuilder()
+            ->select($alias)
+            ->from($this->getClassName(), $alias, $indexBy);
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a new result set mapping builder for this entity.
+     *
+     * The column naming strategy is "INCREMENT".
+     *
+     * @param string $alias
+     *
+     * @return ResultSetMappingBuilder
      */
     public function createResultSetMappingBuilder($alias)
     {
-        return $this->getEntityRepository()->createResultSetMappingBuilder($alias);
+        $rsm = new ResultSetMappingBuilder($this->getEntityManager(), ResultSetMappingBuilder::COLUMN_RENAMING_INCREMENT);
+        $rsm->addRootEntityFromClassMetadata($this->getClassName(), $alias);
+
+        return $rsm;
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a new Query instance based on a predefined metadata named query.
+     *
+     * @param string $queryName
+     *
+     * @return Query
      */
     public function createNamedQuery($queryName)
     {
-        return $this->getEntityRepository()->createNamedQuery($queryName);
+        return $this->getEntityManager()->createQuery($this->getClassMetadata()->getNamedQuery($queryName));
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a native SQL query.
+     *
+     * @param string $queryName
+     *
+     * @return NativeQuery
      */
     public function createNativeNamedQuery($queryName)
     {
-        return $this->getEntityRepository()->createNativeNamedQuery($queryName);
+        $queryMapping = $this->getClassMetadata()->getNamedNativeQuery($queryName);
+        $rsm = new Query\ResultSetMappingBuilder($this->getEntityManager());
+        $rsm->addNamedNativeQueryMapping($this->getClassMetadata(), $queryMapping);
+
+        return $this->getEntityManager()->createNativeQuery($queryMapping['query'], $rsm);
     }
 
     /**
-     * {@inheritDoc}
+     * Clears the repository, causing all managed entities to become detached.
+     *
+     * @return void
      */
     public function clear()
     {
-        $this->getEntityRepository()->clear();
+        $this->getEntityManager()->clear($this->getClassMetadata()->rootEntityName);
     }
 
     /**
-     * {@inheritDoc}
+     * Finds an entity by its primary key / identifier.
+     *
+     * @param mixed $id The identifier.
+     * @param int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
+     *                              or NULL if no specific lock mode should be used
+     *                              during the search.
+     * @param int|null $lockVersion The lock version.
+     *
+     * @return object|null The entity instance or NULL if the entity can not be found.
      */
-    public function matching(Criteria $criteria)
+    public function find($id, $lockMode = null, $lockVersion = null)
     {
-        return $this->getEntityRepository()->matching($criteria);
+        return $this->getEntityManager()->find($this->getClassName(), $id, $lockMode, $lockVersion);
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function find($id)
-    {
-        return $this->getEntityRepository()->find($id);
-    }
-
-    /**
-     * {@inheritDoc}
+     * Finds all entities in the repository.
+     *
+     * @return array The entities.
      */
     public function findAll()
     {
-        return $this->getEntityRepository()->findAll();
+        return $this->findBy(array());
     }
 
     /**
-     * {@inheritDoc}
+     * Finds entities by a set of criteria.
+     *
+     * @param array $criteria
+     * @param array|null $orderBy
+     * @param int|null $limit
+     * @param int|null $offset
+     *
+     * @return array The objects.
      */
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
-        return $this->getEntityRepository()->findBy($criteria, $orderBy, $limit, $offset);
+        $persister = $this->getEntityManager()->getUnitOfWork()->getEntityPersister($this->getClassName());
+
+        return $persister->loadAll($criteria, $orderBy, $limit, $offset);
     }
 
     /**
-     * {@inheritDoc}
+     * Finds a single entity by a set of criteria.
+     *
+     * @param array $criteria
+     * @param array|null $orderBy
+     *
+     * @return object|null The entity instance or NULL if the entity can not be found.
      */
-    public function findOneBy(array $criteria)
+    public function findOneBy(array $criteria, array $orderBy = null)
     {
-        return $this->getEntityRepository()->findOneBy($criteria);
+        $persister = $this->getEntityManager()->getUnitOfWork()->getEntityPersister($this->getClassName());
+
+        return $persister->load($criteria, null, null, array(), null, 1, $orderBy);
+    }
+
+    /**
+     * Adds support for magic finders.
+     *
+     * @param string $method
+     * @param array $arguments
+     *
+     * @return array|object The found entity/entities.
+     *
+     * @throws ORMException
+     * @throws \BadMethodCallException If the method called is an invalid find* method
+     *                                 or no find* method at all and therefore an invalid
+     *                                 method call.
+     */
+    public function __call($method, $arguments)
+    {
+        switch (true) {
+            case (0 === strpos($method, 'findBy')):
+                $by = substr($method, 6);
+                $method = 'findBy';
+                break;
+
+            case (0 === strpos($method, 'findOneBy')):
+                $by = substr($method, 9);
+                $method = 'findOneBy';
+                break;
+
+            default:
+                throw new \BadMethodCallException(
+                    "Undefined method '$method'. The method name must start with " .
+                    "either findBy or findOneBy!"
+                );
+        }
+
+        if (empty($arguments)) {
+            throw ORMException::findByRequiresParameter($method . $by);
+        }
+
+        $fieldName = lcfirst(\Doctrine\Common\Util\Inflector::classify($by));
+
+        if ($this->getClassMetadata()->hasField($fieldName) || $this->getClassMetadata()->hasAssociation($fieldName)) {
+            switch (count($arguments)) {
+                case 1:
+                    return $this->$method(array($fieldName => $arguments[0]));
+
+                case 2:
+                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1]);
+
+                case 3:
+                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2]);
+
+                case 4:
+                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2], $arguments[3]);
+
+                default:
+                    // Do nothing
+            }
+        }
+
+        throw ORMException::invalidFindByCall($this->getClassName(), $fieldName, $method . $by);
+    }
+
+    /**
+     * Select all elements from a selectable that match the expression and
+     * return a new collection containing these elements.
+     *
+     * @param \Doctrine\Common\Collections\Criteria $criteria
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function matching(Criteria $criteria)
+    {
+        $persister = $this->getEntityManager()->getUnitOfWork()->getEntityPersister($this->getClassName());
+
+        return new LazyCriteriaCollection($persister, $criteria);
+    }
+
+    /**
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    private function getClassMetadata()
+    {
+        return $this->getEntityManager()->getClassMetadata($this->getClassName());
     }
 }

--- a/Repository/RepositoryTrait.php
+++ b/Repository/RepositoryTrait.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+use Doctrine\Common\Collections\Criteria;
+
+/**
+ * A helpful trait when creating your own repository.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+trait RepositoryTrait
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createQueryBuilder($alias, $indexBy = null)
+    {
+        return $this->getEntityRepository()->createQueryBuilder($alias, $indexBy);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createResultSetMappingBuilder($alias)
+    {
+        return $this->getEntityRepository()->createResultSetMappingBuilder($alias);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createNamedQuery($queryName)
+    {
+        return $this->getEntityRepository()->createNamedQuery($queryName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createNativeNamedQuery($queryName)
+    {
+        return $this->getEntityRepository()->createNativeNamedQuery($queryName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear()
+    {
+        $this->getEntityRepository()->clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function matching(Criteria $criteria)
+    {
+        return $this->getEntityRepository()->matching($criteria);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function find($id)
+    {
+        return $this->getEntityRepository()->find($id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findAll()
+    {
+        return $this->getEntityRepository()->findAll();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+    {
+        return $this->getEntityRepository()->findBy($criteria, $orderBy, $limit, $offset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findOneBy(array $criteria)
+    {
+        return $this->getEntityRepository()->findOneBy($criteria);
+    }
+
+    public function getClassName()
+    {
+        return $this->getEntityRepository()->getClassName();
+    }
+}

--- a/Repository/RepositoryTrait.php
+++ b/Repository/RepositoryTrait.php
@@ -102,9 +102,4 @@ trait RepositoryTrait
     {
         return $this->getEntityRepository()->findOneBy($criteria);
     }
-
-    public function getClassName()
-    {
-        return $this->getEntityRepository()->getClassName();
-    }
 }

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -102,6 +102,17 @@
             <factory class="%doctrine.orm.entity_manager.class%" method="create" />
         </service>
 
+        <service id="doctrine.orm.container_repository_factory" class="Doctrine\Bundle\DoctrineBundle\Repository\ContainerRepositoryFactory" public="false">
+            <argument type="service">
+                <service class="Symfony\Component\DependencyInjection\ServiceLocator">
+                    <tag name="container.service_locator" />
+                    <!-- services specified in compiler pass -->
+                    <argument type="collection" />
+                </service>
+            </argument>
+            <argument type="service" id="doctrine" />
+        </service>
+
         <!-- The configurator cannot be a private service -->
         <service id="doctrine.orm.manager_configurator.abstract" class="%doctrine.orm.manager_configurator.class%" abstract="true">
             <argument type="collection" />

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -110,7 +110,6 @@
                     <argument type="collection" />
                 </service>
             </argument>
-            <argument type="service" id="doctrine" />
         </service>
 
         <!-- The configurator cannot be a private service -->

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -103,13 +103,7 @@
         </service>
 
         <service id="doctrine.orm.container_repository_factory" class="Doctrine\Bundle\DoctrineBundle\Repository\ContainerRepositoryFactory" public="false">
-            <argument type="service">
-                <service class="Symfony\Component\DependencyInjection\ServiceLocator">
-                    <tag name="container.service_locator" />
-                    <!-- services specified in compiler pass -->
-                    <argument type="collection" />
-                </service>
-            </argument>
+            <argument /> <!-- repository locator -->
         </service>
 
         <!-- The configurator cannot be a private service -->

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomRepoEntity.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomRepoRepository")
+ */
+class TestCustomRepoEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TestDefaultRepoEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomRepoRepository.php
@@ -27,7 +27,7 @@ class TestCustomRepoRepository extends AbstractServiceRepository
         $this->registry = $registry;
     }
 
-    protected function getEntityRepository()
+    protected function getEntityManager()
     {
         return $this->registry->getManager();
     }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomRepoRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\AbstractServiceRepository;
+
+class TestCustomRepoRepository extends AbstractServiceRepository
+{
+    protected function getEntityRepository()
+    {
+    }
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomRepoRepository.php
@@ -14,11 +14,26 @@
 
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
+use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Bundle\DoctrineBundle\Repository\AbstractServiceRepository;
+use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomRepoEntity;
 
 class TestCustomRepoRepository extends AbstractServiceRepository
 {
+    private $registry;
+
+    public function __construct(Registry $registry)
+    {
+        $this->registry = $registry;
+    }
+
     protected function getEntityRepository()
     {
+        return $this->registry->getManager();
+    }
+
+    public function getClassName()
+    {
+        return TestCustomRepoEntity::class;
     }
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/RepositoryServiceBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/RepositoryServiceBundle.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Bundles\RepositoryServiceBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class RepositoryServiceBundle extends Bundle
+{
+}

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -18,6 +18,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositor
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Repository\DefaultServiceRepository;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\EntityRepository;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomRepoEntity;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestDefaultRepoEntity;
 use Fixtures\Bundles\RepositoryServiceBundle\RepositoryServiceBundle;
@@ -67,8 +68,6 @@ class ServiceRepositoryTest extends TestCase
         $container->register(TestCustomRepoRepository::class)
             ->addTag('doctrine.repository_service');
 
-        $container->getDefinition('doctrine.orm.container_repository_factory')
-            ->setPublic(true);
         $container->getCompilerPassConfig()->addPass(new ServiceRepositoryCompilerPass());
         $container->compile();
 

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Doctrine\Bundle\DoctrineBundle\Repository\DefaultServiceRepository;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomRepoEntity;
+use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestDefaultRepoEntity;
+use Fixtures\Bundles\RepositoryServiceBundle\RepositoryServiceBundle;
+use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomRepoRepository;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class ServiceRepositoryTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!class_exists('Doctrine\\ORM\\Version')) {
+            $this->markTestSkipped('Doctrine ORM is not available.');
+        }
+    }
+
+    public function testRepositoryServiceWiring()
+    {
+        $container = new ContainerBuilder(new ParameterBag(array(
+            'kernel.name' => 'app',
+            'kernel.debug' => false,
+            'kernel.bundles' => array('RepositoryServiceBundle' => RepositoryServiceBundle::class),
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => 'test',
+            'kernel.root_dir' => __DIR__.'/../../../../', // src dir
+        )));
+        $container->set('annotation_reader', new AnnotationReader());
+        $extension = new DoctrineExtension();
+        $container->registerExtension($extension);
+        $extension->load(array(array(
+            'dbal' => array(
+                'driver' => 'pdo_mysql',
+                'charset' => 'UTF8',
+            ),
+            'orm' => array(
+                'mappings' => array('RepositoryServiceBundle' => array(
+                    'type' => 'annotation',
+                    'dir' => __DIR__.'/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity',
+                    'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Entity',
+                )),
+                'use_service_repositories' => true,
+            ),
+        )), $container);
+
+        $container->register(TestCustomRepoRepository::class)
+            ->addTag('doctrine.repository_service');
+
+        $container->getDefinition('doctrine.orm.container_repository_factory')
+            ->setPublic(true);
+        $container->getCompilerPassConfig()->addPass(new ServiceRepositoryCompilerPass());
+        $container->compile();
+
+        $em = $container->get('doctrine.orm.default_entity_manager');
+        $customRepo = $em->getRepository(TestCustomRepoEntity::class);
+        $this->assertSame($customRepo, $container->get(TestCustomRepoRepository::class));
+
+        $genericRepository = $em->getRepository(TestDefaultRepoEntity::class);
+        $this->assertInstanceOf(DefaultServiceRepository::class, $genericRepository);
+        $this->assertSame($genericRepository, $genericRepository = $em->getRepository(TestDefaultRepoEntity::class));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\DoctrineBundle\\": "" }
     },
+    "autoload-dev": {
+        "psr-4": { "": "Tests/DependencyInjection" }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.7.x-dev"


### PR DESCRIPTION
Hi guys!

tl;dr; This PR will allow users to create *true* repository services  so they can be autowired! Replaces #658.

I would like to stop recommending that people use traditional Doctrine repositories, and instead create normal services for their repository classes: https://blog.fervo.se/blog/2017/07/06/doctrine-repositories-autowiring/

This pull requests makes this much easier by adding:

A) A trait & abstract class to make custom repository classes easy
B) A custom entity repository factory that returns your repository services, instead of creating new `EntityRepository` like normal.

## Example

First, the feature needs to be enabled:

```yml
doctrine:
    orm:
        use_service_repositories: true
```

Suppose we have a `BlogPost` entity and we want a custom repository.

```php
/**
 * @ORM\Entity(repositoryClass="App\Repository\BlogPostRepository")
 */
class BlogPost
{

}
```

Because the feature is enabled, the `repositoryClass` is now actually your repository's service id (which is usually your class name anyways). It should look like this:

```php
class BlogRepository extends AbstractServiceRepository
{
    private $registry;

    public function __construct(RegistryInterface $registry)
    {
        $this->registry = $registry;
    }

    protected function getEntityRepository()
    {
        return $this->registry->getRepository(BlogPost::class);
    }
}
```

The `AbstractServiceRepository` has just one abstract method (`getEntityRepository`) and gives you *all* of the same public functions from `EntityRepository`.

To use the repository, you can now auto-wire the service, or fetch it from the entity manager like normal:

```php
public function indexAction()
{
    $posts = $this->getDoctrine()->getRepository(BlogPost::class)->findAll();
}
```

If you don't want a custom repository, that's fine - we will give you a `DefaultServiceRepository` object, which implements `ObjectRepository` and has all the same methods as `EntityRepository`.

Cheers!