### PR TITLE
Fixing master tests

### DIFF
--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -41,7 +41,7 @@ class ConnectionFactoryTest extends TestCase
         $config       = null;
         $eventManager = null;
         $mappingTypes = [0];
-        $exception    = new DriverException('', $this->createMock('\Doctrine\DBAL\Driver\DriverException'));
+        $exception    = new DriverException('', $this->createMock(Driver\AbstractDriverException::class));
 
         // put the mock into the fake driver
         FakeDriver::$exception = $exception;


### PR DESCRIPTION
Hi guys!

While trying to mock the DriverInterface directly, PhpUnit throws:

> Class cannot implement interface Throwable

from the mocked class. I believe this is just a nice workaround. But if there's a more proper way to fix it, let me know!

Thanks!