### PR TITLE
Remove aliases for common interfaces

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -63,7 +63,6 @@
             <argument>%doctrine.default_connection%</argument>
             <argument>%doctrine.default_entity_manager%</argument>
         </service>
-        <service id="Doctrine\Common\Persistence\ManagerRegistry" alias="doctrine" public="false" />
         <service id="Symfony\Bridge\Doctrine\RegistryInterface" alias="doctrine" public="false" />
 
         <service id="doctrine.twig.doctrine_extension" class="Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension" public="false">

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -75,7 +75,6 @@
     </parameters>
 
     <services>
-        <service id="Doctrine\Common\Persistence\ObjectManager" alias="doctrine.orm.entity_manager" public="false" />
         <service id="Doctrine\ORM\EntityManagerInterface" alias="doctrine.orm.entity_manager" public="false" />
 
         <!--- Deprecated Annotation Metadata Reader Service alias, use annotation_reader service -->

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -44,8 +44,6 @@ class DoctrineExtensionTest extends TestCase
         $expectedAliases = array(
             DriverConnection::class => 'database_connection',
             Connection::class => 'database_connection',
-            ManagerRegistry::class => 'doctrine',
-            ObjectManager::class => 'doctrine.orm.entity_manager',
             EntityManagerInterface::class => 'doctrine.orm.entity_manager',
         );
 


### PR DESCRIPTION
#640 added a bunch of aliases for autowiring, but some of them don't make sense because the interfaces might also be implemented by other bundles. Thus, interfaces in `Doctrine\Common` shouldn't be used as service aliases for ORM-specific implementations.

For example, this conflicts with https://github.com/doctrine/DoctrineMongoDBBundle/pull/441 - in order to not confuse people I believe it's best if none of the mappers registers service aliases for the common interfaces.