### PR TITLE
Always register the Entity listener

### DIFF
--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -32,7 +32,7 @@ entity manager it should be registered with. Example:
             </services>
         </container>
 
-If you use a version of doctrine/orm < 2.5 you have to register the entity listener in your entity as well:
+Then you have to register the entity listener in your entity as well:
 
 .. code-block:: php
 


### PR DESCRIPTION
Regardless of doctrine/orm version, you _must_ register the Entity listener in the Entity file. I'm using `symfony/orm-pack: 1.0.4` which points to `doctrine/orm: ^2.4.5` and Listener does not work unless Entity listener is properly declared/registered in Entity class:
```
* @ORM\EntityListeners({"App\Entity\UserListener"})
```