### PR TITLE
New Trait to make service repositories very easy

### DIFF
--- a/Repository/RepositoryTrait.php
+++ b/Repository/RepositoryTrait.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NativeQuery;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * A helpful trait when creating your own repository.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+trait RepositoryTrait
+{
+    /**
+     * @return EntityManagerInterface
+     */
+    abstract protected function getEntityManager();
+
+    /**
+     * @return string The class name for your entity.
+     */
+    abstract protected function getClassName();
+
+    /**
+     * @see EntityRepository::createQueryBuilder()
+     *
+     * @param string $alias
+     * @param string $indexBy The index for the from.
+     *
+     * @return QueryBuilder
+     */
+    public function createQueryBuilder($alias, $indexBy = null)
+    {
+        return $this->getRepository()->createQueryBuilder($alias, $indexBy);
+    }
+
+    /**
+     * @see EntityRepository::createResultSetMappingBuilder()
+     *
+     * @param string $alias
+     *
+     * @return ResultSetMappingBuilder
+     */
+    public function createResultSetMappingBuilder($alias)
+    {
+        return $this->getRepository()->createResultSetMappingBuilder($alias);
+    }
+
+    /**
+     * @see EntityRepository::createNamedQuery()
+     *
+     * @param string $queryName
+     *
+     * @return Query
+     */
+    public function createNamedQuery($queryName)
+    {
+        return $this->getRepository()->createNamedQuery($queryName);
+    }
+
+    /**
+     * @see EntityRepository::createNativeNamedQuery()
+     *
+     * @param string $queryName
+     *
+     * @return NativeQuery
+     */
+    public function createNativeNamedQuery($queryName)
+    {
+        return $this->getRepository()->createNativeNamedQuery($queryName);
+    }
+
+    /**
+     * @see EntityRepository::clear()
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->getRepository()->clear();
+    }
+
+    /**
+     * @see EntityRepository::find()
+     *
+     * @param mixed    $id          The identifier.
+     * @param int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
+     *                              or NULL if no specific lock mode should be used
+     *                              during the search.
+     * @param int|null $lockVersion The lock version.
+     *
+     * @return object|null The entity instance or NULL if the entity can not be found.
+     */
+    public function find($id, $lockMode = null, $lockVersion = null)
+    {
+        return $this->getRepository()->find($id, $lockMode, $lockVersion);
+    }
+
+    /**
+     * @see EntityRepository::findAll()
+     *
+     * @return array The entities.
+     */
+    public function findAll()
+    {
+        return $this->getRepository()->findAll();
+    }
+
+    /**
+     * @see EntityRepository::findBy()
+     *
+     * @param array      $criteria
+     * @param array|null $orderBy
+     * @param int|null   $limit
+     * @param int|null   $offset
+     *
+     * @return array The objects.
+     */
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+    {
+        return $this->getRepository()->findBy($criteria, $orderBy, $limit, $offset);
+    }
+
+    /**
+     * @see EntityRepository::findOneBy()
+     *
+     * @param array $criteria
+     * @param array|null $orderBy
+     *
+     * @return object|null The entity instance or NULL if the entity can not be found.
+     */
+    public function findOneBy(array $criteria, array $orderBy = null)
+    {
+        return $this->findBy($criteria, $orderBy);
+    }
+
+    /**
+     * @see EntityRepository::matching()
+     *
+     * @param \Doctrine\Common\Collections\Criteria $criteria
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function matching(Criteria $criteria)
+    {
+        return $this->getRepository()->matching($criteria);
+    }
+
+    /**
+     * @return EntityRepository
+     */
+    private function getRepository()
+    {
+        return $this->getEntityManager()->getRepository($this->getClassName());
+    }
+}

--- a/Tests/Repository/RepositoryTraitTest.php
+++ b/Tests/Repository/RepositoryTraitTest.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Twig;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\RepositoryTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+class RepositoryTraitTest extends TestCase
+{
+    public function testBasicTraitFunctionality()
+    {
+        $em = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
+        $repo = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
+
+        $em->expects($this->once())
+            ->method('getRepository')
+            ->with('App\Entity\CoolStuff')
+            ->will($this->returnValue($repo));
+
+        $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+        $repo->expects($this->once())
+            ->method('createQueryBuilder')
+            ->with('cs')
+            ->willReturn($qb);
+
+        $stubRepo = new StubRepository($em);
+        $this->assertSame($qb, $stubRepo->createQueryBuilder('cs'));
+    }
+}
+
+class StubRepository
+{
+    use RepositoryTrait;
+
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    protected function getEntityManager()
+    {
+        return $this->em;
+    }
+
+    protected function getClassName()
+    {
+        return 'App\Entity\CoolStuff';
+    }
+}


### PR DESCRIPTION
Hi guys!

This is a much simpler approach that replaces #719. The big difference between this and #719 is that the behavior of `$em->getRepository()` is unchanged: it still returns the normal `EntityRepository`. But with the new`RepositoryTrait`, creating a new service that decorates your repository is very easy. And the PR (as you can see) is about 50 times simpler :).

Usage:

* You are still allowed to map a `repositoryClass` on your entity, but generally, you will not (create a service instead).

* Create a repository service:

```php
<?php

namespace App\Repository;

use Doctrine\Bundle\DoctrineBundle\Repository\RepositoryTrait;
use Symfony\Bridge\Doctrine\RegistryInterface;
use App\Entity\CoolStuff;

class CoolStuffRepository
{
    use RepositoryTrait;

    private $registry;

    public function __construct(RegistryInterface $registry)
    {
        $this->registry = $registry;
    }

    // 2 abstract methods to fuel the trait
    protected function getEntityManager()
    {
        return $this->registry->getManager();
    }
    protected function getClassName()
    {
        return CoolStuff::class;
    }

    // add custom methods here
}
```

The `RepositoryTrait` gives you all the existing methods on `EntityRepository`, like `createQueryBuilder()` and `find**` (but no magic methods). If the user wants to make their class implement the `ObjectRepository` interface, that's totally up to them. You can also ignore our trait and create your services all on your own.

To use it, just DI your class like normal. 

For entities with NO custom repository, users can still use `$em->getRepository()`. But when they need custom methods, they would create a custom service and start using it.

Thanks!