### PR TITLE
Reverts the bump from PHP 5 to PHP 7.1: re-adds php 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,19 @@ cache:
     - $HOME/.composer/cache
 
 php:
+  - 5.5
+  - 5.6
+  - 7.0
   - 7.1
   - nightly
 
 matrix:
   include:
-    - php: 7.1
+    - php: 5.5
       env: deps=low SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.1
+    - php: 5.6
+      env: SYMFONY_VERSION="2.8.*@dev"
+    - php: 5.6
       env: deps=dev
   allow_failures:
     - php: nightly

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -808,7 +808,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
     /**
      * @return string
      */
-    private function getDefinitionClassname(): string
+    private function getDefinitionClassname()
     {
         return class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
     }

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -41,7 +41,7 @@ class ConnectionFactoryTest extends TestCase
         $config       = null;
         $eventManager = null;
         $mappingTypes = [0];
-        $exception    = new DriverException('', $this->createMock(Driver\AbstractDriverException::class));
+        $exception    = new DriverException('', $this->getMockBuilder(Driver\AbstractDriverException::class)->disableOriginalConstructor()->getMock());
 
         // put the mock into the fake driver
         FakeDriver::$exception = $exception;

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -28,7 +28,7 @@ class DoctrineDataCollectorTest extends TestCase
     public function testCollectEntities()
     {
         $manager = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
-        $config = $this->createMock('Doctrine\ORM\Configuration');
+        $config = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
         $factory = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory')
             ->setMethods(array('getLoadedMetadata'))->getMockForAbstractClass();
         $collector = $this->createCollector(array('default' => $manager));
@@ -83,7 +83,7 @@ class DoctrineDataCollectorTest extends TestCase
      */
     private function createCollector(array $managers)
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $registry
             ->expects($this->any())
             ->method('getConnectionNames')

--- a/Tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/Tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -27,16 +27,18 @@ class DisconnectedMetadataFactoryTest extends TestCase
         }
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Can't find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest
+     */
     public function testCannotFindNamespaceAndPathForMetadata()
     {
         $class = new ClassMetadataInfo(__CLASS__);
         $collection = new ClassMetadataCollection(array($class));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $factory = new DisconnectedMetadataFactory($registry);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Can\'t find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest');
         $factory->findNamespaceAndPathForMetadata($collection);
     }
 
@@ -45,7 +47,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
         $class = new ClassMetadataInfo('\Vendor\Package\Class');
         $collection = new ClassMetadataCollection(array($class));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $factory = new DisconnectedMetadataFactory($registry);
 
         $factory->findNamespaceAndPathForMetadata($collection, '/path/to/code');

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -20,7 +20,7 @@ class RegistryTest extends TestCase
 {
     public function testGetDefaultConnectionName()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
         $this->assertEquals('default', $registry->getDefaultConnectionName());
@@ -28,7 +28,7 @@ class RegistryTest extends TestCase
 
     public function testGetDefaultEntityManagerName()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
         $this->assertEquals('default', $registry->getDefaultManagerName());
@@ -36,8 +36,8 @@ class RegistryTest extends TestCase
 
     public function testGetDefaultConnection()
     {
-        $conn = $this->createMock('Doctrine\DBAL\Connection', array(), array(), '', false);
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.dbal.default_connection'))
@@ -50,8 +50,8 @@ class RegistryTest extends TestCase
 
     public function testGetConnection()
     {
-        $conn = $this->createMock('Doctrine\DBAL\Connection', array(), array(), '', false);
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.dbal.default_connection'))
@@ -62,19 +62,21 @@ class RegistryTest extends TestCase
         $this->assertSame($conn, $registry->getConnection('default'));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Doctrine ORM Connection named "default" does not exist.
+     */
     public function testGetUnknownConnection()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Doctrine ORM Connection named "default" does not exist.');
         $registry->getConnection('default');
     }
 
     public function testGetConnectionNames()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry = new Registry($container, array('default' => 'doctrine.dbal.default_connection'), array(), 'default', 'default');
 
         $this->assertEquals(array('default' => 'doctrine.dbal.default_connection'), $registry->getConnectionNames());
@@ -83,7 +85,7 @@ class RegistryTest extends TestCase
     public function testGetDefaultEntityManager()
     {
         $em = new \stdClass();
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))
@@ -97,7 +99,7 @@ class RegistryTest extends TestCase
     public function testGetEntityManager()
     {
         $em = new \stdClass();
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))
@@ -108,23 +110,27 @@ class RegistryTest extends TestCase
         $this->assertSame($em, $registry->getManager('default'));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Doctrine ORM Manager named "default" does not exist.
+     */
     public function testGetUnknownEntityManager()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Doctrine ORM Manager named "default" does not exist.');
         $registry->getManager('default');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Doctrine ORM Manager named "default" does not exist.
+     */
     public function testResetUnknownEntityManager()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Doctrine ORM Manager named "default" does not exist.');
         $registry->resetManager('default');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^5.5.9|^7.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/console": "~2.7|~3.0|~4.0",
         "symfony/dependency-injection": "~2.7|~3.0|~4.0",
@@ -41,7 +41,7 @@
         "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
         "twig/twig": "~1.12|~2.0",
         "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^4.8.36|^5.7|^6.4"
     },
     "suggest": {
         "symfony/web-profiler-bundle": "To use the data collector.",


### PR DESCRIPTION
Hi guys!

This bundle was bumped to PHP 7.1 only, but the next version of Symfony (3.4) will still support 5.5. This inconsistency makes the latest version of this bundle not usable by some users (including Ubuntu LTS). This re-adds PHP 5 support without breaking BC.

I believe Fabien (https://github.com/doctrine/DoctrineBundle/pull/725#issuecomment-339421794) is also in favor of this - I don't think it makes sense to bump the version yet, especially when this bundle really isn't using any PHP 7 features.

Thanks!