### PR TITLE
Align CS with Doctrine CS 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor
 composer.phar
 composer.lock
 phpunit.xml
+/phpcs.xml
+/.phpcs-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,14 @@ jobs:
         - composer config minimum-stability alpha
         - travis_retry composer update -n --prefer-dist
 
+    - stage: Code Quality
+      env: CODING_STANDARDS
+      php: 7.1
+      install:
+        - travis_retry composer require -n --prefer-dist --dev doctrine/coding-standard:~2.1.0
+      script:
+        - ./vendor/bin/phpcs
+
     - stage: Coverage
       php: 7.2
       before_script:

--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\DBAL\DriverManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Database tool allows you to easily drop and create your configured databases.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class CreateDatabaseDoctrineCommand extends DoctrineCommand
 {
@@ -66,7 +62,7 @@ EOT
             unset($params['global']['dbname']);
             if ($input->getOption('shard')) {
                 foreach ($shards as $i => $shard) {
-                    if ($shard['id'] === (int)$input->getOption('shard')) {
+                    if ($shard['id'] === (int) $input->getOption('shard')) {
                         // Select sharded database
                         $params = array_merge($params, $shard);
                         unset($params['shards'][$i]['dbname'], $params['id']);
@@ -77,8 +73,8 @@ EOT
         }
 
         $hasPath = isset($params['path']);
-        $name = $hasPath ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);
-        if (!$name) {
+        $name    = $hasPath ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);
+        if (! $name) {
             throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
         }
         // Need to get rid of _every_ occurrence of dbname from connection configuration and we have already extracted all relevant info from url
@@ -89,7 +85,7 @@ EOT
         $shouldNotCreateDatabase = $ifNotExists && in_array($name, $tmpConnection->getSchemaManager()->listDatabases());
 
         // Only quote if we don't have a path
-        if (!$hasPath) {
+        if (! $hasPath) {
             $name = $tmpConnection->getDatabasePlatform()->quoteSingleIdentifier($name);
         }
 

--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
 use Doctrine\DBAL\Connection;
@@ -11,8 +10,6 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
 /**
  * Base class for Doctrine console commands to extend from.
- *
- * @author Fabien Potencier <fabien@symfony.com>
  */
 abstract class DoctrineCommand extends ContainerAwareCommand
 {
@@ -37,8 +34,8 @@ abstract class DoctrineCommand extends ContainerAwareCommand
     /**
      * Get a doctrine entity manager by symfony name.
      *
-     * @param string       $name
-     * @param null|integer $shardId
+     * @param string   $name
+     * @param null|int $shardId
      *
      * @return EntityManager
      */
@@ -47,7 +44,7 @@ abstract class DoctrineCommand extends ContainerAwareCommand
         $manager = $this->getContainer()->get('doctrine')->getManager($name);
 
         if ($shardId) {
-            if (!$manager->getConnection() instanceof PoolingShardConnection) {
+            if (! $manager->getConnection() instanceof PoolingShardConnection) {
                 throw new \LogicException(sprintf("Connection of EntityManager '%s' must implement shards configuration.", $name));
             }
 

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
 use Doctrine\DBAL\DriverManager;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Database tool allows you to easily drop and create your configured databases.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class DropDatabaseDoctrineCommand extends DoctrineCommand
 {
@@ -54,7 +50,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $connection = $this->getDoctrineConnection($input->getOption('connection'));
-        $ifExists = $input->getOption('if-exists');
+        $ifExists   = $input->getOption('if-exists');
 
         $params = $connection->getParams();
         if (isset($params['master'])) {
@@ -67,7 +63,7 @@ EOT
             $params = array_merge($params, $params['global']);
             if ($input->getOption('shard')) {
                 foreach ($shards as $shard) {
-                    if ($shard['id'] === (int)$input->getOption('shard')) {
+                    if ($shard['id'] === (int) $input->getOption('shard')) {
                         // Select sharded database
                         $params = $shard;
                         unset($params['id']);
@@ -78,7 +74,7 @@ EOT
         }
 
         $name = isset($params['path']) ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);
-        if (!$name) {
+        if (! $name) {
             throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
         }
         unset($params['dbname']);
@@ -87,11 +83,11 @@ EOT
             // Reopen connection without database name set
             // as some vendors do not allow dropping the database connected to.
             $connection->close();
-            $connection = DriverManager::getConnection($params);
-            $shouldDropDatabase = !$ifExists || in_array($name, $connection->getSchemaManager()->listDatabases());
+            $connection         = DriverManager::getConnection($params);
+            $shouldDropDatabase = ! $ifExists || in_array($name, $connection->getSchemaManager()->listDatabases());
 
             // Only quote if we don't have a path
-            if (!isset($params['path'])) {
+            if (! isset($params['path'])) {
                 $name = $connection->getDatabasePlatform()->quoteSingleIdentifier($name);
             }
 

--- a/Command/GenerateEntitiesDoctrineCommand.php
+++ b/Command/GenerateEntitiesDoctrineCommand.php
@@ -1,20 +1,16 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Doctrine\ORM\Tools\EntityRepositoryGenerator;
 use Doctrine\Bundle\DoctrineBundle\Mapping\DisconnectedMetadataFactory;
+use Doctrine\ORM\Tools\EntityRepositoryGenerator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Generate entity classes from mapping information
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class GenerateEntitiesDoctrineCommand extends DoctrineCommand
 {
@@ -25,7 +21,7 @@ class GenerateEntitiesDoctrineCommand extends DoctrineCommand
     {
         $this
             ->setName('doctrine:generate:entities')
-            ->setAliases(array('generate:doctrine:entities'))
+            ->setAliases(['generate:doctrine:entities'])
             ->setDescription('Generates entity classes and method stubs from your mapping information')
             ->addArgument('name', InputArgument::REQUIRED, 'A bundle name, a namespace, or a class name')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path where to generate entities when it cannot be guessed')
@@ -85,9 +81,10 @@ EOT
             $metadata = $manager->getBundleMetadata($bundle);
         } catch (\InvalidArgumentException $e) {
             $name = strtr($input->getArgument('name'), '/', '\\');
+            $pos  = strpos($name, ':');
 
-            if (false !== $pos = strpos($name, ':')) {
-                $name = $this->getContainer()->get('doctrine')->getAliasNamespace(substr($name, 0, $pos)).'\\'.substr($name, $pos + 1);
+            if ($pos !== false) {
+                $name = $this->getContainer()->get('doctrine')->getAliasNamespace(substr($name, 0, $pos)) . '\\' . substr($name, $pos + 1);
             }
 
             if (class_exists($name)) {
@@ -101,7 +98,7 @@ EOT
 
         $generator = $this->getEntityGenerator();
 
-        $backupExisting = !$input->getOption('no-backup');
+        $backupExisting = ! $input->getOption('no-backup');
         $generator->setBackupExisting($backupExisting);
 
         $repoGenerator = new EntityRepositoryGenerator();
@@ -119,9 +116,9 @@ EOT
             }
 
             $output->writeln(sprintf('  > generating <comment>%s</comment>', $m->name));
-            $generator->generate(array($m), $entityMetadata->getPath());
+            $generator->generate([$m], $entityMetadata->getPath());
 
-            if ($m->customRepositoryClassName && false !== strpos($m->customRepositoryClassName, $metadata->getNamespace())) {
+            if ($m->customRepositoryClassName && strpos($m->customRepositoryClassName, $metadata->getNamespace()) !== false) {
                 $repoGenerator->writeEntityRepositoryClass($m->customRepositoryClassName, $metadata->getPath());
             }
         }

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -1,22 +1,18 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
+use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
-use Doctrine\ORM\Tools\Console\MetadataFilter;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Import Doctrine ORM metadata mapping information from an existing database.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
@@ -66,21 +62,21 @@ EOT
         $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('bundle'));
 
         $destPath = $bundle->getPath();
-        $type = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
-        if ('annotation' === $type) {
+        $type     = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
+        if ($type === 'annotation') {
             $destPath .= '/Entity';
         } else {
             $destPath .= '/Resources/config/doctrine';
         }
-        if ('yaml' === $type) {
+        if ($type === 'yaml') {
             $type = 'yml';
         }
 
-        $cme = new ClassMetadataExporter();
+        $cme      = new ClassMetadataExporter();
         $exporter = $cme->getExporter($type);
         $exporter->setOverwriteExistingFiles($input->getOption('force'));
 
-        if ('annotation' === $type) {
+        if ($type === 'annotation') {
             $entityGenerator = $this->getEntityGenerator();
             $exporter->setEntityGenerator($entityGenerator);
         }
@@ -100,16 +96,17 @@ EOT
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {
-                $className = $class->name;
-                $class->name = $bundle->getNamespace().'\\Entity\\'.$className;
-                if ('annotation' === $type) {
-                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.php';
+                $className   = $class->name;
+                $class->name = $bundle->getNamespace() . '\\Entity\\' . $className;
+                if ($type === 'annotation') {
+                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.php';
                 } else {
-                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.orm.'.$type;
+                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.orm.' . $type;
                 }
                 $output->writeln(sprintf('  > writing <comment>%s</comment>', $path));
                 $code = $exporter->exportClassMetadata($class);
-                if (!is_dir($dir = dirname($path))) {
+                $dir  = dirname($path);
+                if (! is_dir($dir)) {
                     mkdir($dir, 0775, true);
                 }
                 file_put_contents($path, $code);

--- a/Command/Proxy/ClearMetadataCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearMetadataCacheDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to clear the metadata cache of the various cache drivers.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ClearMetadataCacheDoctrineCommand extends MetadataCommand
 {

--- a/Command/Proxy/ClearQueryCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearQueryCacheDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to clear the query cache of the various cache drivers.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ClearQueryCacheDoctrineCommand extends QueryCommand
 {

--- a/Command/Proxy/ClearResultCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearResultCacheDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to clear the result cache of the various cache drivers.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ClearResultCacheDoctrineCommand extends ResultCommand
 {

--- a/Command/Proxy/CollectionRegionDoctrineCommand.php
+++ b/Command/Proxy/CollectionRegionDoctrineCommand.php
@@ -1,14 +1,11 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
 use Doctrine\ORM\Tools\Console\Command\ClearCache\CollectionRegionCommand;
 
 /**
  * Command to clear a collection cache region.
- *
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
 class CollectionRegionDoctrineCommand extends DelegateCommand
 {

--- a/Command/Proxy/ConvertMappingDoctrineCommand.php
+++ b/Command/Proxy/ConvertMappingDoctrineCommand.php
@@ -1,21 +1,17 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand;
 use Doctrine\ORM\Tools\Export\Driver\XmlExporter;
 use Doctrine\ORM\Tools\Export\Driver\YamlExporter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Convert Doctrine ORM metadata mapping information between the various supported
  * formats.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ConvertMappingDoctrineCommand extends ConvertMappingCommand
 {
@@ -48,7 +44,7 @@ class ConvertMappingDoctrineCommand extends ConvertMappingCommand
      */
     protected function getExporter($toType, $destPath)
     {
-        /** @var $exporter \Doctrine\ORM\Tools\Export\Driver\AbstractExporter */
+        /** @var \Doctrine\ORM\Tools\Export\Driver\AbstractExporter $exporter */
         $exporter = parent::getExporter($toType, $destPath);
         if ($exporter instanceof XmlExporter) {
             $exporter->setExtension('.orm.xml');

--- a/Command/Proxy/CreateSchemaDoctrineCommand.php
+++ b/Command/Proxy/CreateSchemaDoctrineCommand.php
@@ -1,19 +1,15 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to execute the SQL needed to generate the database schema for
  * a given entity manager.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class CreateSchemaDoctrineCommand extends CreateCommand
 {

--- a/Command/Proxy/DelegateCommand.php
+++ b/Command/Proxy/DelegateCommand.php
@@ -1,17 +1,15 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
+use Doctrine\ORM\Version;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command Delegate.
- *
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
 abstract class DelegateCommand extends Command
 {
@@ -34,11 +32,11 @@ abstract class DelegateCommand extends Command
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     private function isVersionCompatible()
     {
-        return (version_compare(\Doctrine\ORM\Version::VERSION, $this->getMinimalVersion()) >= 0);
+        return version_compare(Version::VERSION, $this->getMinimalVersion()) >= 0;
     }
 
     /**
@@ -56,7 +54,7 @@ abstract class DelegateCommand extends Command
      */
     protected function wrapCommand($entityManagerName)
     {
-        if (!$this->isVersionCompatible()) {
+        if (! $this->isVersionCompatible()) {
             throw new \RuntimeException(sprintf('"%s" requires doctrine-orm "%s" or newer', $this->getName(), $this->getMinimalVersion()));
         }
 

--- a/Command/Proxy/DoctrineCommandHelper.php
+++ b/Command/Proxy/DoctrineCommandHelper.php
@@ -2,28 +2,25 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 /**
  * Provides some helper and convenience methods to configure doctrine commands in the context of bundles
  * and multiple connections/entity managers.
- *
- * @author Fabien Potencier <fabien@symfony.com>
  */
 abstract class DoctrineCommandHelper
 {
     /**
      * Convenience method to push the helper sets of a given entity manager into the application.
      *
-     * @param Application $application
-     * @param string      $emName
+     * @param string $emName
      */
     public static function setApplicationEntityManager(Application $application, $emName)
     {
-        /** @var $em \Doctrine\ORM\EntityManager */
-        $em = $application->getKernel()->getContainer()->get('doctrine')->getManager($emName);
+        /** @var \Doctrine\ORM\EntityManager $em */
+        $em        = $application->getKernel()->getContainer()->get('doctrine')->getManager($emName);
         $helperSet = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
         $helperSet->set(new EntityManagerHelper($em), 'em');
@@ -32,13 +29,12 @@ abstract class DoctrineCommandHelper
     /**
      * Convenience method to push the helper sets of a given connection into the application.
      *
-     * @param Application $application
-     * @param string      $connName
+     * @param string $connName
      */
     public static function setApplicationConnection(Application $application, $connName)
     {
         $connection = $application->getKernel()->getContainer()->get('doctrine')->getConnection($connName);
-        $helperSet = $application->getHelperSet();
+        $helperSet  = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($connection), 'db');
     }
 }

--- a/Command/Proxy/DropSchemaDoctrineCommand.php
+++ b/Command/Proxy/DropSchemaDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to drop the database schema for a set of classes based on their mappings.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class DropSchemaDoctrineCommand extends DropCommand
 {

--- a/Command/Proxy/EnsureProductionSettingsDoctrineCommand.php
+++ b/Command/Proxy/EnsureProductionSettingsDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Ensure the Doctrine ORM is configured properly for a production environment.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class EnsureProductionSettingsDoctrineCommand extends EnsureProductionSettingsCommand
 {

--- a/Command/Proxy/EntityRegionCacheDoctrineCommand.php
+++ b/Command/Proxy/EntityRegionCacheDoctrineCommand.php
@@ -1,14 +1,11 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
 use Doctrine\ORM\Tools\Console\Command\ClearCache\EntityRegionCommand;
 
 /**
  * Command to clear a entity cache region.
- *
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
 class EntityRegionCacheDoctrineCommand extends DelegateCommand
 {

--- a/Command/Proxy/ImportDoctrineCommand.php
+++ b/Command/Proxy/ImportDoctrineCommand.php
@@ -1,24 +1,14 @@
 <?php
 
-/*
- * This file is part of the Doctrine Bundle
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
 use Doctrine\DBAL\Tools\Console\Command\ImportCommand;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Loads an SQL file and executes it.
- *
- * @author Matthias Pigulla <mp@webfactory.de>
- * @author Sebastian Landwehr <sl@webfactory.de>
  */
 class ImportDoctrineCommand extends ImportCommand
 {

--- a/Command/Proxy/InfoDoctrineCommand.php
+++ b/Command/Proxy/InfoDoctrineCommand.php
@@ -1,17 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
 use Doctrine\ORM\Tools\Console\Command\InfoCommand;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Show information about mapped entities
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
 class InfoDoctrineCommand extends InfoCommand
 {

--- a/Command/Proxy/QueryRegionCacheDoctrineCommand.php
+++ b/Command/Proxy/QueryRegionCacheDoctrineCommand.php
@@ -1,14 +1,11 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
 use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryRegionCommand;
 
 /**
  * Command to clear a query cache region.
- *
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
 class QueryRegionCacheDoctrineCommand extends DelegateCommand
 {

--- a/Command/Proxy/RunDqlDoctrineCommand.php
+++ b/Command/Proxy/RunDqlDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\RunDqlCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Execute a Doctrine DQL query and output the results.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class RunDqlDoctrineCommand extends RunDqlCommand
 {

--- a/Command/Proxy/RunSqlDoctrineCommand.php
+++ b/Command/Proxy/RunSqlDoctrineCommand.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Execute a SQL query and output the results.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class RunSqlDoctrineCommand extends RunSqlCommand
 {

--- a/Command/Proxy/UpdateSchemaDoctrineCommand.php
+++ b/Command/Proxy/UpdateSchemaDoctrineCommand.php
@@ -1,19 +1,15 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to generate the SQL needed to update the database schema to match
  * the current mapping information.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class UpdateSchemaDoctrineCommand extends UpdateCommand
 {

--- a/Command/Proxy/ValidateSchemaCommand.php
+++ b/Command/Proxy/ValidateSchemaCommand.php
@@ -1,19 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand as DoctrineValidateSchemaCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to run Doctrine ValidateSchema() on the current mappings.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
- * @author Neil Katin <symfony@askneil.com>
  */
 class ValidateSchemaCommand extends DoctrineValidateSchemaCommand
 {

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -5,8 +5,8 @@ namespace Doctrine\Bundle\DoctrineBundle;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Types\Type;
 
@@ -15,14 +15,19 @@ use Doctrine\DBAL\Types\Type;
  */
 class ConnectionFactory
 {
-    private $typesConfig = array();
-    private $commentedTypes = array();
+    /** @var mixed[][] */
+    private $typesConfig = [];
+
+    /** @var string[] */
+    private $commentedTypes = [];
+
+    /** @var bool */
     private $initialized = false;
 
     /**
      * Construct.
      *
-     * @param array $typesConfig
+     * @param mixed[][] $typesConfig
      */
     public function __construct(array $typesConfig)
     {
@@ -32,28 +37,26 @@ class ConnectionFactory
     /**
      * Create a connection by name.
      *
-     * @param array         $params
-     * @param Configuration $config
-     * @param EventManager  $eventManager
-     * @param array         $mappingTypes
+     * @param mixed[]         $params
+     * @param string[]|Type[] $mappingTypes
      *
      * @return \Doctrine\DBAL\Connection
      */
-    public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = array())
+    public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = [])
     {
-        if (!$this->initialized) {
+        if (! $this->initialized) {
             $this->initializeTypes();
         }
 
         $connection = DriverManager::getConnection($params, $config, $eventManager);
 
-        if (!empty($mappingTypes)) {
+        if (! empty($mappingTypes)) {
             $platform = $this->getDatabasePlatform($connection);
             foreach ($mappingTypes as $dbType => $doctrineType) {
                 $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
             }
         }
-        if (!empty($this->commentedTypes)) {
+        if (! empty($this->commentedTypes)) {
             $platform = $this->getDatabasePlatform($connection);
             foreach ($this->commentedTypes as $type) {
                 $platform->markDoctrineTypeCommented(Type::getType($type));
@@ -70,7 +73,6 @@ class ConnectionFactory
      * and the platform version is unknown.
      * For details have a look at DoctrineBundle issue #673.
      *
-     * @param  \Doctrine\DBAL\Connection $connection
      *
      * @return \Doctrine\DBAL\Platforms\AbstractPlatform
      * @throws \Doctrine\DBAL\DBALException
@@ -82,10 +84,10 @@ class ConnectionFactory
         } catch (DBALException $driverException) {
             if ($driverException instanceof DriverException) {
                 throw new DBALException(
-                    "An exception occured while establishing a connection to figure out your platform version." . PHP_EOL .
+                    'An exception occured while establishing a connection to figure out your platform version.' . PHP_EOL .
                     "You can circumvent this by setting a 'server_version' configuration value" . PHP_EOL . PHP_EOL .
-                    "For further information have a look at:" . PHP_EOL .
-                    "https://github.com/doctrine/DoctrineBundle/issues/673",
+                    'For further information have a look at:' . PHP_EOL .
+                    'https://github.com/doctrine/DoctrineBundle/issues/673',
                     0,
                     $driverException
                 );

--- a/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -1,15 +1,5 @@
 <?php
 
-/*
- * This file is part of the Doctrine Bundle
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass;
@@ -21,8 +11,6 @@ use Symfony\Component\DependencyInjection\Reference;
  * auto-mapped folder.
  *
  * NOTE: alias is only supported by Symfony 2.6+ and will be ignored with older versions.
- *
- * @author David Buchmann <david@liip.ch>
  */
 class DoctrineOrmMappingsPass extends RegisterMappingsPass
 {
@@ -41,7 +29,7 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
      *                                                container.
      * @param array                $aliasMap          Map of alias to namespace.
      */
-    public function __construct($driver, array $namespaces, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
+    public function __construct($driver, array $namespaces, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
         $managerParameters[] = 'doctrine.default_entity_manager';
         parent::__construct(
@@ -57,45 +45,45 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
     }
 
     /**
-     * @param array    $namespaces        Hashmap of directory path to namespace.
-     * @param string[] $managerParameters List of parameters that could which object manager name
-     *                                    your bundle uses. This compiler pass will automatically
-     *                                    append the parameter name for the default entity manager
-     *                                    to this list.
-     * @param string|false   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
-     * @param string[] $aliasMap          Map of alias to namespace.
+     * @param array        $namespaces        Hashmap of directory path to namespace.
+     * @param string[]     $managerParameters List of parameters that could which object manager name
+     *                                        your bundle uses. This compiler pass will automatically
+     *                                        append the parameter name for the default entity manager
+     *                                        to this list.
+     * @param string|false $enabledParameter  Service container parameter that must be present to
+     *                                  enable the mapping. Set to false to not do any check,
+     *                                  optional.
+     * @param string[]     $aliasMap          Map of alias to namespace.
      *
      * @return self
      */
-    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
+    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
-        $arguments = array($namespaces, '.orm.xml');
-        $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
-        $driver = new Definition('Doctrine\ORM\Mapping\Driver\XmlDriver', array($locator));
+        $arguments = [$namespaces, '.orm.xml'];
+        $locator   = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
+        $driver    = new Definition('Doctrine\ORM\Mapping\Driver\XmlDriver', [$locator]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**
-     * @param array    $namespaces        Hashmap of directory path to namespace
-     * @param string[] $managerParameters List of parameters that could which object manager name
-     *                                    your bundle uses. This compiler pass will automatically
-     *                                    append the parameter name for the default entity manager
-     *                                    to this list.
-     * @param string|false   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
-     * @param string[] $aliasMap          Map of alias to namespace.
+     * @param array        $namespaces        Hashmap of directory path to namespace
+     * @param string[]     $managerParameters List of parameters that could which object manager name
+     *                                        your bundle uses. This compiler pass will automatically
+     *                                        append the parameter name for the default entity manager
+     *                                        to this list.
+     * @param string|false $enabledParameter  Service container parameter that must be present to
+     *                                  enable the mapping. Set to false to not do any check,
+     *                                  optional.
+     * @param string[]     $aliasMap          Map of alias to namespace.
      *
      * @return self
      */
-    public static function createYamlMappingDriver(array $namespaces, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
+    public static function createYamlMappingDriver(array $namespaces, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
-        $arguments = array($namespaces, '.orm.yml');
-        $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
-        $driver = new Definition('Doctrine\ORM\Mapping\Driver\YamlDriver', array($locator));
+        $arguments = [$namespaces, '.orm.yml'];
+        $locator   = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
+        $driver    = new Definition('Doctrine\ORM\Mapping\Driver\YamlDriver', [$locator]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -113,54 +101,54 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
      *
      * @return self
      */
-    public static function createPhpMappingDriver(array $namespaces, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
+    public static function createPhpMappingDriver(array $namespaces, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
-        $arguments = array($namespaces, '.php');
-        $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
-        $driver = new Definition('Doctrine\Common\Persistence\Mapping\Driver\PHPDriver', array($locator));
+        $arguments = [$namespaces, '.php'];
+        $locator   = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
+        $driver    = new Definition('Doctrine\Common\Persistence\Mapping\Driver\PHPDriver', [$locator]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**
-     * @param array    $namespaces        List of namespaces that are handled with annotation mapping
-     * @param array    $directories       List of directories to look for annotated classes
-     * @param string[] $managerParameters List of parameters that could which object manager name
-     *                                    your bundle uses. This compiler pass will automatically
-     *                                    append the parameter name for the default entity manager
-     *                                    to this list.
-     * @param string|false   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
-     * @param string[] $aliasMap          Map of alias to namespace.
+     * @param array        $namespaces        List of namespaces that are handled with annotation mapping
+     * @param array        $directories       List of directories to look for annotated classes
+     * @param string[]     $managerParameters List of parameters that could which object manager name
+     *                                        your bundle uses. This compiler pass will automatically
+     *                                        append the parameter name for the default entity manager
+     *                                        to this list.
+     * @param string|false $enabledParameter  Service container parameter that must be present to
+     *                                  enable the mapping. Set to false to not do any check,
+     *                                  optional.
+     * @param string[]     $aliasMap          Map of alias to namespace.
      *
      * @return self
      */
-    public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
+    public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
         $reader = new Reference('annotation_reader');
-        $driver = new Definition('Doctrine\ORM\Mapping\Driver\AnnotationDriver', array($reader, $directories));
+        $driver = new Definition('Doctrine\ORM\Mapping\Driver\AnnotationDriver', [$reader, $directories]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**
-     * @param array    $namespaces        List of namespaces that are handled with static php mapping
-     * @param array    $directories       List of directories to look for static php mapping files
-     * @param string[] $managerParameters List of parameters that could which object manager name
-     *                                    your bundle uses. This compiler pass will automatically
-     *                                    append the parameter name for the default entity manager
-     *                                    to this list.
-     * @param string|false   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
-     * @param string[] $aliasMap          Map of alias to namespace.
+     * @param array        $namespaces        List of namespaces that are handled with static php mapping
+     * @param array        $directories       List of directories to look for static php mapping files
+     * @param string[]     $managerParameters List of parameters that could which object manager name
+     *                                        your bundle uses. This compiler pass will automatically
+     *                                        append the parameter name for the default entity manager
+     *                                        to this list.
+     * @param string|false $enabledParameter  Service container parameter that must be present to
+     *                                  enable the mapping. Set to false to not do any check,
+     *                                  optional.
+     * @param string[]     $aliasMap          Map of alias to namespace.
      *
      * @return self
      */
-    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
+    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
-        $driver = new Definition('Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver', array($directories));
+        $driver = new Definition('Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver', [$directories]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }

--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -1,26 +1,14 @@
 <?php
 
-/*
- * This file is part of the Doctrine Bundle
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Class for Symfony bundles to register entity listeners
- *
- * @author Sander Marechal <s.marechal@jejik.com>
  */
 class EntityListenerPass implements CompilerPassInterface
 {
@@ -33,16 +21,16 @@ class EntityListenerPass implements CompilerPassInterface
 
         foreach ($resolvers as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
-                $name = isset($attributes['entity_manager']) ? $attributes['entity_manager'] : $container->getParameter('doctrine.default_entity_manager');
+                $name          = isset($attributes['entity_manager']) ? $attributes['entity_manager'] : $container->getParameter('doctrine.default_entity_manager');
                 $entityManager = sprintf('doctrine.orm.%s_entity_manager', $name);
 
-                if (!$container->hasDefinition($entityManager)) {
+                if (! $container->hasDefinition($entityManager)) {
                     continue;
                 }
 
                 $resolverId = sprintf('doctrine.orm.%s_entity_listener_resolver', $name);
 
-                if (!$container->has($resolverId)) {
+                if (! $container->has($resolverId)) {
                     continue;
                 }
 
@@ -61,14 +49,14 @@ class EntityListenerPass implements CompilerPassInterface
                     }
 
                     $interface = 'Doctrine\\Bundle\\DoctrineBundle\\Mapping\\EntityListenerServiceResolver';
-                    $class = $resolver->getClass();
+                    $class     = $resolver->getClass();
 
                     if (substr($class, 0, 1) === '%') {
                         // resolve container parameter first
                         $class = $container->getParameterBag()->resolveValue($resolver->getClass());
                     }
 
-                    if (!is_a($class, $interface, true)) {
+                    if (! is_a($class, $interface, true)) {
                         throw new InvalidArgumentException(
                             sprintf('Lazy-loaded entity listeners can only be resolved by a resolver implementing %s.', $interface)
                         );
@@ -76,9 +64,9 @@ class EntityListenerPass implements CompilerPassInterface
 
                     $listener->setPublic(true);
 
-                    $resolver->addMethodCall('registerService', array($listener->getClass(), $id));
+                    $resolver->addMethodCall('registerService', [$listener->getClass(), $id]);
                 } else {
-                    $resolver->addMethodCall('register', array(new Reference($id)));
+                    $resolver->addMethodCall('register', [new Reference($id)]);
                 }
             }
         }
@@ -88,17 +76,17 @@ class EntityListenerPass implements CompilerPassInterface
     {
         $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $name);
 
-        if (!$container->has($listenerId)) {
+        if (! $container->has($listenerId)) {
             return;
         }
 
         $serviceDef = $container->getDefinition($id);
 
-        $args = array(
+        $args = [
             $attributes['entity'],
             $serviceDef->getClass(),
             $attributes['event'],
-        );
+        ];
 
         if (isset($attributes['method'])) {
             $args[] = $attributes['method'];

--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -9,9 +8,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * @author Ryan Weaver <ryan@knpuniversity.com>
- */
 final class ServiceRepositoryCompilerPass implements CompilerPassInterface
 {
     const REPOSITORY_SERVICE_TAG = 'doctrine.repository_service';
@@ -19,7 +15,7 @@ final class ServiceRepositoryCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         // when ORM is not enabled
-        if (!$container->hasDefinition('doctrine.orm.container_repository_factory')) {
+        if (! $container->hasDefinition('doctrine.orm.container_repository_factory')) {
             return;
         }
 
@@ -28,8 +24,8 @@ final class ServiceRepositoryCompilerPass implements CompilerPassInterface
         $repoServiceIds = array_keys($container->findTaggedServiceIds(self::REPOSITORY_SERVICE_TAG));
 
         // Symfony 3.2 and lower sanity check
-        if (!class_exists(ServiceLocatorTagPass::class)) {
-            if (!empty($repoServiceIds)) {
+        if (! class_exists(ServiceLocatorTagPass::class)) {
+            if (! empty($repoServiceIds)) {
                 throw new RuntimeException(sprintf('The "%s" tag can only be used with Symfony 3.3 or higher. Remove the tag from the following services (%s) or upgrade to Symfony 3.3 or higher.', self::REPOSITORY_SERVICE_TAG, implode(', ', $repoServiceIds)));
             }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -12,17 +11,16 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *
  * This information is solely responsible for how the different configuration
  * sections are normalized, and merged.
- *
- * @author Christophe Coevoet <stof@notk.org>
  */
 class Configuration implements ConfigurationInterface
 {
+    /** @var bool */
     private $debug;
 
     /**
      * Constructor
      *
-     * @param Boolean $debug Whether to use the debug mode
+     * @param bool $debug Whether to use the debug mode
      */
     public function __construct($debug)
     {
@@ -35,7 +33,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('doctrine');
+        $rootNode    = $treeBuilder->root('doctrine');
 
         $this->addDbalSection($rootNode);
         $this->addOrmSection($rootNode);
@@ -45,8 +43,6 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Add DBAL section to configuration tree
-     *
-     * @param ArrayNodeDefinition $node
      */
     private function addDbalSection(ArrayNodeDefinition $node)
     {
@@ -54,11 +50,13 @@ class Configuration implements ConfigurationInterface
             ->children()
             ->arrayNode('dbal')
                 ->beforeNormalization()
-                    ->ifTrue(function ($v) { return is_array($v) && !array_key_exists('connections', $v) && !array_key_exists('connection', $v); })
+                    ->ifTrue(function ($v) {
+                        return is_array($v) && ! array_key_exists('connections', $v) && ! array_key_exists('connection', $v);
+                    })
                     ->then(function ($v) {
                         // Key that should not be rewritten to the connection config
-                        $excludedKeys = array('default_connection' => true, 'types' => true, 'type' => true);
-                        $connection = array();
+                        $excludedKeys = ['default_connection' => true, 'types' => true, 'type' => true];
+                        $connection   = [];
                         foreach ($v as $key => $value) {
                             if (isset($excludedKeys[$key])) {
                                 continue;
@@ -67,7 +65,7 @@ class Configuration implements ConfigurationInterface
                             unset($v[$key]);
                         }
                         $v['default_connection'] = isset($v['default_connection']) ? (string) $v['default_connection'] : 'default';
-                        $v['connections'] = array($v['default_connection'] => $connection);
+                        $v['connections']        = [$v['default_connection'] => $connection];
 
                         return $v;
                     })
@@ -82,7 +80,9 @@ class Configuration implements ConfigurationInterface
                         ->prototype('array')
                             ->beforeNormalization()
                                 ->ifString()
-                                ->then(function ($v) { return array('class' => $v); })
+                                ->then(function ($v) {
+                                    return ['class' => $v];
+                                })
                             ->end()
                             ->children()
                                 ->scalarNode('class')->isRequired()->end()
@@ -105,9 +105,9 @@ class Configuration implements ConfigurationInterface
     private function getDbalConnectionsNode()
     {
         $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('connections');
+        $node        = $treeBuilder->root('connections');
 
-        /** @var $connectionNode ArrayNodeDefinition */
+        /** @var ArrayNodeDefinition $connectionNode */
         $connectionNode = $node
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
@@ -180,8 +180,6 @@ class Configuration implements ConfigurationInterface
      * Adds config keys related to params processed by the DBAL drivers
      *
      * These keys are available for slave configurations too.
-     *
-     * @param ArrayNodeDefinition $node
      */
     private function configureDbalDriverNode(ArrayNodeDefinition $node)
     {
@@ -205,7 +203,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('servicename')
                     ->info(
-                        'Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter '.
+                        'Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter ' .
                         'for Oracle depending on the service parameter.'
                     )
                 ->end()
@@ -217,13 +215,13 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('sslmode')
                     ->info(
-                        'Determines whether or with what priority a SSL TCP/IP connection will be negotiated with '.
+                        'Determines whether or with what priority a SSL TCP/IP connection will be negotiated with ' .
                         'the server for PostgreSQL.'
                     )
                 ->end()
                 ->scalarNode('sslrootcert')
                     ->info(
-                        'The name of a file containing SSL certificate authority (CA) certificate(s). '.
+                        'The name of a file containing SSL certificate authority (CA) certificate(s). ' .
                         'If the file exists, the server\'s certificate will be verified to be signed by one of these authorities.'
                     )
                 ->end()
@@ -232,22 +230,24 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('use_savepoints')->info('Use savepoints for nested transactions')->end()
                 ->scalarNode('instancename')
                 ->info(
-                    'Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection.'.
-                    ' It is generally used to connect to an Oracle RAC server to select the name'.
+                    'Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection.' .
+                    ' It is generally used to connect to an Oracle RAC server to select the name' .
                     ' of a particular instance.'
                 )
                 ->end()
                 ->scalarNode('connectstring')
                 ->info(
-                    'Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.'.
-                    'When using this option, you will still need to provide the user and password parameters, but the other '.
-                    'parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods'.
+                    'Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.' .
+                    'When using this option, you will still need to provide the user and password parameters, but the other ' .
+                    'parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods' .
                     ' from Doctrine\DBAL\Connection will no longer function as expected.'
                 )
                 ->end()
             ->end()
             ->beforeNormalization()
-                ->ifTrue(function ($v) {return !isset($v['sessionMode']) && isset($v['session_mode']);})
+                ->ifTrue(function ($v) {
+                    return ! isset($v['sessionMode']) && isset($v['session_mode']);
+                })
                 ->then(function ($v) {
                     $v['sessionMode'] = $v['session_mode'];
                     unset($v['session_mode']);
@@ -256,7 +256,9 @@ class Configuration implements ConfigurationInterface
                 })
             ->end()
             ->beforeNormalization()
-                ->ifTrue(function ($v) {return !isset($v['MultipleActiveResultSets']) && isset($v['multiple_active_result_sets']);})
+                ->ifTrue(function ($v) {
+                    return ! isset($v['MultipleActiveResultSets']) && isset($v['multiple_active_result_sets']);
+                })
                 ->then(function ($v) {
                     $v['MultipleActiveResultSets'] = $v['multiple_active_result_sets'];
                     unset($v['multiple_active_result_sets']);
@@ -269,8 +271,6 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Add the ORM section to configuration tree
-     *
-     * @param ArrayNodeDefinition $node
      */
     private function addOrmSection(ArrayNodeDefinition $node)
     {
@@ -280,16 +280,21 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('orm')
                     ->beforeNormalization()
-                        ->ifTrue(function ($v) { return null === $v || (is_array($v) && !array_key_exists('entity_managers', $v) && !array_key_exists('entity_manager', $v)); })
+                        ->ifTrue(function ($v) {
+                            return $v === null || (is_array($v) && ! array_key_exists('entity_managers', $v) && ! array_key_exists('entity_manager', $v));
+                        })
                         ->then(function ($v) {
                             $v = (array) $v;
                             // Key that should not be rewritten to the connection config
-                            $excludedKeys = array(
-                                'default_entity_manager' => true, 'auto_generate_proxy_classes' => true,
-                                'proxy_dir' => true, 'proxy_namespace' => true, 'resolve_target_entities' => true,
+                            $excludedKeys  = [
+                                'default_entity_manager' => true,
+                            'auto_generate_proxy_classes' => true,
+                                'proxy_dir' => true,
+                            'proxy_namespace' => true,
+                            'resolve_target_entities' => true,
                                 'resolve_target_entity' => true,
-                            );
-                            $entityManager = array();
+                            ];
+                            $entityManager = [];
                             foreach ($v as $key => $value) {
                                 if (isset($excludedKeys[$key])) {
                                     continue;
@@ -298,7 +303,7 @@ class Configuration implements ConfigurationInterface
                                 unset($v[$key]);
                             }
                             $v['default_entity_manager'] = isset($v['default_entity_manager']) ? (string) $v['default_entity_manager'] : 'default';
-                            $v['entity_managers'] = array($v['default_entity_manager'] => $entityManager);
+                            $v['entity_managers']        = [$v['default_entity_manager'] => $entityManager];
 
                             return $v;
                         })
@@ -328,7 +333,7 @@ class Configuration implements ConfigurationInterface
                             ->validate()
                                 ->ifString()
                                 ->then(function ($v) {
-                                    return constant('Doctrine\Common\Proxy\AbstractProxyFactory::AUTOGENERATE_'.strtoupper($v));
+                                    return constant('Doctrine\Common\Proxy\AbstractProxyFactory::AUTOGENERATE_' . strtoupper($v));
                                 })
                             ->end()
                         ->end()
@@ -352,7 +357,7 @@ class Configuration implements ConfigurationInterface
     private function getOrmTargetEntityResolverNode()
     {
         $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('resolve_target_entities');
+        $node        = $treeBuilder->root('resolve_target_entities');
 
         $node
             ->useAttributeAsKey('interface')
@@ -371,49 +376,51 @@ class Configuration implements ConfigurationInterface
      */
     private function getOrmEntityListenersNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('entity_listeners');
+        $builder    = new TreeBuilder();
+        $node       = $builder->root('entity_listeners');
         $normalizer = function ($mappings) {
-            $entities = array();
+            $entities = [];
 
             foreach ($mappings as $entityClass => $mapping) {
-                $listeners = array();
+                $listeners = [];
 
                 foreach ($mapping as $listenerClass => $listenerEvent) {
-                    $events = array();
+                    $events = [];
 
                     foreach ($listenerEvent as $eventType => $eventMapping) {
                         if ($eventMapping === null) {
-                            $eventMapping = array(null);
+                            $eventMapping = [null];
                         }
 
                         foreach ($eventMapping as $method) {
-                            $events[] = array(
+                            $events[] = [
                                'type' => $eventType,
                                'method' => $method,
-                            );
+                            ];
                         }
                     }
 
-                    $listeners[] = array(
+                    $listeners[] = [
                         'class' => $listenerClass,
                         'event' => $events,
-                    );
+                    ];
                 }
 
-                $entities[] = array(
+                $entities[] = [
                     'class' => $entityClass,
                     'listener' => $listeners,
-                );
+                ];
             }
 
-            return array('entities' => $entities);
+            return ['entities' => $entities];
         };
 
         $node
             ->beforeNormalization()
                 // Yaml normalization
-                ->ifTrue(function ($v) { return is_array(reset($v)) && is_string(key(reset($v))); })
+                ->ifTrue(function ($v) {
+                    return is_array(reset($v)) && is_string(key(reset($v)));
+                })
                 ->then($normalizer)
             ->end()
             ->fixXmlConfig('entity', 'entities')
@@ -456,7 +463,7 @@ class Configuration implements ConfigurationInterface
     private function getOrmEntityManagersNode()
     {
         $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('entity_managers');
+        $node        = $treeBuilder->root('entity_managers');
 
         $node
             ->requiresAtLeastOneElement()
@@ -532,10 +539,12 @@ class Configuration implements ConfigurationInterface
                         ->prototype('array')
                             ->beforeNormalization()
                                 ->ifString()
-                                ->then(function ($v) { return array('type' => $v); })
+                                ->then(function ($v) {
+                                    return ['type' => $v];
+                                })
                             ->end()
-                            ->treatNullLike(array())
-                            ->treatFalseLike(array('mapping' => false))
+                            ->treatNullLike([])
+                            ->treatFalseLike(['mapping' => false])
                             ->performNoDeepMerging()
                             ->children()
                                 ->scalarNode('mapping')->defaultValue(true)->end()
@@ -575,7 +584,9 @@ class Configuration implements ConfigurationInterface
                         ->prototype('array')
                             ->beforeNormalization()
                                 ->ifString()
-                                ->then(function ($v) { return array('class' => $v); })
+                                ->then(function ($v) {
+                                    return ['class' => $v];
+                                })
                             ->end()
                             ->beforeNormalization()
                                 // The content of the XML node is returned as the "value" key so we need to rename it
@@ -617,13 +628,15 @@ class Configuration implements ConfigurationInterface
     private function getOrmCacheDriverNode($name)
     {
         $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root($name);
+        $node        = $treeBuilder->root($name);
 
         $node
             ->addDefaultsIfNotSet()
             ->beforeNormalization()
                 ->ifString()
-                ->then(function ($v) { return array('type' => $v); })
+                ->then(function ($v) {
+                    return ['type' => $v];
+                })
             ->end()
             ->children()
                 ->scalarNode('type')->defaultValue('array')->end()
@@ -649,22 +662,22 @@ class Configuration implements ConfigurationInterface
     private function getAutoGenerateModes()
     {
         $constPrefix = 'AUTOGENERATE_';
-        $prefixLen = strlen($constPrefix);
-        $refClass = new \ReflectionClass('Doctrine\Common\Proxy\AbstractProxyFactory');
+        $prefixLen   = strlen($constPrefix);
+        $refClass    = new \ReflectionClass('Doctrine\Common\Proxy\AbstractProxyFactory');
         $constsArray = $refClass->getConstants();
-        $namesArray = array();
-        $valuesArray = array();
+        $namesArray  = [];
+        $valuesArray = [];
 
         foreach ($constsArray as $key => $value) {
             if (strpos($key, $constPrefix) === 0) {
-                $namesArray[] = substr($key, $prefixLen);
+                $namesArray[]  = substr($key, $prefixLen);
                 $valuesArray[] = (int) $value;
             }
         }
 
-        return array(
+        return [
             'names' => $namesArray,
             'values' => $valuesArray,
-        );
+        ];
     }
 }

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -1,35 +1,28 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
+use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\CacheProviderLoader;
+use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\SymfonyBridgeAdapter;
 use Doctrine\ORM\Version;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
-use Symfony\Component\DependencyInjection\Alias;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
-use Symfony\Component\DependencyInjection\ChildDefinition;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\Config\FileLocator;
-use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\SymfonyBridgeAdapter;
-use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\CacheProviderLoader;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Form\AbstractType;
 
 /**
  * DoctrineExtension is an extension for the Doctrine DBAL and ORM library.
- *
- * @author Jonathan H. Wage <jonwage@gmail.com>
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
- * @author Kinn Coelho Julião <kinncj@php.net>
  */
 class DoctrineExtension extends AbstractDoctrineExtension
 {
@@ -43,9 +36,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     private $adapter;
 
-    /**
-     * @param SymfonyBridgeAdapter $adapter
-     */
     public function __construct(SymfonyBridgeAdapter $adapter = null)
     {
         $this->adapter = $adapter ?: new SymfonyBridgeAdapter(new CacheProviderLoader(), 'doctrine.orm', 'orm');
@@ -57,20 +47,20 @@ class DoctrineExtension extends AbstractDoctrineExtension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = $this->getConfiguration($configs, $container);
-        $config = $this->processConfiguration($configuration, $configs);
+        $config        = $this->processConfiguration($configuration, $configs);
 
         $this->adapter->loadServicesConfiguration($container);
 
-        if (!empty($config['dbal'])) {
+        if (! empty($config['dbal'])) {
             $this->dbalLoad($config['dbal'], $container);
         }
 
-        if (!empty($config['orm'])) {
+        if (! empty($config['orm'])) {
             if (empty($config['dbal'])) {
                 throw new \LogicException('Configuring the ORM layer requires to configure the DBAL layer as well.');
             }
 
-            if (!class_exists('Doctrine\ORM\Version')) {
+            if (! class_exists('Doctrine\ORM\Version')) {
                 throw new \LogicException('To configure the ORM layer, you must first install the doctrine/orm package.');
             }
 
@@ -90,11 +80,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function dbalLoad(array $config, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('dbal.xml');
 
         if (empty($config['default_connection'])) {
-            $keys = array_keys($config['connections']);
+            $keys                         = array_keys($config['connections']);
             $config['default_connection'] = reset($keys);
         }
 
@@ -106,7 +96,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $container->setParameter('doctrine.dbal.connection_factory.types', $config['types']);
 
-        $connections = array();
+        $connections = [];
 
         foreach (array_keys($config['connections']) as $name) {
             $connections[$name] = sprintf('doctrine.dbal.%s_connection', $name);
@@ -133,22 +123,22 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $definitionClassname = $this->getDefinitionClassname();
 
         $configuration = $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name), new $definitionClassname('doctrine.dbal.connection.configuration'));
-        $logger = null;
+        $logger        = null;
         if ($connection['logging']) {
             $logger = new Reference('doctrine.dbal.logger');
         }
-        unset ($connection['logging']);
+        unset($connection['logging']);
         if ($connection['profiling']) {
-            $profilingLoggerId = 'doctrine.dbal.logger.profiling.'.$name;
+            $profilingLoggerId = 'doctrine.dbal.logger.profiling.' . $name;
             $container->setDefinition($profilingLoggerId, new $definitionClassname('doctrine.dbal.logger.profiling'));
             $profilingLogger = new Reference($profilingLoggerId);
-            $container->getDefinition('data_collector.doctrine')->addMethodCall('addLogger', array($name, $profilingLogger));
+            $container->getDefinition('data_collector.doctrine')->addMethodCall('addLogger', [$name, $profilingLogger]);
 
-            if (null !== $logger) {
+            if ($logger !== null) {
                 $chainLogger = new $definitionClassname('doctrine.dbal.logger.chain');
-                $chainLogger->addMethodCall('addLogger', array($profilingLogger));
+                $chainLogger->addMethodCall('addLogger', [$profilingLogger]);
 
-                $loggerId = 'doctrine.dbal.logger.chain.'.$name;
+                $loggerId = 'doctrine.dbal.logger.chain.' . $name;
                 $container->setDefinition($loggerId, $chainLogger);
                 $logger = new Reference($loggerId);
             } else {
@@ -158,19 +148,19 @@ class DoctrineExtension extends AbstractDoctrineExtension
         unset($connection['profiling']);
 
         if (isset($connection['auto_commit'])) {
-            $configuration->addMethodCall('setAutoCommit', array($connection['auto_commit']));
+            $configuration->addMethodCall('setAutoCommit', [$connection['auto_commit']]);
         }
 
         unset($connection['auto_commit']);
 
         if (isset($connection['schema_filter']) && $connection['schema_filter']) {
-            $configuration->addMethodCall('setFilterSchemaAssetsExpression', array($connection['schema_filter']));
+            $configuration->addMethodCall('setFilterSchemaAssetsExpression', [$connection['schema_filter']]);
         }
 
         unset($connection['schema_filter']);
 
         if ($logger) {
-            $configuration->addMethodCall('setSQLLogger', array($logger));
+            $configuration->addMethodCall('setSQLLogger', [$logger]);
         }
 
         // event manager
@@ -182,12 +172,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $def = $container
             ->setDefinition(sprintf('doctrine.dbal.%s_connection', $name), new $definitionClassname('doctrine.dbal.connection'))
             ->setPublic(true)
-            ->setArguments(array(
+            ->setArguments([
                 $options,
                 new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name)),
                 new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $name)),
                 $connection['mapping_types'],
-            ))
+            ])
         ;
 
         // Set class in case "wrapper_class" option was used to assist IDEs
@@ -195,15 +185,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $def->setClass($options['wrapperClass']);
         }
 
-        if (!empty($connection['use_savepoints'])) {
-            $def->addMethodCall('setNestTransactionsWithSavepoints', array($connection['use_savepoints']));
+        if (! empty($connection['use_savepoints'])) {
+            $def->addMethodCall('setNestTransactionsWithSavepoints', [$connection['use_savepoints']]);
         }
 
         // Create a shard_manager for this connection
         if (isset($options['shards'])) {
-            $shardManagerDefinition = new Definition($options['shardManagerClass'], array(
-                new Reference(sprintf('doctrine.dbal.%s_connection', $name))
-            ));
+            $shardManagerDefinition = new Definition($options['shardManagerClass'], [new Reference(sprintf('doctrine.dbal.%s_connection', $name))]);
             $container->setDefinition(sprintf('doctrine.dbal.%s_shard_manager', $name), $shardManagerDefinition);
         }
     }
@@ -223,7 +211,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             unset($options['shard_choser_service']);
         }
 
-        foreach (array(
+        foreach ([
             'options' => 'driverOptions',
             'driver_class' => 'driverClass',
             'wrapper_class' => 'wrapperClass',
@@ -232,26 +220,36 @@ class DoctrineExtension extends AbstractDoctrineExtension
             'shard_manager_class' => 'shardManagerClass',
             'server_version' => 'serverVersion',
             'default_table_options' => 'defaultTableOptions',
-        ) as $old => $new) {
+        ] as $old => $new) {
             if (isset($options[$old])) {
                 $options[$new] = $options[$old];
                 unset($options[$old]);
             }
         }
 
-        if (!empty($options['slaves']) && !empty($options['shards'])) {
+        if (! empty($options['slaves']) && ! empty($options['shards'])) {
             throw new InvalidArgumentException('Sharding and master-slave connection cannot be used together');
         }
 
-        if (!empty($options['slaves'])) {
-            $nonRewrittenKeys = array(
-                'driver' => true, 'driverOptions' => true, 'driverClass' => true,
-                'wrapperClass' => true, 'keepSlave' => true, 'shardChoser' => true,
-                'platform' => true, 'slaves' => true, 'master' => true, 'shards' => true,
+        if (! empty($options['slaves'])) {
+            $nonRewrittenKeys = [
+                'driver' => true,
+            'driverOptions' => true,
+            'driverClass' => true,
+                'wrapperClass' => true,
+            'keepSlave' => true,
+            'shardChoser' => true,
+                'platform' => true,
+            'slaves' => true,
+            'master' => true,
+            'shards' => true,
                 'serverVersion' => true,
                 // included by safety but should have been unset already
-                'logging' => true, 'profiling' => true, 'mapping_types' => true, 'platform_service' => true,
-            );
+                'logging' => true,
+            'profiling' => true,
+            'mapping_types' => true,
+            'platform_service' => true,
+            ];
             foreach ($options as $key => $value) {
                 if (isset($nonRewrittenKeys[$key])) {
                     continue;
@@ -267,15 +265,25 @@ class DoctrineExtension extends AbstractDoctrineExtension
             unset($options['slaves']);
         }
 
-        if (!empty($options['shards'])) {
-            $nonRewrittenKeys = array(
-                'driver' => true, 'driverOptions' => true, 'driverClass' => true,
-                'wrapperClass' => true, 'keepSlave' => true, 'shardChoser' => true,
-                'platform' => true, 'slaves' => true, 'global' => true, 'shards' => true,
+        if (! empty($options['shards'])) {
+            $nonRewrittenKeys = [
+                'driver' => true,
+            'driverOptions' => true,
+            'driverClass' => true,
+                'wrapperClass' => true,
+            'keepSlave' => true,
+            'shardChoser' => true,
+                'platform' => true,
+            'slaves' => true,
+            'global' => true,
+            'shards' => true,
                 'serverVersion' => true,
                 // included by safety but should have been unset already
-                'logging' => true, 'profiling' => true, 'mapping_types' => true, 'platform_service' => true,
-            );
+                'logging' => true,
+            'profiling' => true,
+            'mapping_types' => true,
+            'platform_service' => true,
+            ];
             foreach ($options as $key => $value) {
                 if (isset($nonRewrittenKeys[$key])) {
                     continue;
@@ -310,28 +318,28 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function ormLoad(array $config, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('orm.xml');
 
         if (class_exists(AbstractType::class) && method_exists(DoctrineType::class, 'reset')) {
-            $container->getDefinition('form.type.entity')->addTag('kernel.reset', array('method' => 'reset'));
+            $container->getDefinition('form.type.entity')->addTag('kernel.reset', ['method' => 'reset']);
         }
 
-        $entityManagers = array();
+        $entityManagers = [];
         foreach (array_keys($config['entity_managers']) as $name) {
             $entityManagers[$name] = sprintf('doctrine.orm.%s_entity_manager', $name);
         }
         $container->setParameter('doctrine.entity_managers', $entityManagers);
 
         if (empty($config['default_entity_manager'])) {
-            $tmp = array_keys($entityManagers);
+            $tmp                              = array_keys($entityManagers);
             $config['default_entity_manager'] = reset($tmp);
         }
         $container->setParameter('doctrine.default_entity_manager', $config['default_entity_manager']);
 
-        $options = array('auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
+        $options = ['auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace'];
         foreach ($options as $key) {
-            $container->setParameter('doctrine.orm.'.$key, $config[$key]);
+            $container->setParameter('doctrine.orm.' . $key, $config[$key]);
         }
 
         $container->setAlias('doctrine.orm.entity_manager', sprintf('doctrine.orm.%s_entity_manager', $config['default_entity_manager']));
@@ -354,15 +362,17 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if ($config['resolve_target_entities']) {
             $def = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
             foreach ($config['resolve_target_entities'] as $name => $implementation) {
-                $def->addMethodCall('addResolveTargetEntity', array(
-                    $name, $implementation, array(),
-                ));
+                $def->addMethodCall('addResolveTargetEntity', [
+                    $name,
+                $implementation,
+                [],
+                ]);
             }
 
             // BC: ResolveTargetEntityListener implements the subscriber interface since
             // v2.5.0-beta1 (Commit 437f812)
             if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
-                $def->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+                $def->addTag('doctrine.event_listener', ['event' => 'loadClassMetadata']);
             } else {
                 $def->addTag('doctrine.event_subscriber');
             }
@@ -397,7 +407,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
     protected function loadOrmEntityManager(array $entityManager, ContainerBuilder $container)
     {
         $definitionClassname = $this->getDefinitionClassname();
-        $ormConfigDef = $container->setDefinition(sprintf('doctrine.orm.%s_configuration', $entityManager['name']), new $definitionClassname('doctrine.orm.configuration'));
+        $ormConfigDef        = $container->setDefinition(sprintf('doctrine.orm.%s_configuration', $entityManager['name']), new $definitionClassname('doctrine.orm.configuration'));
 
         $this->loadOrmEntityManagerMappingInformation($entityManager, $ormConfigDef, $container);
         $this->loadOrmCacheDrivers($entityManager, $container);
@@ -410,35 +420,35 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $container->setDefinition(sprintf('doctrine.orm.%s_entity_listener_resolver', $entityManager['name']), $definition);
         }
 
-        $methods = array(
+        $methods = [
             'setMetadataCacheImpl' => new Reference(sprintf('doctrine.orm.%s_metadata_cache', $entityManager['name'])),
             'setQueryCacheImpl' => new Reference(sprintf('doctrine.orm.%s_query_cache', $entityManager['name'])),
             'setResultCacheImpl' => new Reference(sprintf('doctrine.orm.%s_result_cache', $entityManager['name'])),
-            'setMetadataDriverImpl' => new Reference('doctrine.orm.'.$entityManager['name'].'_metadata_driver'),
+            'setMetadataDriverImpl' => new Reference('doctrine.orm.' . $entityManager['name'] . '_metadata_driver'),
             'setProxyDir' => '%doctrine.orm.proxy_dir%',
             'setProxyNamespace' => '%doctrine.orm.proxy_namespace%',
             'setAutoGenerateProxyClasses' => '%doctrine.orm.auto_generate_proxy_classes%',
             'setClassMetadataFactoryName' => $entityManager['class_metadata_factory_name'],
             'setDefaultRepositoryClassName' => $entityManager['default_repository_class'],
-        );
+        ];
         // check for version to keep BC
-        if (version_compare(Version::VERSION, "2.3.0-DEV") >= 0) {
-            $methods = array_merge($methods, array(
+        if (version_compare(Version::VERSION, '2.3.0-DEV') >= 0) {
+            $methods = array_merge($methods, [
                 'setNamingStrategy' => new Reference($entityManager['naming_strategy']),
                 'setQuoteStrategy' => new Reference($entityManager['quote_strategy']),
-            ));
+            ]);
         }
 
-        if (version_compare(Version::VERSION, "2.4.0-DEV") >= 0) {
-            $methods = array_merge($methods, array(
+        if (version_compare(Version::VERSION, '2.4.0-DEV') >= 0) {
+            $methods = array_merge($methods, [
                 'setEntityListenerResolver' => new Reference(sprintf('doctrine.orm.%s_entity_listener_resolver', $entityManager['name'])),
-            ));
+            ]);
         }
 
-        if (version_compare(Version::VERSION, "2.5.0-DEV") >= 0) {
-            $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
-            $listenerDef = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
-            $listenerTagParams = array('event' => 'loadClassMetadata');
+        if (version_compare(Version::VERSION, '2.5.0-DEV') >= 0) {
+            $listenerId        = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $entityManager['name']);
+            $listenerDef       = $container->setDefinition($listenerId, new Definition('%doctrine.orm.listeners.attach_entity_listeners.class%'));
+            $listenerTagParams = ['event' => 'loadClassMetadata'];
             if (isset($entityManager['connection'])) {
                 $listenerTagParams['connection'] = $entityManager['connection'];
             }
@@ -454,29 +464,29 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         foreach ($methods as $method => $arg) {
-            $ormConfigDef->addMethodCall($method, array($arg));
+            $ormConfigDef->addMethodCall($method, [$arg]);
         }
 
         foreach ($entityManager['hydrators'] as $name => $class) {
-            $ormConfigDef->addMethodCall('addCustomHydrationMode', array($name, $class));
+            $ormConfigDef->addMethodCall('addCustomHydrationMode', [$name, $class]);
         }
 
-        if (!empty($entityManager['dql'])) {
+        if (! empty($entityManager['dql'])) {
             foreach ($entityManager['dql']['string_functions'] as $name => $function) {
-                $ormConfigDef->addMethodCall('addCustomStringFunction', array($name, $function));
+                $ormConfigDef->addMethodCall('addCustomStringFunction', [$name, $function]);
             }
             foreach ($entityManager['dql']['numeric_functions'] as $name => $function) {
-                $ormConfigDef->addMethodCall('addCustomNumericFunction', array($name, $function));
+                $ormConfigDef->addMethodCall('addCustomNumericFunction', [$name, $function]);
             }
             foreach ($entityManager['dql']['datetime_functions'] as $name => $function) {
-                $ormConfigDef->addMethodCall('addCustomDatetimeFunction', array($name, $function));
+                $ormConfigDef->addMethodCall('addCustomDatetimeFunction', [$name, $function]);
             }
         }
 
-        $enabledFilters = array();
-        $filtersParameters = array();
+        $enabledFilters    = [];
+        $filtersParameters = [];
         foreach ($entityManager['filters'] as $name => $filter) {
-            $ormConfigDef->addMethodCall('addFilter', array($name, $filter['class']));
+            $ormConfigDef->addMethodCall('addFilter', [$name, $filter['class']]);
             if ($filter['enabled']) {
                 $enabledFilters[] = $name;
             }
@@ -492,18 +502,18 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ->replaceArgument(1, $filtersParameters)
         ;
 
-        if (!isset($entityManager['connection'])) {
+        if (! isset($entityManager['connection'])) {
             $entityManager['connection'] = $this->defaultConnection;
         }
 
         $container
             ->setDefinition(sprintf('doctrine.orm.%s_entity_manager', $entityManager['name']), new $definitionClassname('doctrine.orm.entity_manager.abstract'))
             ->setPublic(true)
-            ->setArguments(array(
+            ->setArguments([
                 new Reference(sprintf('doctrine.dbal.%s_connection', $entityManager['connection'])),
                 new Reference(sprintf('doctrine.orm.%s_configuration', $entityManager['name'])),
-            ))
-            ->setConfigurator(array(new Reference($managerConfiguratorName), 'configure'))
+            ])
+            ->setConfigurator([new Reference($managerConfiguratorName), 'configure'])
         ;
 
         $container->setAlias(
@@ -512,7 +522,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         );
 
         if (isset($entityManager['entity_listeners'])) {
-            if (!isset($listenerDef)) {
+            if (! isset($listenerDef)) {
                 throw new InvalidArgumentException('Entity listeners configuration requires doctrine-orm 2.5.0 or newer');
             }
 
@@ -522,15 +532,17 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 foreach ($entity['listeners'] as $listenerClass => $listener) {
                     foreach ($listener['events'] as $listenerEvent) {
                         $listenerEventName = $listenerEvent['type'];
-                        $listenerMethod = $listenerEvent['method'];
+                        $listenerMethod    = $listenerEvent['method'];
 
-                        $listenerDef->addMethodCall('addEntityListener', array(
-                            $entityListenerClass, $listenerClass, $listenerEventName, $listenerMethod,
-                        ));
+                        $listenerDef->addMethodCall('addEntityListener', [
+                            $entityListenerClass,
+                        $listenerClass,
+                        $listenerEventName,
+                        $listenerMethod,
+                        ]);
                     }
                 }
             }
-
         }
     }
 
@@ -570,13 +582,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
     protected function loadOrmEntityManagerMappingInformation(array $entityManager, Definition $ormConfigDef, ContainerBuilder $container)
     {
         // reset state of drivers and alias map. They are only used by this methods and children.
-        $this->drivers = array();
-        $this->aliasMap = array();
+        $this->drivers  = [];
+        $this->aliasMap = [];
 
         $this->loadMappingInformation($entityManager, $container);
         $this->registerMappingDrivers($entityManager, $container);
 
-        $ormConfigDef->addMethodCall('setEntityNamespaces', array($this->aliasMap));
+        $ormConfigDef->addMethodCall('setEntityNamespaces', [$this->aliasMap]);
     }
 
     /**
@@ -614,50 +626,50 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         $driverId = null;
-        $enabled = $entityManager['second_level_cache']['enabled'];
+        $enabled  = $entityManager['second_level_cache']['enabled'];
 
         if (isset($entityManager['second_level_cache']['region_cache_driver'])) {
             $driverName = 'second_level_cache.region_cache_driver';
-            $driverMap = $entityManager['second_level_cache']['region_cache_driver'];
-            $driverId = $this->loadCacheDriver($driverName, $entityManager['name'], $driverMap, $container);
+            $driverMap  = $entityManager['second_level_cache']['region_cache_driver'];
+            $driverId   = $this->loadCacheDriver($driverName, $entityManager['name'], $driverMap, $container);
         }
 
-        $configId = sprintf('doctrine.orm.%s_second_level_cache.cache_configuration', $entityManager['name']);
-        $regionsId = sprintf('doctrine.orm.%s_second_level_cache.regions_configuration', $entityManager['name']);
-        $driverId = $driverId ?: sprintf('doctrine.orm.%s_second_level_cache.region_cache_driver', $entityManager['name']);
-        $configDef = $container->setDefinition($configId, new Definition('%doctrine.orm.second_level_cache.cache_configuration.class%'));
+        $configId   = sprintf('doctrine.orm.%s_second_level_cache.cache_configuration', $entityManager['name']);
+        $regionsId  = sprintf('doctrine.orm.%s_second_level_cache.regions_configuration', $entityManager['name']);
+        $driverId   = $driverId ?: sprintf('doctrine.orm.%s_second_level_cache.region_cache_driver', $entityManager['name']);
+        $configDef  = $container->setDefinition($configId, new Definition('%doctrine.orm.second_level_cache.cache_configuration.class%'));
         $regionsDef = $container->setDefinition($regionsId, new Definition('%doctrine.orm.second_level_cache.regions_configuration.class%'));
 
         $slcFactoryId = sprintf('doctrine.orm.%s_second_level_cache.default_cache_factory', $entityManager['name']);
         $factoryClass = isset($entityManager['second_level_cache']['factory']) ? $entityManager['second_level_cache']['factory'] : '%doctrine.orm.second_level_cache.default_cache_factory.class%';
 
-        $definition = new Definition($factoryClass, array(new Reference($regionsId), new Reference($driverId)));
+        $definition = new Definition($factoryClass, [new Reference($regionsId), new Reference($driverId)]);
 
         $slcFactoryDef = $container
             ->setDefinition($slcFactoryId, $definition);
 
         if (isset($entityManager['second_level_cache']['regions'])) {
             foreach ($entityManager['second_level_cache']['regions'] as $name => $region) {
-                $regionRef = null;
+                $regionRef  = null;
                 $regionType = $region['type'];
 
                 if ($regionType === 'service') {
-                    $regionId = sprintf('doctrine.orm.%s_second_level_cache.region.%s', $entityManager['name'], $name);
+                    $regionId  = sprintf('doctrine.orm.%s_second_level_cache.region.%s', $entityManager['name'], $name);
                     $regionRef = new Reference($region['service']);
 
                     $container->setAlias($regionId, new Alias($region['service'], false));
                 }
 
                 if ($regionType === 'default' || $regionType === 'filelock') {
-                    $regionId = sprintf('doctrine.orm.%s_second_level_cache.region.%s', $entityManager['name'], $name);
+                    $regionId   = sprintf('doctrine.orm.%s_second_level_cache.region.%s', $entityManager['name'], $name);
                     $driverName = sprintf('second_level_cache.region.%s_driver', $name);
-                    $driverMap = $region['cache_driver'];
-                    $driverId = $this->loadCacheDriver($driverName, $entityManager['name'], $driverMap, $container);
-                    $regionRef = new Reference($regionId);
+                    $driverMap  = $region['cache_driver'];
+                    $driverId   = $this->loadCacheDriver($driverName, $entityManager['name'], $driverMap, $container);
+                    $regionRef  = new Reference($regionId);
 
                     $container
                         ->setDefinition($regionId, new Definition('%doctrine.orm.second_level_cache.default_region.class%'))
-                        ->setArguments(array($name, new Reference($driverId), $region['lifetime']));
+                        ->setArguments([$name, new Reference($driverId), $region['lifetime']]);
                 }
 
                 if ($regionType === 'filelock') {
@@ -665,39 +677,39 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
                     $container
                         ->setDefinition($regionId, new Definition('%doctrine.orm.second_level_cache.filelock_region.class%'))
-                        ->setArguments(array($regionRef, $region['lock_path'], $region['lock_lifetime']));
+                        ->setArguments([$regionRef, $region['lock_path'], $region['lock_lifetime']]);
 
                     $regionRef = new Reference($regionId);
-                    $regionsDef->addMethodCall('getLockLifetime', array($name, $region['lock_lifetime']));
+                    $regionsDef->addMethodCall('getLockLifetime', [$name, $region['lock_lifetime']]);
                 }
 
-                $regionsDef->addMethodCall('setLifetime', array($name, $region['lifetime']));
-                $slcFactoryDef->addMethodCall('setRegion', array($regionRef));
+                $regionsDef->addMethodCall('setLifetime', [$name, $region['lifetime']]);
+                $slcFactoryDef->addMethodCall('setRegion', [$regionRef]);
             }
         }
 
         if ($entityManager['second_level_cache']['log_enabled']) {
-            $loggerChainId = sprintf('doctrine.orm.%s_second_level_cache.logger_chain', $entityManager['name']);
-            $loggerStatsId = sprintf('doctrine.orm.%s_second_level_cache.logger_statistics', $entityManager['name']);
+            $loggerChainId   = sprintf('doctrine.orm.%s_second_level_cache.logger_chain', $entityManager['name']);
+            $loggerStatsId   = sprintf('doctrine.orm.%s_second_level_cache.logger_statistics', $entityManager['name']);
             $loggerChaingDef = $container->setDefinition($loggerChainId, new Definition('%doctrine.orm.second_level_cache.logger_chain.class%'));
-            $loggerStatsDef = $container->setDefinition($loggerStatsId, new Definition('%doctrine.orm.second_level_cache.logger_statistics.class%'));
+            $loggerStatsDef  = $container->setDefinition($loggerStatsId, new Definition('%doctrine.orm.second_level_cache.logger_statistics.class%'));
 
-            $loggerChaingDef->addMethodCall('setLogger', array('statistics', $loggerStatsDef));
-            $configDef->addMethodCall('setCacheLogger', array($loggerChaingDef));
+            $loggerChaingDef->addMethodCall('setLogger', ['statistics', $loggerStatsDef]);
+            $configDef->addMethodCall('setCacheLogger', [$loggerChaingDef]);
 
             foreach ($entityManager['second_level_cache']['loggers'] as $name => $logger) {
-                $loggerId = sprintf('doctrine.orm.%s_second_level_cache.logger.%s', $entityManager['name'], $name);
+                $loggerId  = sprintf('doctrine.orm.%s_second_level_cache.logger.%s', $entityManager['name'], $name);
                 $loggerRef = new Reference($logger['service']);
 
                 $container->setAlias($loggerId, new Alias($logger['service'], false));
-                $loggerChaingDef->addMethodCall('setLogger', array($name, $loggerRef));
+                $loggerChaingDef->addMethodCall('setLogger', [$name, $loggerRef]);
             }
         }
 
-        $configDef->addMethodCall('setCacheFactory', array($slcFactoryDef));
-        $configDef->addMethodCall('setRegionsConfiguration', array($regionsDef));
-        $ormConfigDef->addMethodCall('setSecondLevelCacheEnabled', array($enabled));
-        $ormConfigDef->addMethodCall('setSecondLevelCacheConfiguration', array($configDef));
+        $configDef->addMethodCall('setCacheFactory', [$slcFactoryDef]);
+        $configDef->addMethodCall('setRegionsConfiguration', [$regionsDef]);
+        $ormConfigDef->addMethodCall('setSecondLevelCacheEnabled', [$enabled]);
+        $ormConfigDef->addMethodCall('setSecondLevelCacheConfiguration', [$configDef]);
     }
 
     /**
@@ -705,7 +717,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function getObjectManagerElementName($name)
     {
-        return 'doctrine.orm.'.$name;
+        return 'doctrine.orm.' . $name;
     }
 
     protected function getMappingObjectDefaultName()
@@ -734,8 +746,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function loadCacheDriver($driverName, $entityManagerName, array $driverMap, ContainerBuilder $container)
     {
-        if (!empty($driverMap['cache_provider'])) {
-            $aliasId = $this->getObjectManagerElementName(sprintf('%s_%s', $entityManagerName, $driverName));
+        if (! empty($driverMap['cache_provider'])) {
+            $aliasId   = $this->getObjectManagerElementName(sprintf('%s_%s', $entityManagerName, $driverName));
             $serviceId = sprintf('doctrine_cache.providers.%s', $driverMap['cache_provider']);
 
             $container->setAlias($aliasId, new Alias($serviceId, false));
@@ -762,34 +774,32 @@ class DoctrineExtension extends AbstractDoctrineExtension
     /**
      * Loads a property info extractor for each defined entity manager.
      *
-     * @param string           $entityManagerName
-     * @param ContainerBuilder $container
+     * @param string $entityManagerName
      */
     private function loadPropertyInfoExtractor($entityManagerName, ContainerBuilder $container)
     {
         $metadataFactoryService = sprintf('doctrine.orm.%s_entity_manager.metadata_factory', $entityManagerName);
 
         $metadataFactoryDefinition = $container->register($metadataFactoryService, 'Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
-        $metadataFactoryDefinition->setFactory(array(
+        $metadataFactoryDefinition->setFactory([
             new Reference(sprintf('doctrine.orm.%s_entity_manager', $entityManagerName)),
-            'getMetadataFactory'
-        ));
+            'getMetadataFactory',
+        ]);
         $metadataFactoryDefinition->setPublic(false);
 
         $propertyExtractorDefinition = $container->register(sprintf('doctrine.orm.%s_entity_manager.property_info_extractor', $entityManagerName), 'Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor');
         $propertyExtractorDefinition->addArgument(new Reference($metadataFactoryService));
-        $propertyExtractorDefinition->addTag('property_info.list_extractor', array('priority' => -1001));
-        $propertyExtractorDefinition->addTag('property_info.type_extractor', array('priority' => -999));
+        $propertyExtractorDefinition->addTag('property_info.list_extractor', ['priority' => -1001]);
+        $propertyExtractorDefinition->addTag('property_info.type_extractor', ['priority' => -999]);
     }
 
     /**
-     * @param array            $objectManager
-     * @param ContainerBuilder $container
-     * @param string           $cacheName
+     * @param array  $objectManager
+     * @param string $cacheName
      */
     public function loadObjectManagerCacheDriver(array $objectManager, ContainerBuilder $container, $cacheName)
     {
-        $this->loadCacheDriver($cacheName, $objectManager['name'], $objectManager[$cacheName.'_driver'], $container);
+        $this->loadCacheDriver($cacheName, $objectManager['name'], $objectManager[$cacheName . '_driver'], $container);
     }
 
     /**
@@ -797,7 +807,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     public function getXsdValidationBasePath()
     {
-        return __DIR__.'/../Resources/config/schema';
+        return __DIR__ . '/../Resources/config/schema';
     }
 
     /**

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -7,24 +7,28 @@ use Doctrine\ORM\Query\Filter\SQLFilter;
 
 /**
  * Configurator for an EntityManager
- *
- * @author Christophe Coevoet <stof@notk.org>
  */
 class ManagerConfigurator
 {
-    private $enabledFilters = array();
-    private $filtersParameters = array();
+    /** @var string[] */
+    private $enabledFilters = [];
 
+    /** @var string[] */
+    private $filtersParameters = [];
+
+    /**
+     * @param string[] $enabledFilters
+     * @param string[] $filtersParameters
+     */
     public function __construct(array $enabledFilters, array $filtersParameters)
     {
-        $this->enabledFilters = $enabledFilters;
+        $this->enabledFilters    = $enabledFilters;
         $this->filtersParameters = $filtersParameters;
     }
 
     /**
      * Create a connection by name.
      *
-     * @param EntityManager $entityManager
      */
     public function configure(EntityManager $entityManager)
     {
@@ -34,7 +38,6 @@ class ManagerConfigurator
     /**
      * Enables filters for a given entity manager
      *
-     * @param EntityManager $entityManager
      */
     private function enableFilters(EntityManager $entityManager)
     {
@@ -45,7 +48,7 @@ class ManagerConfigurator
         $filterCollection = $entityManager->getFilters();
         foreach ($this->enabledFilters as $filter) {
             $filterObject = $filterCollection->enable($filter);
-            if (null !== $filterObject) {
+            if ($filterObject !== null) {
                 $this->setFilterParameters($filter, $filterObject);
             }
         }
@@ -59,7 +62,7 @@ class ManagerConfigurator
      */
     private function setFilterParameters($name, SQLFilter $filter)
     {
-        if (!empty($this->filtersParameters[$name])) {
+        if (! empty($this->filtersParameters[$name])) {
             $parameters = $this->filtersParameters[$name];
             foreach ($parameters as $paramName => $paramValue) {
                 $filter->setParameter($paramName, $paramValue);

--- a/Mapping/ClassMetadataCollection.php
+++ b/Mapping/ClassMetadataCollection.php
@@ -1,21 +1,24 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
-/**
- * @author Fabien Potencier <fabien@symfony.com>
- */
+use Doctrine\ORM\Mapping\ClassMetadata;
+
 class ClassMetadataCollection
 {
+    /** @var string */
     private $path;
+
+    /** @var string */
     private $namespace;
+
+    /** @var ClassMetadata[] */
     private $metadata;
 
     /**
      * Constructor
      *
-     * @param array $metadata
+     * @param ClassMetadata[] $metadata
      */
     public function __construct(array $metadata)
     {
@@ -23,7 +26,7 @@ class ClassMetadataCollection
     }
 
     /**
-     * @return array
+     * @return ClassMetadata[]
      */
     public function getMetadata()
     {

--- a/Mapping/ContainerAwareEntityListenerResolver.php
+++ b/Mapping/ContainerAwareEntityListenerResolver.php
@@ -12,18 +12,15 @@ class ContainerAwareEntityListenerResolver implements EntityListenerServiceResol
     private $container;
 
     /**
-     * @var array Map to store entity listener instances.
+     * @var object[] Map to store entity listener instances.
      */
-    private $instances = array();
+    private $instances = [];
 
     /**
-     * @var array Map to store registered service ids
+     * @var string[] Map to store registered service ids
      */
-    private $serviceIds = array();
+    private $serviceIds = [];
 
-    /**
-     * @param ContainerInterface $container
-     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
@@ -35,7 +32,7 @@ class ContainerAwareEntityListenerResolver implements EntityListenerServiceResol
     public function clear($className = null)
     {
         if ($className === null) {
-            $this->instances = array();
+            $this->instances = [];
 
             return;
         }
@@ -52,7 +49,7 @@ class ContainerAwareEntityListenerResolver implements EntityListenerServiceResol
      */
     public function register($object)
     {
-        if ( ! is_object($object)) {
+        if (! is_object($object)) {
             throw new \InvalidArgumentException(sprintf('An object was expected, but got "%s".', gettype($object)));
         }
 
@@ -76,7 +73,7 @@ class ContainerAwareEntityListenerResolver implements EntityListenerServiceResol
     {
         $className = $this->normalizeClassName($className);
 
-        if (!isset($this->instances[$className])) {
+        if (! isset($this->instances[$className])) {
             if (isset($this->serviceIds[$className])) {
                 $this->instances[$className] = $this->resolveService($this->serviceIds[$className]);
             } else {
@@ -94,7 +91,7 @@ class ContainerAwareEntityListenerResolver implements EntityListenerServiceResol
      */
     private function resolveService($serviceId)
     {
-        if (!$this->container->has($serviceId)) {
+        if (! $this->container->has($serviceId)) {
             throw new \RuntimeException(sprintf('There is no service named "%s"', $serviceId));
         }
 
@@ -102,7 +99,7 @@ class ContainerAwareEntityListenerResolver implements EntityListenerServiceResol
     }
 
     /**
-     * @param $className
+     * @param string $className
      *
      * @return string
      */

--- a/Mapping/DisconnectedMetadataFactory.php
+++ b/Mapping/DisconnectedMetadataFactory.php
@@ -1,9 +1,9 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -11,11 +11,10 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 /**
  * This class provides methods to access Doctrine entity class metadata for a
  * given bundle, namespace or entity class, for generation purposes
- *
- * @author Fabien Potencier <fabien@symfony.com>
  */
 class DisconnectedMetadataFactory
 {
+    /** @var ManagerRegistry */
     private $registry;
 
     /**
@@ -35,13 +34,13 @@ class DisconnectedMetadataFactory
      *
      * @return ClassMetadataCollection A ClassMetadataCollection instance
      *
-     * @throws \RuntimeException When bundle does not contain mapped entities
+     * @throws \RuntimeException When bundle does not contain mapped entities.
      */
     public function getBundleMetadata(BundleInterface $bundle)
     {
         $namespace = $bundle->getNamespace();
-        $metadata = $this->getMetadataForNamespace($namespace);
-        if (!$metadata->getMetadata()) {
+        $metadata  = $this->getMetadataForNamespace($namespace);
+        if (! $metadata->getMetadata()) {
             throw new \RuntimeException(sprintf('Bundle "%s" does not contain any mapped entities.', $bundle->getName()));
         }
 
@@ -61,12 +60,12 @@ class DisconnectedMetadataFactory
      *
      * @return ClassMetadataCollection A ClassMetadataCollection instance
      *
-     * @throws MappingException When class is not valid entity or mapped superclass
+     * @throws MappingException When class is not valid entity or mapped superclass.
      */
     public function getClassMetadata($class, $path = null)
     {
         $metadata = $this->getMetadataForClass($class);
-        if (!$metadata->getMetadata()) {
+        if (! $metadata->getMetadata()) {
             throw MappingException::classIsNotAValidEntityOrMappedSuperClass($class);
         }
 
@@ -83,12 +82,12 @@ class DisconnectedMetadataFactory
      *
      * @return ClassMetadataCollection A ClassMetadataCollection instance
      *
-     * @throws \RuntimeException When namespace not contain mapped entities
+     * @throws \RuntimeException When namespace not contain mapped entities.
      */
     public function getNamespaceMetadata($namespace, $path = null)
     {
         $metadata = $this->getMetadataForNamespace($namespace);
-        if (!$metadata->getMetadata()) {
+        if (! $metadata->getMetadata()) {
             throw new \RuntimeException(sprintf('Namespace "%s" does not contain any mapped entities.', $namespace));
         }
 
@@ -100,25 +99,22 @@ class DisconnectedMetadataFactory
     /**
      * Find and configure path and namespace for the metadata collection.
      *
-     * @param ClassMetadataCollection $metadata
-     * @param string|null             $path
+     * @param string|null $path
      *
-     * @throws \RuntimeException When unable to determine the path
+     * @throws \RuntimeException When unable to determine the path.
      */
     public function findNamespaceAndPathForMetadata(ClassMetadataCollection $metadata, $path = null)
     {
         $all = $metadata->getMetadata();
         if (class_exists($all[0]->name)) {
-            $r = new \ReflectionClass($all[0]->name);
+            $r    = new \ReflectionClass($all[0]->name);
             $path = $this->getBasePathForClass($r->getName(), $r->getNamespaceName(), dirname($r->getFilename()));
-            $ns = $r->getNamespaceName();
-
+            $ns   = $r->getNamespaceName();
         } elseif ($path) {
             // Get namespace by removing the last component of the FQCN
             $nsParts = explode('\\', $all[0]->name);
             array_pop($nsParts);
             $ns = implode('\\', $nsParts);
-
         } else {
             throw new \RuntimeException(sprintf('Unable to determine where to save the "%s" class (use the --path option).', $all[0]->name));
         }
@@ -135,15 +131,16 @@ class DisconnectedMetadataFactory
      * @param string $path      class path
      *
      * @return string
-     * @throws \RuntimeException When base path not found
+     *
+     * @throws \RuntimeException When base path not found.
      */
     private function getBasePathForClass($name, $namespace, $path)
     {
-        $namespace = str_replace('\\', '/', $namespace);
-        $search = str_replace('\\', '/', $path);
-        $destination = str_replace('/'.$namespace, '', $search, $c);
+        $namespace   = str_replace('\\', '/', $namespace);
+        $search      = str_replace('\\', '/', $path);
+        $destination = str_replace('/' . $namespace, '', $search, $c);
 
-        if ($c != 1) {
+        if ($c !== 1) {
             throw new \RuntimeException(sprintf('Can\'t find base path for "%s" (path: "%s", destination: "%s").', $name, $path, $destination));
         }
 
@@ -157,7 +154,7 @@ class DisconnectedMetadataFactory
      */
     private function getMetadataForNamespace($namespace)
     {
-        $metadata = array();
+        $metadata = [];
         foreach ($this->getAllMetadata() as $m) {
             if (strpos($m->name, $namespace) === 0) {
                 $metadata[] = $m;
@@ -178,20 +175,20 @@ class DisconnectedMetadataFactory
             $cmf = new DisconnectedClassMetadataFactory();
             $cmf->setEntityManager($em);
 
-            if (!$cmf->isTransient($entity)) {
-                return new ClassMetadataCollection(array($cmf->getMetadataFor($entity)));
+            if (! $cmf->isTransient($entity)) {
+                return new ClassMetadataCollection([$cmf->getMetadataFor($entity)]);
             }
         }
 
-        return new ClassMetadataCollection(array());
+        return new ClassMetadataCollection([]);
     }
 
     /**
-     * @return array
+     * @return ClassMetadata[]
      */
     private function getAllMetadata()
     {
-        $metadata = array();
+        $metadata = [];
         foreach ($this->registry->getManagers() as $em) {
             $cmf = new DisconnectedClassMetadataFactory();
             $cmf->setEntityManager($em);

--- a/Registry.php
+++ b/Registry.php
@@ -2,28 +2,27 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMException;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
-use Symfony\Bridge\Doctrine\ManagerRegistry;
-use Doctrine\ORM\ORMException;
-use Doctrine\ORM\EntityManager;
 
 /**
  * References all Doctrine connections and entity managers in a given Container.
- *
- * @author Fabien Potencier <fabien@symfony.com>
  */
 class Registry extends ManagerRegistry implements RegistryInterface
 {
     /**
      * Construct.
      *
-     * @param ContainerInterface $container
-     * @param array              $connections
-     * @param array              $entityManagers
-     * @param string             $defaultConnection
-     * @param string             $defaultEntityManager
+     * @param Connection[]             $connections
+     * @param EntityManagerInterface[] $entityManagers
+     * @param string                   $defaultConnection
+     * @param string                   $defaultEntityManager
      */
     public function __construct(ContainerInterface $container, array $connections, array $entityManagers, $defaultConnection, $defaultEntityManager)
     {
@@ -98,7 +97,6 @@ class Registry extends ManagerRegistry implements RegistryInterface
      *
      * @param string $name The entity manager name (null for the default one)
      *
-     * @return EntityManager
      *
      * @deprecated
      */
@@ -153,7 +151,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
     /**
      * Gets all connection names.
      *
-     * @return array An array of connection names
+     * @return string[] An array of connection names
      *
      * @deprecated
      */

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -1,25 +1,25 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
+use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Psr\Container\ContainerInterface;
-use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 
 /**
  * Fetches repositories from the container or falls back to normal creation.
- *
- * @author Ryan Weaver <ryan@knpuniversity.com>
  */
 final class ContainerRepositoryFactory implements RepositoryFactory
 {
+    /** @var ObjectRepository[] */
     private $managedRepositories = [];
 
+    /** @var ContainerInterface|null */
     private $container;
 
     /**
@@ -29,7 +29,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
     {
         // When DoctrineBundle requires Symfony 3.3+, this can be removed
         // and the $container argument can become required.
-        if (null === $container && class_exists(ServiceLocatorTagPass::class)) {
+        if ($container === null && class_exists(ServiceLocatorTagPass::class)) {
             throw new \InvalidArgumentException(sprintf('The first argument of %s::__construct() is required on Symfony 3.3 or higher.', self::class));
         }
 
@@ -41,16 +41,16 @@ final class ContainerRepositoryFactory implements RepositoryFactory
      */
     public function getRepository(EntityManagerInterface $entityManager, $entityName)
     {
-        $metadata = $entityManager->getClassMetadata($entityName);
+        $metadata            = $entityManager->getClassMetadata($entityName);
         $repositoryServiceId = $metadata->customRepositoryClassName;
 
         $customRepositoryName = $metadata->customRepositoryClassName;
-        if (null !== $customRepositoryName) {
+        if ($customRepositoryName !== null) {
             // fetch from the container
             if ($this->container && $this->container->has($customRepositoryName)) {
                 $repository = $this->container->get($customRepositoryName);
 
-                if (!$repository instanceof EntityRepository) {
+                if (! $repository instanceof EntityRepository) {
                     throw new \RuntimeException(sprintf('The service "%s" must extend EntityRepository (or a base class, like ServiceEntityRepository).', $repositoryServiceId));
                 }
 
@@ -60,14 +60,14 @@ final class ContainerRepositoryFactory implements RepositoryFactory
             // if not in the container but the class/id implements the interface, throw an error
             if (is_a($customRepositoryName, ServiceEntityRepositoryInterface::class, true)) {
                 // can be removed when DoctrineBundle requires Symfony 3.3
-                if (null === $this->container) {
+                if ($this->container === null) {
                     throw new \RuntimeException(sprintf('Support for loading entities from the service container only works for Symfony 3.3 or higher. Upgrade your version of Symfony or make sure your "%s" class does not implement "%s"', $customRepositoryName, ServiceEntityRepositoryInterface::class));
                 }
 
                 throw new \RuntimeException(sprintf('The "%s" entity repository implements "%s", but its service could not be found. Make sure the service exists and is tagged with "%s".', $customRepositoryName, ServiceEntityRepositoryInterface::class, ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG));
             }
 
-            if (!class_exists($customRepositoryName)) {
+            if (! class_exists($customRepositoryName)) {
                 throw new \RuntimeException(sprintf('The "%s" entity has a repositoryClass set to "%s", but this is not a valid class. Check your class naming. If this is meant to be a service id, make sure this service exists and is tagged with "%s".', $metadata->name, $customRepositoryName, ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG));
             }
 
@@ -79,7 +79,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
 
     private function getOrCreateRepository(EntityManagerInterface $entityManager, ClassMetadata $metadata)
     {
-        $repositoryHash = $metadata->getName().spl_object_hash($entityManager);
+        $repositoryHash = $metadata->getName() . spl_object_hash($entityManager);
         if (isset($this->managedRepositories[$repositoryHash])) {
             return $this->managedRepositories[$repositoryHash];
         }

--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -19,14 +18,11 @@ use Doctrine\ORM\EntityRepository;
  *         parent::__construct($registry, YourEntity::class);
  *     }
  * }
- *
- * @author Ryan Weaver <ryan@knpuniversity.com>
  */
 class ServiceEntityRepository extends EntityRepository implements ServiceEntityRepositoryInterface
 {
     /**
-     * @param ManagerRegistry $registry
-     * @param string          $entityClass The class name of the entity this repository manages
+     * @param string $entityClass The class name of the entity this repository manages
      */
     public function __construct(ManagerRegistry $registry, $entityClass)
     {

--- a/Repository/ServiceEntityRepositoryInterface.php
+++ b/Repository/ServiceEntityRepositoryInterface.php
@@ -1,12 +1,9 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
 /**
  * This interface signals that your repository should be loaded from the container.
- *
- * @author Ryan Weaver <ryan@knpuniversity.com>
  */
 interface ServiceEntityRepositoryInterface
 {

--- a/Tests/Builder/BundleConfigurationBuilder.php
+++ b/Tests/Builder/BundleConfigurationBuilder.php
@@ -2,10 +2,9 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Builder;
 
-
 class BundleConfigurationBuilder
 {
-
+    /** @var array */
     private $configuration;
 
     public static function createBuilder()
@@ -26,10 +25,8 @@ class BundleConfigurationBuilder
     {
         $this->addConnection([
             'connections' => [
-                'default' => [
-                    'password' => 'foo'
-                ]
-            ]
+                'default' => ['password' => 'foo'],
+            ],
         ]);
 
         return $this;
@@ -42,10 +39,10 @@ class BundleConfigurationBuilder
             'entity_managers' => [
                 'default' => [
                     'mappings' => [
-                        'YamlBundle' => []
-                    ]
-                ]
-            ]
+                        'YamlBundle' => [],
+                    ],
+                ],
+            ],
         ]);
 
         return $this;
@@ -54,14 +51,10 @@ class BundleConfigurationBuilder
     public function addBaseSecondLevelCache()
     {
         $this->addSecondLevelCache([
-            'region_cache_driver' => [
-                'type' => 'memcache'
-            ],
+            'region_cache_driver' => ['type' => 'memcache'],
             'regions' => [
-                'hour_region' => [
-                    'lifetime' => 3600
-                ]
-            ]
+                'hour_region' => ['lifetime' => 3600],
+            ],
         ]);
 
         return $this;

--- a/Tests/BundleTest.php
+++ b/Tests/BundleTest.php
@@ -3,25 +3,25 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 
 class BundleTest extends TestCase
 {
     public function testBuildCompilerPasses()
     {
         $container = new ContainerBuilder();
-        $bundle = new DoctrineBundle();
+        $bundle    = new DoctrineBundle();
         $bundle->build($container);
 
         $config = $container->getCompilerPassConfig();
         $passes = $config->getBeforeOptimizationPasses();
 
         $foundEventListener = false;
-        $foundValidation = false;
+        $foundValidation    = false;
 
         foreach ($passes as $pass) {
             if ($pass instanceof RegisterEventListenersAndSubscribersPass) {

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand;
@@ -12,19 +11,19 @@ class CreateDatabaseDoctrineTest extends TestCase
 {
     public function tearDown()
     {
-        @unlink(sys_get_temp_dir() . "/test");
-        @unlink(sys_get_temp_dir() . "/shard_1");
-        @unlink(sys_get_temp_dir() . "/shard_2");
+        @unlink(sys_get_temp_dir() . '/test');
+        @unlink(sys_get_temp_dir() . '/shard_1');
+        @unlink(sys_get_temp_dir() . '/shard_2');
     }
 
     public function testExecute()
     {
         $connectionName = 'default';
-        $dbName = 'test';
-        $params = array(
-            'path' => sys_get_temp_dir() . "/" . $dbName,
+        $dbName         = 'test';
+        $params         = [
+            'path' => sys_get_temp_dir() . '/' . $dbName,
             'driver' => 'pdo_sqlite',
-        );
+        ];
 
         $application = new Application();
         $application->add(new CreateDatabaseDoctrineCommand());
@@ -34,36 +33,36 @@ class CreateDatabaseDoctrineTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(
-            array_merge(array('command' => $command->getName()))
+            array_merge(['command' => $command->getName()])
         );
 
-        $this->assertContains("Created database " . sys_get_temp_dir() . "/" . $dbName . " for connection named $connectionName", $commandTester->getDisplay());
+        $this->assertContains('Created database ' . sys_get_temp_dir() . '/' . $dbName . ' for connection named ' . $connectionName, $commandTester->getDisplay());
     }
 
     public function testExecuteWithShardOption()
     {
         $connectionName = 'default';
-        $params = array(
+        $params         = [
             'dbname' => 'test',
             'memory' => true,
             'driver' => 'pdo_sqlite',
-            'global' => array(
+            'global' => [
                 'driver' => 'pdo_sqlite',
                 'dbname' => 'test',
-            ),
-            'shards' => array(
-                'foo' => array(
+            ],
+            'shards' => [
+                'foo' => [
                     'id' => 1,
                     'path' => sys_get_temp_dir() . '/shard_1',
                     'driver' => 'pdo_sqlite',
-                ),
-                'bar' => array(
+                ],
+                'bar' => [
                     'id' => 2,
                     'path' => sys_get_temp_dir() . '/shard_2',
                     'driver' => 'pdo_sqlite',
-                ),
-            )
-        );
+                ],
+            ],
+        ];
 
         $application = new Application();
         $application->add(new CreateDatabaseDoctrineCommand());
@@ -72,19 +71,19 @@ class CreateDatabaseDoctrineTest extends TestCase
         $command->setContainer($this->getMockContainer($connectionName, $params));
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), '--shard' => 1));
+        $commandTester->execute(['command' => $command->getName(), '--shard' => 1]);
 
-        $this->assertContains("Created database " . sys_get_temp_dir() ."/shard_1 for connection named $connectionName", $commandTester->getDisplay());
+        $this->assertContains('Created database ' . sys_get_temp_dir() . '/shard_1 for connection named ' . $connectionName, $commandTester->getDisplay());
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), '--shard' => 2));
+        $commandTester->execute(['command' => $command->getName(), '--shard' => 2]);
 
-        $this->assertContains("Created database " . sys_get_temp_dir() ."/shard_2 for connection named $connectionName", $commandTester->getDisplay());
+        $this->assertContains('Created database ' . sys_get_temp_dir() . '/shard_2 for connection named ' . $connectionName, $commandTester->getDisplay());
     }
 
     /**
-     * @param string     $connectionName Connection name
-     * @param array|null $params         Connection parameters
+     * @param string       $connectionName Connection name
+     * @param mixed[]|null $params         Connection parameters
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getMockContainer($connectionName, $params = null)
@@ -100,7 +99,7 @@ class CreateDatabaseDoctrineTest extends TestCase
 
         $mockConnection = $this->getMockBuilder('Doctrine\DBAL\Connection')
             ->disableOriginalConstructor()
-            ->setMethods(array('getParams'))
+            ->setMethods(['getParams'])
             ->getMockForAbstractClass();
 
         $mockConnection->expects($this->any())
@@ -114,7 +113,7 @@ class CreateDatabaseDoctrineTest extends TestCase
             ->willReturn($mockConnection);
 
         $mockContainer = $this->getMockBuilder('Symfony\Component\DependencyInjection\Container')
-            ->setMethods(array('get'))
+            ->setMethods(['get'])
             ->getMock();
 
         $mockContainer->expects($this->any())

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
@@ -14,7 +13,7 @@ class ConnectionFactoryTest extends TestCase
     {
         parent::setUp();
 
-        if (!class_exists('Doctrine\\ORM\\Version')) {
+        if (! class_exists('Doctrine\\ORM\\Version')) {
             $this->markTestSkipped('Doctrine ORM is not available.');
         }
     }
@@ -63,7 +62,6 @@ class FakeDriver implements Driver
      * This method gets called to determine the database version which in our case leeds to the problem.
      * So we have to fake the exception a driver would normally throw.
      *
-     *
      * @link https://github.com/doctrine/DoctrineBundle/issues/673
      */
     public function getDatabasePlatform()
@@ -73,6 +71,12 @@ class FakeDriver implements Driver
 
     // ----- below this line follow only dummy methods to satisfy the interface requirements ----
 
+    /**
+     * @param mixed[]     $params
+     * @param string|null $username
+     * @param string|null $password
+     * @param mixed[]     $driverOptions
+     */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         throw new \Exception('not implemented');

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\DBAL\Types\Type;
@@ -11,7 +10,7 @@ class ContainerTest extends TestCase
     {
         parent::setUp();
 
-        if (!class_exists('Doctrine\\ORM\\Version')) {
+        if (! class_exists('Doctrine\\ORM\\Version')) {
             $this->markTestSkipped('Doctrine ORM is not available.');
         }
     }

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -1,26 +1,25 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DataCollector;
 
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 
 class DoctrineDataCollectorTest extends TestCase
 {
-    const FIRST_ENTITY = 'TestBundle\Test\Entity\Test1';
+    const FIRST_ENTITY  = 'TestBundle\Test\Entity\Test1';
     const SECOND_ENTITY = 'TestBundle\Test\Entity\Test2';
 
     public function testCollectEntities()
     {
-        $manager = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
-        $config = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
-        $factory = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory')
-            ->setMethods(array('getLoadedMetadata'))->getMockForAbstractClass();
-        $collector = $this->createCollector(array('default' => $manager));
+        $manager   = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $config    = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
+        $factory   = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory')
+            ->setMethods(['getLoadedMetadata'])->getMockForAbstractClass();
+        $collector = $this->createCollector(['default' => $manager]);
 
         $manager->expects($this->any())
             ->method('getMetadataFactory')
@@ -35,11 +34,11 @@ class DoctrineDataCollectorTest extends TestCase
                 ->will($this->returnValue(false));
         }
 
-        $metadatas = array(
+        $metadatas = [
             $this->createEntityMetadata(self::FIRST_ENTITY),
             $this->createEntityMetadata(self::SECOND_ENTITY),
             $this->createEntityMetadata(self::FIRST_ENTITY),
-        );
+        ];
         $factory->expects($this->once())
             ->method('getLoadedMetadata')
             ->will($this->returnValue($metadatas));
@@ -58,8 +57,8 @@ class DoctrineDataCollectorTest extends TestCase
      */
     private function createEntityMetadata($entityFQCN)
     {
-        $metadata = new ClassMetadataInfo($entityFQCN);
-        $metadata->name = $entityFQCN;
+        $metadata            = new ClassMetadataInfo($entityFQCN);
+        $metadata->name      = $entityFQCN;
         $metadata->reflClass = new \ReflectionClass('stdClass');
 
         return $metadata;
@@ -76,11 +75,11 @@ class DoctrineDataCollectorTest extends TestCase
         $registry
             ->expects($this->any())
             ->method('getConnectionNames')
-            ->will($this->returnValue(array('default' => 'doctrine.dbal.default_connection')));
+            ->will($this->returnValue(['default' => 'doctrine.dbal.default_connection']));
         $registry
             ->expects($this->any())
             ->method('getManagerNames')
-            ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager')));
+            ->will($this->returnValue(['default' => 'doctrine.orm.default_entity_manager']));
         $registry
             ->expects($this->any())
             ->method('getManagers')

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
@@ -10,11 +9,11 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 
 abstract class AbstractDoctrineExtensionTest extends TestCase
 {
@@ -107,18 +106,26 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('Doctrine\\DBAL\\Connections\\MasterSlaveConnection', $param['wrapperClass']);
         $this->assertTrue($param['keepSlave']);
         $this->assertEquals(
-            array('user' => 'mysql_user', 'password' => 'mysql_s3cr3t',
-                  'port' => null, 'dbname' => 'mysql_db', 'host' => 'localhost',
+            [
+            'user' => 'mysql_user',
+            'password' => 'mysql_s3cr3t',
+                  'port' => null,
+            'dbname' => 'mysql_db',
+            'host' => 'localhost',
                   'unix_socket' => '/path/to/mysqld.sock',
-                  'defaultTableOptions' => array(),
-            ),
+                  'defaultTableOptions' => [],
+            ],
             $param['master']
         );
         $this->assertEquals(
-            array(
-                'user' => 'slave_user', 'password' => 'slave_s3cr3t', 'port' => null, 'dbname' => 'slave_db',
-                'host' => 'localhost', 'unix_socket' => '/path/to/mysqld_slave.sock',
-            ),
+            [
+                'user' => 'slave_user',
+            'password' => 'slave_s3cr3t',
+            'port' => null,
+            'dbname' => 'slave_db',
+                'host' => 'localhost',
+            'unix_socket' => '/path/to/mysqld_slave.sock',
+            ],
             $param['slaves']['slave1']
         );
     }
@@ -133,18 +140,27 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('Doctrine\\DBAL\\Sharding\\PoolingShardConnection', $param['wrapperClass']);
         $this->assertEquals(new Reference('foo.shard_choser'), $param['shardChoser']);
         $this->assertEquals(
-            array('user' => 'mysql_user', 'password' => 'mysql_s3cr3t',
-                  'port' => null, 'dbname' => 'mysql_db', 'host' => 'localhost',
+            [
+            'user' => 'mysql_user',
+            'password' => 'mysql_s3cr3t',
+                  'port' => null,
+            'dbname' => 'mysql_db',
+            'host' => 'localhost',
                   'unix_socket' => '/path/to/mysqld.sock',
-                  'defaultTableOptions' => array(),
-            ),
+                  'defaultTableOptions' => [],
+            ],
             $param['global']
         );
         $this->assertEquals(
-            array(
-                'user' => 'shard_user', 'password' => 'shard_s3cr3t', 'port' => null, 'dbname' => 'shard_db',
-                'host' => 'localhost', 'unix_socket' => '/path/to/mysqld_shard.sock', 'id' => 1,
-            ),
+            [
+                'user' => 'shard_user',
+            'password' => 'shard_s3cr3t',
+            'port' => null,
+            'dbname' => 'shard_db',
+                'host' => 'localhost',
+            'unix_socket' => '/path/to/mysqld_shard.sock',
+            'id' => 1,
+            ],
             $param['shards'][0]
         );
     }
@@ -171,34 +187,35 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
 
-        $this->assertDICConstructorArguments($definition, array(
-            array(
+        $this->assertDICConstructorArguments($definition, [
+            [
                 'dbname' => 'db',
                 'host' => 'localhost',
                 'port' => null,
                 'user' => 'root',
                 'password' => null,
                 'driver' => 'pdo_mysql',
-                'driverOptions' => array(),
-                'defaultTableOptions' => array(),
-            ),
+                'driverOptions' => [],
+                'defaultTableOptions' => [],
+            ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             new Reference('doctrine.dbal.default_connection.event_manager'),
-            array(),
-        ));
+            [],
+        ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
         }
 
-        $this->assertDICConstructorArguments($definition, array(
-            new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
-        ));
+        $this->assertDICConstructorArguments($definition, [
+            new Reference('doctrine.dbal.default_connection'),
+        new Reference('doctrine.orm.default_configuration'),
+        ]);
     }
 
     /**
@@ -206,26 +223,25 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      */
     public function testLoadSimpleSingleConnectionWithoutDbName()
     {
-
         $container = $this->loadContainer('orm_service_simple_single_entity_manager_without_dbname');
 
         /** @var Definition $definition */
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
 
-        $this->assertDICConstructorArguments($definition, array(
-                array(
+        $this->assertDICConstructorArguments($definition, [
+                [
                     'host' => 'localhost',
                     'port' => null,
                     'user' => 'root',
                     'password' => null,
                     'driver' => 'pdo_mysql',
-                    'driverOptions' => array(),
-                    'defaultTableOptions' => array(),
-                ),
+                    'driverOptions' => [],
+                    'defaultTableOptions' => [],
+                ],
                 new Reference('doctrine.dbal.default_connection.configuration'),
                 new Reference('doctrine.dbal.default_connection.event_manager'),
-                array(),
-            ));
+                [],
+            ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -239,9 +255,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $factory[0]);
         $this->assertEquals('create', $factory[1]);
 
-        $this->assertDICConstructorArguments($definition, array(
-                new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration')
-            ));
+        $this->assertDICConstructorArguments($definition, [
+                new Reference('doctrine.dbal.default_connection'),
+        new Reference('doctrine.orm.default_configuration'),
+            ]);
     }
 
     public function testLoadSingleConnection()
@@ -250,38 +267,39 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
 
-        $this->assertDICConstructorArguments($definition, array(
-            array(
+        $this->assertDICConstructorArguments($definition, [
+            [
                 'host' => 'localhost',
                 'driver' => 'pdo_sqlite',
-                'driverOptions' => array(),
+                'driverOptions' => [],
                 'user' => 'sqlite_user',
                 'port' => null,
                 'password' => 'sqlite_s3cr3t',
                 'dbname' => 'sqlite_db',
                 'memory' => true,
-                'defaultTableOptions' => array(),
-            ),
+                'defaultTableOptions' => [],
+            ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             new Reference('doctrine.dbal.default_connection.event_manager'),
-            array(),
-        ));
+            [],
+        ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'setFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
         }
 
-        $this->assertDICConstructorArguments($definition, array(
-            new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
-        ));
+        $this->assertDICConstructorArguments($definition, [
+            new Reference('doctrine.dbal.default_connection'),
+        new Reference('doctrine.orm.default_configuration'),
+        ]);
 
         $configDef = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($configDef, 'setDefaultRepositoryClassName', array('Acme\Doctrine\Repository'));
+        $this->assertDICDefinitionMethodCallOnce($configDef, 'setDefaultRepositoryClassName', ['Acme\Doctrine\Repository']);
     }
 
     public function testLoadMultipleConnections()
@@ -302,7 +320,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $definition = $container->getDefinition('doctrine.orm.em1_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
@@ -326,7 +344,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $definition = $container->getDefinition('doctrine.orm.em2_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
@@ -353,13 +371,13 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('dbal_logging');
 
         $definition = $container->getDefinition('doctrine.dbal.log_connection.configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', array(new Reference('doctrine.dbal.logger')));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', [new Reference('doctrine.dbal.logger')]);
 
         $definition = $container->getDefinition('doctrine.dbal.profile_connection.configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', array(new Reference('doctrine.dbal.logger.profiling.profile')));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', [new Reference('doctrine.dbal.logger.profiling.profile')]);
 
         $definition = $container->getDefinition('doctrine.dbal.both_connection.configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', array(new Reference('doctrine.dbal.logger.chain.both')));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', [new Reference('doctrine.dbal.logger.chain.both')]);
     }
 
     public function testEntityManagerMetadataCacheDriverConfiguration()
@@ -379,15 +397,18 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
         $this->assertDICDefinitionClass($definition, '%doctrine_cache.memcache.class%');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setMemcache',
-            array(new Reference('doctrine_cache.services.doctrine.orm.default_metadata_cache.connection'))
+        $this->assertDICDefinitionMethodCallOnce(
+            $definition,
+            'setMemcache',
+            [new Reference('doctrine_cache.services.doctrine.orm.default_metadata_cache.connection')]
         );
 
         $definition = $container->getDefinition('doctrine_cache.services.doctrine.orm.default_metadata_cache.connection');
         $this->assertDICDefinitionClass($definition, '%doctrine_cache.memcache.connection.class%');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addServer', array(
-            'localhost', '11211',
-        ));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addServer', [
+            'localhost',
+        '11211',
+        ]);
     }
 
     public function testEntityManagerRedisMetadataCacheDriverConfigurationWithDatabaseKey()
@@ -396,14 +417,16 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
         $this->assertDICDefinitionClass($definition, '%doctrine_cache.redis.class%');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setRedis',
-            array(new Reference('doctrine_cache.services.doctrine.orm.default_metadata_cache_redis.connection'))
+        $this->assertDICDefinitionMethodCallOnce(
+            $definition,
+            'setRedis',
+            [new Reference('doctrine_cache.services.doctrine.orm.default_metadata_cache_redis.connection')]
         );
 
         $definition = $container->getDefinition('doctrine_cache.services.doctrine.orm.default_metadata_cache_redis.connection');
         $this->assertDICDefinitionClass($definition, '%doctrine_cache.redis.connection.class%');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'connect', array('localhost', '6379'));
-        $this->assertDICDefinitionMethodCallOnce($definition, 'select', array(1));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'connect', ['localhost', '6379']);
+        $this->assertDICDefinitionMethodCallOnce($definition, 'select', [1]);
     }
 
     public function testDependencyInjectionImportsOverrideDefaults()
@@ -414,96 +437,96 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('%doctrine_cache.apc.class%', $cacheDefinition->getClass());
 
         $configDefinition = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setAutoGenerateProxyClasses', array('%doctrine.orm.auto_generate_proxy_classes%'));
+        $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setAutoGenerateProxyClasses', ['%doctrine.orm.auto_generate_proxy_classes%']);
     }
 
     public function testSingleEntityManagerMultipleMappingBundleDefinitions()
     {
-        $container = $this->loadContainer('orm_single_em_bundle_mappings', array('YamlBundle', 'AnnotationsBundle', 'XmlBundle'));
+        $container = $this->loadContainer('orm_single_em_bundle_mappings', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
 
-        $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', [
             new Reference('doctrine.orm.default_annotation_metadata_driver'),
             'Fixtures\Bundles\AnnotationsBundle\Entity',
-        ));
+        ]);
 
-        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', [
             new Reference('doctrine.orm.default_yml_metadata_driver'),
             'Fixtures\Bundles\YamlBundle\Entity',
-        ));
+        ]);
 
-        $this->assertDICDefinitionMethodCallAt(2, $definition, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallAt(2, $definition, 'addDriver', [
             new Reference('doctrine.orm.default_xml_metadata_driver'),
             'Fixtures\Bundles\XmlBundle',
-        ));
+        ]);
 
         $annDef = $container->getDefinition('doctrine.orm.default_annotation_metadata_driver');
-        $this->assertDICConstructorArguments($annDef, array(
+        $this->assertDICConstructorArguments($annDef, [
             new Reference('doctrine.orm.metadata.annotation_reader'),
-            array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'Bundles'.DIRECTORY_SEPARATOR.'AnnotationsBundle'.DIRECTORY_SEPARATOR.'Entity'),
-        ));
+            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'AnnotationsBundle' . DIRECTORY_SEPARATOR . 'Entity'],
+        ]);
 
         $ymlDef = $container->getDefinition('doctrine.orm.default_yml_metadata_driver');
-        $this->assertDICConstructorArguments($ymlDef, array(
-            array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'Bundles'.DIRECTORY_SEPARATOR.'YamlBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'doctrine' => 'Fixtures\Bundles\YamlBundle\Entity'),
-        ));
+        $this->assertDICConstructorArguments($ymlDef, [
+            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'YamlBundle' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'doctrine' => 'Fixtures\Bundles\YamlBundle\Entity'],
+        ]);
 
         $xmlDef = $container->getDefinition('doctrine.orm.default_xml_metadata_driver');
-        $this->assertDICConstructorArguments($xmlDef, array(
-            array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'Bundles'.DIRECTORY_SEPARATOR.'XmlBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'doctrine' => 'Fixtures\Bundles\XmlBundle'),
-        ));
+        $this->assertDICConstructorArguments($xmlDef, [
+            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'XmlBundle' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'doctrine' => 'Fixtures\Bundles\XmlBundle'],
+        ]);
     }
 
     public function testMultipleEntityManagersMappingBundleDefinitions()
     {
-        $container = $this->loadContainer('orm_multiple_em_bundle_mappings', array('YamlBundle', 'AnnotationsBundle', 'XmlBundle'));
+        $container = $this->loadContainer('orm_multiple_em_bundle_mappings', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
-        $this->assertEquals(array('em1' => 'doctrine.orm.em1_entity_manager', 'em2' => 'doctrine.orm.em2_entity_manager'), $container->getParameter('doctrine.entity_managers'), "Set of the existing EntityManagers names is incorrect.");
-        $this->assertEquals('%doctrine.entity_managers%', $container->getDefinition('doctrine')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
+        $this->assertEquals(['em1' => 'doctrine.orm.em1_entity_manager', 'em2' => 'doctrine.orm.em2_entity_manager'], $container->getParameter('doctrine.entity_managers'), 'Set of the existing EntityManagers names is incorrect.');
+        $this->assertEquals('%doctrine.entity_managers%', $container->getDefinition('doctrine')->getArgument(2), 'Set of the existing EntityManagers names is incorrect.');
 
         $def1 = $container->getDefinition('doctrine.orm.em1_metadata_driver');
         $def2 = $container->getDefinition('doctrine.orm.em2_metadata_driver');
 
-        $this->assertDICDefinitionMethodCallAt(0, $def1, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallAt(0, $def1, 'addDriver', [
             new Reference('doctrine.orm.em1_annotation_metadata_driver'),
             'Fixtures\Bundles\AnnotationsBundle\Entity',
-        ));
+        ]);
 
-        $this->assertDICDefinitionMethodCallAt(0, $def2, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallAt(0, $def2, 'addDriver', [
             new Reference('doctrine.orm.em2_yml_metadata_driver'),
             'Fixtures\Bundles\YamlBundle\Entity',
-        ));
+        ]);
 
-        $this->assertDICDefinitionMethodCallAt(1, $def2, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallAt(1, $def2, 'addDriver', [
             new Reference('doctrine.orm.em2_xml_metadata_driver'),
             'Fixtures\Bundles\XmlBundle',
-        ));
+        ]);
 
         $annDef = $container->getDefinition('doctrine.orm.em1_annotation_metadata_driver');
-        $this->assertDICConstructorArguments($annDef, array(
+        $this->assertDICConstructorArguments($annDef, [
             new Reference('doctrine.orm.metadata.annotation_reader'),
-            array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'Bundles'.DIRECTORY_SEPARATOR.'AnnotationsBundle'.DIRECTORY_SEPARATOR.'Entity'),
-        ));
+            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'AnnotationsBundle' . DIRECTORY_SEPARATOR . 'Entity'],
+        ]);
 
         $ymlDef = $container->getDefinition('doctrine.orm.em2_yml_metadata_driver');
-        $this->assertDICConstructorArguments($ymlDef, array(
-            array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'Bundles'.DIRECTORY_SEPARATOR.'YamlBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'doctrine' => 'Fixtures\Bundles\YamlBundle\Entity'),
-        ));
+        $this->assertDICConstructorArguments($ymlDef, [
+            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'YamlBundle' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'doctrine' => 'Fixtures\Bundles\YamlBundle\Entity'],
+        ]);
 
         $xmlDef = $container->getDefinition('doctrine.orm.em2_xml_metadata_driver');
-        $this->assertDICConstructorArguments($xmlDef, array(
-            array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'Bundles'.DIRECTORY_SEPARATOR.'XmlBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'doctrine' => 'Fixtures\Bundles\XmlBundle'),
-        ));
+        $this->assertDICConstructorArguments($xmlDef, [
+            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'XmlBundle' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'doctrine' => 'Fixtures\Bundles\XmlBundle'],
+        ]);
     }
 
     public function testSingleEntityManagerDefaultTableOptions()
     {
-        $container = $this->loadContainer('orm_single_em_default_table_options', array('YamlBundle', 'AnnotationsBundle', 'XmlBundle'));
+        $container = $this->loadContainer('orm_single_em_default_table_options', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
         $param = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
-        $this->assertArrayHasKey('defaultTableOptions',$param);
+        $this->assertArrayHasKey('defaultTableOptions', $param);
 
         $defaults = $param['defaultTableOptions'];
 
@@ -511,10 +534,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertArrayHasKey('collate', $defaults);
         $this->assertArrayHasKey('engine', $defaults);
 
-        $this->assertEquals('utf8mb4',$defaults['charset']);
-        $this->assertEquals('utf8mb4_unicode_ci',$defaults['collate']);
-        $this->assertEquals('InnoDB',$defaults['engine']);
-
+        $this->assertEquals('utf8mb4', $defaults['charset']);
+        $this->assertEquals('utf8mb4_unicode_ci', $defaults['collate']);
+        $this->assertEquals('InnoDB', $defaults['engine']);
     }
 
     public function testSetTypes()
@@ -522,7 +544,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('dbal_types');
 
         $this->assertEquals(
-            array('test' => array('class' => TestType::class, 'commented' => true)),
+            ['test' => ['class' => TestType::class, 'commented' => true]],
             $container->getParameter('doctrine.dbal.connection_factory.types')
         );
         $this->assertEquals('%doctrine.dbal.connection_factory.types%', $container->getDefinition('doctrine.dbal.connection_factory')->getArgument(0));
@@ -533,14 +555,14 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_functions');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomStringFunction', array('test_string', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction'));
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomNumericFunction', array('test_numeric', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestNumericFunction'));
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomDatetimeFunction', array('test_datetime', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestDatetimeFunction'));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomStringFunction', ['test_string', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction']);
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomNumericFunction', ['test_numeric', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestNumericFunction']);
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomDatetimeFunction', ['test_datetime', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestDatetimeFunction']);
     }
 
     public function testSetNamingStrategy()
     {
-        if (version_compare(Version::VERSION, "2.3.0-DEV") < 0) {
+        if (version_compare(Version::VERSION, '2.3.0-DEV') < 0) {
             $this->markTestSkipped('Naming Strategies are not available');
         }
         $container = $this->loadContainer('orm_namingstrategy');
@@ -548,13 +570,13 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $def1 = $container->getDefinition('doctrine.orm.em1_configuration');
         $def2 = $container->getDefinition('doctrine.orm.em2_configuration');
 
-        $this->assertDICDefinitionMethodCallOnce($def1, 'setNamingStrategy', array(0 => new Reference('doctrine.orm.naming_strategy.default')));
-        $this->assertDICDefinitionMethodCallOnce($def2, 'setNamingStrategy', array(0 => new Reference('doctrine.orm.naming_strategy.underscore')));
+        $this->assertDICDefinitionMethodCallOnce($def1, 'setNamingStrategy', [0 => new Reference('doctrine.orm.naming_strategy.default')]);
+        $this->assertDICDefinitionMethodCallOnce($def2, 'setNamingStrategy', [0 => new Reference('doctrine.orm.naming_strategy.underscore')]);
     }
 
     public function testSetQuoteStrategy()
     {
-        if (version_compare(Version::VERSION, "2.3.0-DEV") < 0) {
+        if (version_compare(Version::VERSION, '2.3.0-DEV') < 0) {
             $this->markTestSkipped('Quote Strategies are not available');
         }
         $container = $this->loadContainer('orm_quotestrategy');
@@ -562,8 +584,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $def1 = $container->getDefinition('doctrine.orm.em1_configuration');
         $def2 = $container->getDefinition('doctrine.orm.em2_configuration');
 
-        $this->assertDICDefinitionMethodCallOnce($def1, 'setQuoteStrategy', array(0 => new Reference('doctrine.orm.quote_strategy.default')));
-        $this->assertDICDefinitionMethodCallOnce($def2, 'setQuoteStrategy', array(0 => new Reference('doctrine.orm.quote_strategy.ansi')));
+        $this->assertDICDefinitionMethodCallOnce($def1, 'setQuoteStrategy', [0 => new Reference('doctrine.orm.quote_strategy.default')]);
+        $this->assertDICDefinitionMethodCallOnce($def2, 'setQuoteStrategy', [0 => new Reference('doctrine.orm.quote_strategy.ansi')]);
     }
 
     public function testSecondLevelCache()
@@ -589,16 +611,16 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertTrue($container->has('doctrine.orm.default_second_level_cache.region.my_service_region'));
         $this->assertTrue($container->has('doctrine.orm.default_second_level_cache.region.my_query_region_filelock'));
 
-        $slcFactoryDef = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
-        $myEntityRegionDef = $container->getDefinition('doctrine.orm.default_second_level_cache.region.my_entity_region');
-        $loggerChainDef = $container->getDefinition('doctrine.orm.default_second_level_cache.logger_chain');
+        $slcFactoryDef       = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
+        $myEntityRegionDef   = $container->getDefinition('doctrine.orm.default_second_level_cache.region.my_entity_region');
+        $loggerChainDef      = $container->getDefinition('doctrine.orm.default_second_level_cache.logger_chain');
         $loggerStatisticsDef = $container->getDefinition('doctrine.orm.default_second_level_cache.logger_statistics');
-        $myQueryRegionDef = $container->getDefinition('doctrine.orm.default_second_level_cache.region.my_query_region_filelock');
-        $cacheDriverDef = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_second_level_cache.region_cache_driver'));
-        $configDef = $container->getDefinition('doctrine.orm.default_configuration');
-        $myEntityRegionArgs = $myEntityRegionDef->getArguments();
-        $myQueryRegionArgs = $myQueryRegionDef->getArguments();
-        $slcFactoryArgs = $slcFactoryDef->getArguments();
+        $myQueryRegionDef    = $container->getDefinition('doctrine.orm.default_second_level_cache.region.my_query_region_filelock');
+        $cacheDriverDef      = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_second_level_cache.region_cache_driver'));
+        $configDef           = $container->getDefinition('doctrine.orm.default_configuration');
+        $myEntityRegionArgs  = $myEntityRegionDef->getArguments();
+        $myQueryRegionArgs   = $myQueryRegionDef->getArguments();
+        $slcFactoryArgs      = $slcFactoryDef->getArguments();
 
         $this->assertDICDefinitionClass($slcFactoryDef, '%doctrine.orm.second_level_cache.default_cache_factory.class%');
         $this->assertDICDefinitionClass($myQueryRegionDef, '%doctrine.orm.second_level_cache.filelock_region.class%');
@@ -607,8 +629,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionClass($loggerStatisticsDef, '%doctrine.orm.second_level_cache.logger_statistics.class%');
         $this->assertDICDefinitionClass($cacheDriverDef, '%doctrine_cache.array.class%');
         $this->assertDICDefinitionMethodCallOnce($configDef, 'setSecondLevelCacheConfiguration');
-        $this->assertDICDefinitionMethodCallCount($slcFactoryDef, 'setRegion', array(), 3);
-        $this->assertDICDefinitionMethodCallCount($loggerChainDef, 'setLogger', array(), 3);
+        $this->assertDICDefinitionMethodCallCount($slcFactoryDef, 'setRegion', [], 3);
+        $this->assertDICDefinitionMethodCallCount($loggerChainDef, 'setLogger', [], 3);
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $slcFactoryArgs[0]);
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $slcFactoryArgs[1]);
@@ -633,7 +655,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_single_em_dql_functions');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomStringFunction', array('test_string', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction'));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomStringFunction', ['test_string', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction']);
     }
 
     public function testAddCustomHydrationMode()
@@ -641,7 +663,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_hydration_mode');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomHydrationMode', array('test_hydrator', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator'));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomHydrationMode', ['test_hydrator', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator']);
     }
 
     public function testAddFilter()
@@ -649,17 +671,17 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_filters');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $args = array(
-            array('soft_delete', 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter'),
-            array('myFilter', 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter'),
-        );
+        $args       = [
+            ['soft_delete', 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter'],
+            ['myFilter', 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestFilter'],
+        ];
         $this->assertDICDefinitionMethodCallCount($definition, 'addFilter', $args, 2);
 
         $definition = $container->getDefinition('doctrine.orm.default_manager_configurator');
-        $this->assertDICConstructorArguments($definition, array(array('soft_delete', 'myFilter'), array('myFilter' => array('myParameter' => 'myValue', 'mySecondParameter' => 'mySecondValue'))));
+        $this->assertDICConstructorArguments($definition, [['soft_delete', 'myFilter'], ['myFilter' => ['myParameter' => 'myValue', 'mySecondParameter' => 'mySecondValue']]]);
 
         // Let's create the instance to check the configurator work.
-        /** @var $entityManager \Doctrine\ORM\EntityManager */
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
         $entityManager = $container->get('doctrine.orm.entity_manager');
         $this->assertCount(2, $entityManager->getFilters()->getEnabledFilters());
     }
@@ -669,70 +691,88 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_resolve_target_entity');
 
         $definition = $container->getDefinition('doctrine.orm.listeners.resolve_target_entity');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addResolveTargetEntity', array('Symfony\Component\Security\Core\User\UserInterface', 'MyUserClass', array()));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addResolveTargetEntity', ['Symfony\Component\Security\Core\User\UserInterface', 'MyUserClass', []]);
 
         if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
-            $this->assertEquals(array('doctrine.event_listener' => array(array('event' => 'loadClassMetadata'))), $definition->getTags());
+            $this->assertEquals(['doctrine.event_listener' => [['event' => 'loadClassMetadata']]], $definition->getTags());
         } else {
-            $this->assertEquals(array('doctrine.event_subscriber' => array(array())), $definition->getTags());
+            $this->assertEquals(['doctrine.event_subscriber' => [[]]], $definition->getTags());
         }
     }
 
     public function testAttachEntityListeners()
     {
-        if (version_compare(Version::VERSION, '2.5.0-DEV') < 0 ) {
+        if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
             $this->markTestSkipped('This test requires ORM 2.5-dev.');
         }
 
         $container = $this->loadContainer('orm_attach_entity_listener');
 
-        $definition = $container->getDefinition('doctrine.orm.default_listeners.attach_entity_listeners');
+        $definition  = $container->getDefinition('doctrine.orm.default_listeners.attach_entity_listeners');
         $methodCalls = $definition->getMethodCalls();
 
-        $this->assertDICDefinitionMethodCallCount($definition, 'addEntityListener', array(), 6);
-        $this->assertEquals(array('doctrine.event_listener' => array( array('event' => 'loadClassMetadata') ) ), $definition->getTags());
+        $this->assertDICDefinitionMethodCallCount($definition, 'addEntityListener', [], 6);
+        $this->assertEquals(['doctrine.event_listener' => [ ['event' => 'loadClassMetadata'] ] ], $definition->getTags());
 
-        $this->assertEquals($methodCalls[0], array('addEntityListener', array (
+        $this->assertEquals($methodCalls[0], [
+        'addEntityListener',
+        [
             'ExternalBundles\Entities\FooEntity',
             'MyBundles\Listeners\FooEntityListener',
             'prePersist',
             null,
-        )));
+        ],
+        ]);
 
-        $this->assertEquals($methodCalls[1], array('addEntityListener', array (
+        $this->assertEquals($methodCalls[1], [
+        'addEntityListener',
+        [
             'ExternalBundles\Entities\FooEntity',
             'MyBundles\Listeners\FooEntityListener',
             'postPersist',
             'postPersist',
-        )));
+        ],
+        ]);
 
-        $this->assertEquals($methodCalls[2], array('addEntityListener', array (
+        $this->assertEquals($methodCalls[2], [
+        'addEntityListener',
+        [
             'ExternalBundles\Entities\FooEntity',
             'MyBundles\Listeners\FooEntityListener',
             'postLoad',
             'postLoadHandler',
-        )));
+        ],
+        ]);
 
-        $this->assertEquals($methodCalls[3], array('addEntityListener', array (
+        $this->assertEquals($methodCalls[3], [
+        'addEntityListener',
+        [
             'ExternalBundles\Entities\BarEntity',
             'MyBundles\Listeners\BarEntityListener',
             'prePersist',
             'prePersist',
-        )));
+        ],
+        ]);
 
-        $this->assertEquals($methodCalls[4], array('addEntityListener', array (
+        $this->assertEquals($methodCalls[4], [
+        'addEntityListener',
+        [
             'ExternalBundles\Entities\BarEntity',
             'MyBundles\Listeners\BarEntityListener',
             'prePersist',
             'prePersistHandler',
-        )));
+        ],
+        ]);
 
-        $this->assertEquals($methodCalls[5], array('addEntityListener', array (
+        $this->assertEquals($methodCalls[5], [
+        'addEntityListener',
+        [
             'ExternalBundles\Entities\BarEntity',
             'MyBundles\Listeners\LogDeleteEntityListener',
             'postDelete',
             'postDelete',
-        )));
+        ],
+        ]);
     }
 
     public function testDbalAutoCommit()
@@ -740,7 +780,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('dbal_auto_commit');
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection.configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setAutoCommit', array(false));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setAutoCommit', [false]);
     }
 
     public function testDbalOracleConnectstring()
@@ -764,28 +804,28 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('dbal_schema_filter');
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection.configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setFilterSchemaAssetsExpression', array('^sf2_'));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setFilterSchemaAssetsExpression', ['^sf2_']);
     }
 
     public function testEntityListenerResolver()
     {
-        $container = $this->loadContainer('orm_entity_listener_resolver', array('YamlBundle'), new EntityListenerPass());
+        $container = $this->loadContainer('orm_entity_listener_resolver', ['YamlBundle'], new EntityListenerPass());
 
         $definition = $container->getDefinition('doctrine.orm.em1_configuration');
-        if (version_compare(Version::VERSION, "2.4.0-DEV") >= 0) {
-            $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityListenerResolver', array(new Reference('doctrine.orm.em1_entity_listener_resolver')));
+        if (version_compare(Version::VERSION, '2.4.0-DEV') >= 0) {
+            $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityListenerResolver', [new Reference('doctrine.orm.em1_entity_listener_resolver')]);
         }
 
         $definition = $container->getDefinition('doctrine.orm.em2_configuration');
-        if (version_compare(Version::VERSION, "2.4.0-DEV") >= 0) {
-            $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityListenerResolver', array(new Reference('doctrine.orm.em2_entity_listener_resolver')));
+        if (version_compare(Version::VERSION, '2.4.0-DEV') >= 0) {
+            $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityListenerResolver', [new Reference('doctrine.orm.em2_entity_listener_resolver')]);
         }
 
         $listener = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener1')));
+        $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener1')]);
 
         $listener = $container->getDefinition('entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener2')));
+        $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener2')]);
     }
 
     public function testAttachEntityListenerTag()
@@ -794,8 +834,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
         }
 
-        $container = $this->getContainer(array());
-        $loader = new DoctrineExtension();
+        $container = $this->getContainer([]);
+        $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
         $container->addCompilerPass(new EntityListenerPass());
 
@@ -804,16 +844,16 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->compileContainer($container);
 
         $listener = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener1')));
+        $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener1')]);
 
         $listener = $container->getDefinition('doctrine.orm.em2_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'register', array(new Reference('entity_listener2')));
+        $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener2')]);
 
         $attachListener = $container->getDefinition('doctrine.orm.em1_listeners.attach_entity_listeners');
-        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('My/Entity1', 'EntityListener1', 'postLoad'));
+        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', ['My/Entity1', 'EntityListener1', 'postLoad']);
 
         $attachListener = $container->getDefinition('doctrine.orm.em2_listeners.attach_entity_listeners');
-        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', array('My/Entity2', 'EntityListener2', 'preFlush', 'preFlushHandler'));
+        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', ['My/Entity2', 'EntityListener2', 'preFlush', 'preFlushHandler']);
     }
 
     public function testAttachEntityListenersTwoConnections()
@@ -823,7 +863,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         }
 
         $container = $this->getContainer(['YamlBundle']);
-        $loader = new DoctrineExtension();
+        $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
         $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass('doctrine.connections', 'doctrine.dbal.%s_connection.event_manager', 'doctrine'));
 
@@ -846,8 +886,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
         }
 
-        $container = $this->getContainer(array());
-        $loader = new DoctrineExtension();
+        $container = $this->getContainer([]);
+        $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
         $container->addCompilerPass(new EntityListenerPass());
 
@@ -856,10 +896,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->compileContainer($container);
 
         $resolver1 = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($resolver1, 'registerService', array('EntityListener1', 'entity_listener1'));
+        $this->assertDICDefinitionMethodCallOnce($resolver1, 'registerService', ['EntityListener1', 'entity_listener1']);
 
         $resolver2 = $container->findDefinition('custom_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($resolver2, 'registerService', array('EntityListener2', 'entity_listener2'));
+        $this->assertDICDefinitionMethodCallOnce($resolver2, 'registerService', ['EntityListener2', 'entity_listener2']);
     }
 
     /**
@@ -872,8 +912,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
         }
 
-        $container = $this->getContainer(array());
-        $loader = new DoctrineExtension();
+        $container = $this->getContainer([]);
+        $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
         $container->addCompilerPass(new EntityListenerPass());
 
@@ -888,8 +928,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
         }
 
-        $container = $this->getContainer(array());
-        $loader = new DoctrineExtension();
+        $container = $this->getContainer([]);
+        $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
         $container->addCompilerPass(new EntityListenerPass());
 
@@ -910,8 +950,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             $this->markTestSkipped('Attaching entity listeners by tag requires doctrine-orm 2.5.0 or newer');
         }
 
-        $container = $this->getContainer(array());
-        $loader = new DoctrineExtension();
+        $container = $this->getContainer([]);
+        $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
         $container->addCompilerPass(new EntityListenerPass());
 
@@ -925,17 +965,17 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_repository_factory');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setRepositoryFactory', array('repository_factory'));
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setRepositoryFactory', ['repository_factory']);
     }
 
-    private function loadContainer($fixture, array $bundles = array('YamlBundle'), CompilerPassInterface $compilerPass = null)
+    private function loadContainer($fixture, array $bundles = ['YamlBundle'], CompilerPassInterface $compilerPass = null)
     {
         $container = $this->getContainer($bundles);
         $container->registerExtension(new DoctrineExtension());
 
         $this->loadFromFile($container, $fixture);
 
-        if (null !== $compilerPass) {
+        if ($compilerPass !== null) {
             $container->addCompilerPass($compilerPass);
         }
 
@@ -946,28 +986,27 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     private function getContainer(array $bundles)
     {
-        $map = array();
+        $map = [];
         foreach ($bundles as $bundle) {
-            require_once __DIR__.'/Fixtures/Bundles/'.$bundle.'/'.$bundle.'.php';
+            require_once __DIR__ . '/Fixtures/Bundles/' . $bundle . '/' . $bundle . '.php';
 
-            $map[$bundle] = 'Fixtures\\Bundles\\'.$bundle.'\\'.$bundle;
+            $map[$bundle] = 'Fixtures\\Bundles\\' . $bundle . '\\' . $bundle;
         }
 
-        return new ContainerBuilder(new ParameterBag(array(
+        return new ContainerBuilder(new ParameterBag([
             'kernel.name' => 'app',
             'kernel.debug' => false,
             'kernel.bundles' => $map,
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
-            'kernel.root_dir' => __DIR__.'/../../', // src dir
-        )));
+            'kernel.root_dir' => __DIR__ . '/../../', // src dir
+        ]));
     }
 
     /**
      * Assertion on the Class of a DIC Service Definition.
      *
-     * @param Definition $definition
-     * @param string     $expectedClass
+     * @param string $expectedClass
      */
     private function assertDICDefinitionClass(Definition $definition, $expectedClass)
     {
@@ -976,17 +1015,17 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     private function assertDICConstructorArguments(Definition $definition, $args)
     {
-        $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '".$definition->getClass()."' don't match.");
+        $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '" . $definition->getClass() . "' don't match.");
     }
 
     private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null)
     {
         $calls = $definition->getMethodCalls();
         if (isset($calls[$pos][0])) {
-            $this->assertEquals($methodName, $calls[$pos][0], "Method '".$methodName."' is expected to be called at position $pos.");
+            $this->assertEquals($methodName, $calls[$pos][0], "Method '" . $methodName . "' is expected to be called at position " . $pos . '.');
 
             if ($params !== null) {
-                $this->assertEquals($params, $calls[$pos][1], "Expected parameters to methods '".$methodName."' do not match the actual parameters.");
+                $this->assertEquals($params, $calls[$pos][1], "Expected parameters to methods '" . $methodName . "' do not match the actual parameters.");
             }
         }
     }
@@ -994,43 +1033,42 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     /**
      * Assertion for the DI Container, check if the given definition contains a method call with the given parameters.
      *
-     * @param Definition $definition
-     * @param string     $methodName
-     * @param array      $params
+     * @param string $methodName
+     * @param array  $params
      */
     private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null)
     {
-        $calls = $definition->getMethodCalls();
+        $calls  = $definition->getMethodCalls();
         $called = false;
         foreach ($calls as $call) {
-            if ($call[0] == $methodName) {
+            if ($call[0] === $methodName) {
                 if ($called) {
-                    $this->fail("Method '".$methodName."' is expected to be called only once, a second call was registered though.");
+                    $this->fail("Method '" . $methodName . "' is expected to be called only once, a second call was registered though.");
                 } else {
                     $called = true;
                     if ($params !== null) {
-                        $this->assertEquals($params, $call[1], "Expected parameters to methods '".$methodName."' do not match the actual parameters.");
+                        $this->assertEquals($params, $call[1], "Expected parameters to methods '" . $methodName . "' do not match the actual parameters.");
                     }
                 }
             }
         }
-        if (!$called) {
-            $this->fail("Method '".$methodName."' is expected to be called once, definition does not contain a call though.");
+        if (! $called) {
+            $this->fail("Method '" . $methodName . "' is expected to be called once, definition does not contain a call though.");
         }
     }
 
-    private function assertDICDefinitionMethodCallCount(Definition $definition, $methodName, array $params = array(), $nbCalls = 1)
+    private function assertDICDefinitionMethodCallCount(Definition $definition, $methodName, array $params = [], $nbCalls = 1)
     {
-        $calls = $definition->getMethodCalls();
+        $calls  = $definition->getMethodCalls();
         $called = 0;
         foreach ($calls as $call) {
-            if ($call[0] == $methodName) {
+            if ($call[0] === $methodName) {
                 if ($called > $nbCalls) {
                     break;
                 }
 
                 if (isset($params[$called])) {
-                    $this->assertEquals($params[$called], $call[1], "Expected parameters to methods '".$methodName."' do not match the actual parameters.");
+                    $this->assertEquals($params[$called], $call[1], "Expected parameters to methods '" . $methodName . "' do not match the actual parameters.");
                 }
                 $called++;
             }
@@ -1042,15 +1080,14 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     /**
      * Assertion for the DI Container, check if the given definition does not contain a method call with the given parameters.
      *
-     * @param Definition $definition
-     * @param string     $methodName
-     * @param array      $params
+     * @param string $methodName
+     * @param array  $params
      */
     private function assertDICDefinitionNoMethodCall(Definition $definition, $methodName, array $params = null)
     {
         $calls = $definition->getMethodCalls();
         foreach ($calls as $call) {
-            if ($call[0] == $methodName) {
+            if ($call[0] === $methodName) {
                 if ($params !== null) {
                     $this->assertNotEquals($params, $call[1], "Method '" . $methodName . "' is not expected to be called with the given parameters.");
                 } else {
@@ -1062,8 +1099,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     private function compileContainer(ContainerBuilder $container)
     {
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(class_exists(ResolveChildDefinitionsPass::class) ? new ResolveChildDefinitionsPass() : new ResolveDefinitionTemplatesPass()));
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([class_exists(ResolveChildDefinitionsPass::class) ? new ResolveChildDefinitionsPass() : new ResolveDefinitionTemplatesPass()]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
     }
 }

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1,12 +1,9 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
@@ -26,15 +23,15 @@ class DoctrineExtensionTest extends TestCase
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
-        $config = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
+        $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
 
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
-        $expectedAliases = array(
+        $expectedAliases = [
             DriverConnection::class => 'database_connection',
             Connection::class => 'database_connection',
             EntityManagerInterface::class => 'doctrine.orm.entity_manager',
-        );
+        ];
 
         foreach ($expectedAliases as $id => $target) {
             $this->assertTrue($container->hasAlias($id), sprintf('The container should have a `%s` alias for autowiring support.', $id));
@@ -49,9 +46,9 @@ class DoctrineExtensionTest extends TestCase
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
-        $config = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
+        $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
 
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $this->assertTrue($container->getDefinition('doctrine')->isPublic());
         $this->assertTrue($container->getAlias('doctrine.orm.entity_manager')->isPublic());
@@ -65,7 +62,7 @@ class DoctrineExtensionTest extends TestCase
 
         $container->registerExtension($extension);
 
-        $extension->load(array(array('dbal' => array())), $container);
+        $extension->load([['dbal' => []]], $container);
 
         // doctrine.dbal.default_connection
         $this->assertEquals('%doctrine.default_connection%', $container->getDefinition('doctrine')->getArgument(3));
@@ -75,7 +72,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('localhost', $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0)['host']);
         $this->assertNull($container->getDefinition('doctrine.dbal.default_connection')->getArgument(0)['port']);
         $this->assertEquals('pdo_mysql', $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0)['driver']);
-        $this->assertEquals(array(), $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0)['driverOptions']);
+        $this->assertEquals([], $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0)['driverOptions']);
     }
 
     public function testDbalOverrideDefaultConnection()
@@ -85,7 +82,7 @@ class DoctrineExtensionTest extends TestCase
 
         $container->registerExtension($extension);
 
-        $extension->load(array(array(), array('dbal' => array('default_connection' => 'foo')), array()), $container);
+        $extension->load([[], ['dbal' => ['default_connection' => 'foo']], []], $container);
 
         // doctrine.dbal.default_connection
         $this->assertEquals('%doctrine.default_connection%', $container->getDefinition('doctrine')->getArgument(3), '->load() overrides existing configuration options');
@@ -100,54 +97,42 @@ class DoctrineExtensionTest extends TestCase
     {
         $extension = new DoctrineExtension();
 
-        $extension->load(array(array('orm' => array('auto_mapping' => true))), $this->getContainer());
+        $extension->load([['orm' => ['auto_mapping' => true]]], $this->getContainer());
     }
 
     public function getAutomappingConfigurations()
     {
-        return array(
-            array(
-                array(
-                    'em1' => array(
-                        'mappings' => array(
-                            'YamlBundle' => null,
-                        ),
-                    ),
-                    'em2' => array(
-                        'mappings' => array(
-                            'XmlBundle' => null,
-                        ),
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'em1' => array(
+        return [
+            [
+                [
+                    'em1' => [
+                        'mappings' => ['YamlBundle' => null],
+                    ],
+                    'em2' => [
+                        'mappings' => ['XmlBundle' => null],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'em1' => ['auto_mapping' => true],
+                    'em2' => [
+                        'mappings' => ['XmlBundle' => null],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'em1' => [
                         'auto_mapping' => true,
-                    ),
-                    'em2' => array(
-                        'mappings' => array(
-                            'XmlBundle' => null,
-                        ),
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'em1' => array(
-                        'auto_mapping' => true,
-                        'mappings' => array(
-                            'YamlBundle' => null,
-                        ),
-                    ),
-                    'em2' => array(
-                        'mappings' => array(
-                            'XmlBundle' => null,
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        'mappings' => ['YamlBundle' => null],
+                    ],
+                    'em2' => [
+                        'mappings' => ['XmlBundle' => null],
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -157,55 +142,51 @@ class DoctrineExtensionTest extends TestCase
     {
         $extension = new DoctrineExtension();
 
-        if (!method_exists($extension, 'fixManagersAutoMappings')) {
+        if (! method_exists($extension, 'fixManagersAutoMappings')) {
             $this->markTestSkipped('Auto mapping with multiple managers available with Symfony ~2.6');
         }
 
-        $container = $this->getContainer(array(
+        $container = $this->getContainer([
             'YamlBundle',
             'XmlBundle',
-        ));
+        ]);
 
         $extension->load(
-            array(
-                array(
-                    'dbal' => array(
+            [
+                [
+                    'dbal' => [
                         'default_connection' => 'cn1',
-                        'connections' => array(
-                            'cn1' => array(),
-                            'cn2' => array(),
-                        ),
-                    ),
-                    'orm' => array(
-                        'entity_managers' => $entityManagers,
-                    ),
-                ),
-            ), $container);
+                        'connections' => [
+                            'cn1' => [],
+                            'cn2' => [],
+                        ],
+                    ],
+                    'orm' => ['entity_managers' => $entityManagers],
+                ],
+            ],
+            $container
+        );
 
         $configEm1 = $container->getDefinition('doctrine.orm.em1_configuration');
         $configEm2 = $container->getDefinition('doctrine.orm.em2_configuration');
 
         $this->assertContains(
-            array(
+            [
                 'setEntityNamespaces',
-                array(
-                    array(
-                        'YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity',
-                    ),
-                ),
-            ),
+                [
+                    ['YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity'],
+                ],
+            ],
             $configEm1->getMethodCalls()
         );
 
         $this->assertContains(
-            array(
+            [
                 'setEntityNamespaces',
-                array(
-                    array(
-                        'XmlBundle' => 'Fixtures\Bundles\XmlBundle\Entity',
-                    ),
-                ),
-            ),
+                [
+                    ['XmlBundle' => 'Fixtures\Bundles\XmlBundle\Entity'],
+                ],
+            ],
             $configEm2->getMethodCalls()
         );
     }
@@ -215,11 +196,12 @@ class DoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
-        $extension->load(array(
-            array('dbal' => array('connections' => array('default' => array('password' => 'foo')))),
-            array(),
-            array('dbal' => array('default_connection' => 'foo')),
-            array()), $container);
+        $extension->load([
+            ['dbal' => ['connections' => ['default' => ['password' => 'foo']]]],
+            [],
+            ['dbal' => ['default_connection' => 'foo']],
+            [],
+        ], $container);
 
         $config = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
@@ -233,15 +215,19 @@ class DoctrineExtensionTest extends TestCase
         $extension = new DoctrineExtension();
 
         $extension->load(
-            array(
-                array('dbal' => array('connections' => array(
-                    'default' => array('password' => 'foo', 'wrapper_class' => TestWrapperClass::class),
-                    'second' => array('password' => 'boo'),
-                ))),
-                array(),
-                array('dbal' => array('default_connection' => 'foo')),
-                array()
-            ),
+            [
+                [
+            'dbal' => [
+            'connections' => [
+                    'default' => ['password' => 'foo', 'wrapper_class' => TestWrapperClass::class],
+                    'second' => ['password' => 'boo'],
+                ],
+            ],
+                ],
+                [],
+                ['dbal' => ['default_connection' => 'foo']],
+                [],
+            ],
             $container
         );
 
@@ -253,9 +239,9 @@ class DoctrineExtensionTest extends TestCase
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
-        $config = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
+        $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
 
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $this->assertFalse($container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
         $this->assertEquals('Doctrine\ORM\Configuration', $container->getParameter('doctrine.orm.configuration.class'));
@@ -282,23 +268,22 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('Doctrine\ORM\Cache\CacheConfiguration', $container->getParameter('doctrine.orm.second_level_cache.cache_configuration.class'));
         $this->assertEquals('Doctrine\ORM\Cache\RegionsConfiguration', $container->getParameter('doctrine.orm.second_level_cache.regions_configuration.class'));
 
-
         $config = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager(array(
+            ->addEntityManager([
                 'proxy_namespace' => 'MyProxies',
                 'auto_generate_proxy_classes' => true,
                 'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array(
-                        'mappings' => array('YamlBundle' => array()),
-                    ),
-                ),
-            ))
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => ['YamlBundle' => []],
+                    ],
+                ],
+            ])
             ->build();
 
         $container = $this->getContainer();
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
         $this->compileContainer($container);
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
@@ -314,14 +299,14 @@ class DoctrineExtensionTest extends TestCase
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
         }
 
-        $this->assertEquals(array('default' => 'doctrine.orm.default_entity_manager'), $container->getParameter('doctrine.entity_managers'), "Set of the existing EntityManagers names is incorrect.");
-        $this->assertEquals('%doctrine.entity_managers%', $container->getDefinition('doctrine')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
+        $this->assertEquals(['default' => 'doctrine.orm.default_entity_manager'], $container->getParameter('doctrine.entity_managers'), 'Set of the existing EntityManagers names is incorrect.');
+        $this->assertEquals('%doctrine.entity_managers%', $container->getDefinition('doctrine')->getArgument(2), 'Set of the existing EntityManagers names is incorrect.');
 
         $arguments = $definition->getArguments();
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
@@ -330,17 +315,17 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('doctrine.orm.default_configuration', (string) $arguments[1]);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $calls = array_values($definition->getMethodCalls());
-        $this->assertEquals(array('YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity'), $calls[0][1][0]);
+        $calls      = array_values($definition->getMethodCalls());
+        $this->assertEquals(['YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity'], $calls[0][1][0]);
         $this->assertEquals('doctrine.orm.default_metadata_cache', (string) $calls[1][1][0]);
         $this->assertEquals('doctrine.orm.default_query_cache', (string) $calls[2][1][0]);
         $this->assertEquals('doctrine.orm.default_result_cache', (string) $calls[3][1][0]);
 
-        if (version_compare(Version::VERSION, "2.3.0-DEV") >= 0) {
+        if (version_compare(Version::VERSION, '2.3.0-DEV') >= 0) {
             $this->assertEquals('doctrine.orm.naming_strategy.default', (string) $calls[10][1][0]);
             $this->assertEquals('doctrine.orm.quote_strategy.default', (string) $calls[11][1][0]);
         }
-        if (version_compare(Version::VERSION, "2.4.0-DEV") >= 0) {
+        if (version_compare(Version::VERSION, '2.4.0-DEV') >= 0) {
             $this->assertEquals('doctrine.orm.default_entity_listener_resolver', (string) $calls[12][1][0]);
         }
 
@@ -359,9 +344,14 @@ class DoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
-        $extension->load(array(array('dbal' => array('connections' => array(
-            'default' => array('password' => 'foo', 'use_savepoints' => true)
-        )))), $container);
+        $extension->load([[
+        'dbal' => [
+        'connections' => [
+            'default' => ['password' => 'foo', 'use_savepoints' => true],
+        ],
+        ],
+        ],
+        ], $container);
 
         $calls = $container->getDefinition('doctrine.dbal.default_connection')->getMethodCalls();
         $this->assertCount(1, $calls);
@@ -376,19 +366,19 @@ class DoctrineExtensionTest extends TestCase
 
         $config = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager(array(
+            ->addEntityManager([
                 'proxy_namespace' => 'MyProxies',
                 'auto_generate_proxy_classes' => 'eval',
                 'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array(
-                        'mappings' => array('YamlBundle' => array()),
-                    ),
-                ),
-            ))
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => ['YamlBundle' => []],
+                    ],
+                ],
+            ])
             ->build();
 
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $this->assertEquals(AbstractProxyFactory::AUTOGENERATE_EVAL, $container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
     }
@@ -400,26 +390,27 @@ class DoctrineExtensionTest extends TestCase
 
         $configurationArray = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
 
-        $extension->load(array($configurationArray), $container);
+        $extension->load([$configurationArray], $container);
         $this->compileContainer($container);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
         }
 
-        $this->assertDICConstructorArguments($definition, array(
-            new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
-        ));
+        $this->assertDICConstructorArguments($definition, [
+            new Reference('doctrine.dbal.default_connection'),
+        new Reference('doctrine.orm.default_configuration'),
+        ]);
     }
 
     public function testSingleEntityManagerWithDefaultSecondLevelCacheConfiguration()
     {
-        if (version_compare(Version::VERSION, "2.5.0-DEV") < 0) {
+        if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
             $this->markTestSkipped(sprintf('Second Level cache not supported by this version of the ORM : %s', Version::VERSION));
         }
         $container = $this->getContainer();
@@ -429,21 +420,22 @@ class DoctrineExtensionTest extends TestCase
             ->addBaseSecondLevelCache()
             ->build();
 
-        $extension->load(array($configurationArray), $container);
+        $extension->load([$configurationArray], $container);
         $this->compileContainer($container);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
         }
 
-        $this->assertDICConstructorArguments($definition, array(
-            new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
-        ));
+        $this->assertDICConstructorArguments($definition, [
+            new Reference('doctrine.dbal.default_connection'),
+        new Reference('doctrine.orm.default_configuration'),
+        ]);
 
         $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
         $this->assertEquals('%doctrine.orm.second_level_cache.default_cache_factory.class%', $slcDefinition->getClass());
@@ -451,7 +443,7 @@ class DoctrineExtensionTest extends TestCase
 
     public function testSingleEntityManagerWithCustomSecondLevelCacheConfiguration()
     {
-        if (version_compare(Version::VERSION, "2.5.0-DEV") < 0) {
+        if (version_compare(Version::VERSION, '2.5.0-DEV') < 0) {
             $this->markTestSkipped(sprintf('Second Level cache not supported by this version of the ORM : %s', Version::VERSION));
         }
         $container = $this->getContainer();
@@ -459,32 +451,30 @@ class DoctrineExtensionTest extends TestCase
 
         $configurationArray = BundleConfigurationBuilder::createBuilderWithBaseValues()
             ->addSecondLevelCache([
-                'region_cache_driver' => [
-                    'type' => 'memcache'],
+                'region_cache_driver' => ['type' => 'memcache'],
                 'regions' => [
-                    'hour_region' => [
-                        'lifetime' => 3600
-                    ]
+                    'hour_region' => ['lifetime' => 3600],
                 ],
                 'factory' => 'YamlBundle\Cache\MyCacheFactory',
             ])
             ->build();
 
-        $extension->load(array($configurationArray), $container);
+        $extension->load([$configurationArray], $container);
         $this->compileContainer($container);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
         if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine.orm.entity_manager.class%', 'create'), $definition->getFactory());
+            $this->assertEquals(['%doctrine.orm.entity_manager.class%', 'create'], $definition->getFactory());
         } else {
             $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
             $this->assertEquals('create', $definition->getFactoryMethod());
         }
 
-        $this->assertDICConstructorArguments($definition, array(
-            new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration'),
-        ));
+        $this->assertDICConstructorArguments($definition, [
+            new Reference('doctrine.dbal.default_connection'),
+        new Reference('doctrine.orm.default_configuration'),
+        ]);
 
         $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
         $this->assertEquals('YamlBundle\Cache\MyCacheFactory', $slcDefinition->getClass());
@@ -495,15 +485,17 @@ class DoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
-        $config = BundleConfigurationBuilder::createBuilder()
+        $config        = BundleConfigurationBuilder::createBuilder()
              ->addBaseConnection()
              ->build();
-        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))));
-        $extension->load(array($config), $container);
+        $config['orm'] = ['default_entity_manager' => 'default', 'entity_managers' => ['default' => ['mappings' => ['YamlBundle' => []]]]];
+        $extension->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
-            array(array('YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity'))
+        $this->assertDICDefinitionMethodCallOnce(
+            $definition,
+            'setEntityNamespaces',
+            [['YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity']]
         );
     }
 
@@ -512,15 +504,17 @@ class DoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
-        $config = BundleConfigurationBuilder::createBuilder()
+        $config        = BundleConfigurationBuilder::createBuilder()
              ->addBaseConnection()
              ->build();
-        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array('alias' => 'yml')))));
-        $extension->load(array($config), $container);
+        $config['orm'] = ['default_entity_manager' => 'default', 'entity_managers' => ['default' => ['mappings' => ['YamlBundle' => ['alias' => 'yml']]]]];
+        $extension->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
-            array(array('yml' => 'Fixtures\Bundles\YamlBundle\Entity'))
+        $this->assertDICDefinitionMethodCallOnce(
+            $definition,
+            'setEntityNamespaces',
+            [['yml' => 'Fixtures\Bundles\YamlBundle\Entity']]
         );
     }
 
@@ -533,13 +527,13 @@ class DoctrineExtensionTest extends TestCase
             ->addBaseConnection()
             ->addBaseEntityManager()
             ->build();
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', [
             new Reference('doctrine.orm.default_yml_metadata_driver'),
             'Fixtures\Bundles\YamlBundle\Entity',
-        ));
+        ]);
     }
 
     public function testXmlBundleMappingDetection()
@@ -549,24 +543,24 @@ class DoctrineExtensionTest extends TestCase
 
         $config = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager(array(
+            ->addEntityManager([
                 'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array(
-                        'mappings' => array(
-                            'XmlBundle' => array()
-                        )
-                    )
-                )
-            ))
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => [
+                            'XmlBundle' => [],
+                        ],
+                    ],
+                ],
+            ])
             ->build();
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', [
             new Reference('doctrine.orm.default_xml_metadata_driver'),
             'Fixtures\Bundles\XmlBundle\Entity',
-        ));
+        ]);
     }
 
     public function testAnnotationsBundleMappingDetection()
@@ -576,70 +570,70 @@ class DoctrineExtensionTest extends TestCase
 
         $config = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager(array(
+            ->addEntityManager([
                 'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array(
-                        'mappings' => array(
-                            'AnnotationsBundle' => array()
-                        )
-                    )
-                )
-            ))
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => [
+                            'AnnotationsBundle' => [],
+                        ],
+                    ],
+                ],
+            ])
             ->build();
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', [
             new Reference('doctrine.orm.default_annotation_metadata_driver'),
             'Fixtures\Bundles\AnnotationsBundle\Entity',
-        ));
+        ]);
     }
 
     public function testOrmMergeConfigs()
     {
-        $container = $this->getContainer(array('XmlBundle', 'AnnotationsBundle'));
+        $container = $this->getContainer(['XmlBundle', 'AnnotationsBundle']);
         $extension = new DoctrineExtension();
 
         $config1 = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager(array(
+            ->addEntityManager([
                 'auto_generate_proxy_classes' => true,
                 'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array(
-                        'mappings' => array(
-                            'AnnotationsBundle' => array()
-                        )
-                    ),
-                ),
-            ))
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => [
+                            'AnnotationsBundle' => [],
+                        ],
+                    ],
+                ],
+            ])
             ->build();
         $config2 = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager(array(
+            ->addEntityManager([
                 'auto_generate_proxy_classes' => false,
                 'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array(
-                        'mappings' => array(
-                            'XmlBundle' => array()
-                        )
-                    ),
-                ),
-            ))
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => [
+                            'XmlBundle' => [],
+                        ],
+                    ],
+                ],
+            ])
             ->build();
-        $extension->load(array($config1, $config2), $container);
+        $extension->load([$config1, $config2], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
-        $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', array(
+        $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', [
             new Reference('doctrine.orm.default_annotation_metadata_driver'),
             'Fixtures\Bundles\AnnotationsBundle\Entity',
-        ));
-        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', array(
+        ]);
+        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', [
             new Reference('doctrine.orm.default_xml_metadata_driver'),
             'Fixtures\Bundles\XmlBundle\Entity',
-        ));
+        ]);
 
         $configDef = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($configDef, 'setAutoGenerateProxyClasses');
@@ -660,18 +654,18 @@ class DoctrineExtensionTest extends TestCase
 
         $config = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager(array(
+            ->addEntityManager([
                 'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array(
-                        'mappings' => array(
-                            'AnnotationsBundle' => array()
-                        )
-                    )
-                )
-            ))
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => [
+                            'AnnotationsBundle' => [],
+                        ],
+                    ],
+                ],
+            ])
             ->build();
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $calls = $container->getDefinition('doctrine.orm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.orm.default_annotation_metadata_driver', (string) $calls[0][1][0]);
@@ -685,20 +679,14 @@ class DoctrineExtensionTest extends TestCase
 
         $config = BundleConfigurationBuilder::createBuilder()
              ->addBaseConnection()
-             ->addEntityManager(array(
-                 'metadata_cache_driver' => array(
-                     'cache_provider' => 'metadata_cache',
-                 ),
-                 'query_cache_driver' => array(
-                     'cache_provider' => 'query_cache',
-                 ),
-                 'result_cache_driver' => array(
-                     'cache_provider' => 'result_cache',
-                 ),
-             ))
+             ->addEntityManager([
+                 'metadata_cache_driver' => ['cache_provider' => 'metadata_cache'],
+                 'query_cache_driver' => ['cache_provider' => 'query_cache'],
+                 'result_cache_driver' => ['cache_provider' => 'result_cache'],
+             ])
             ->build();
 
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $this->assertTrue($container->hasAlias('doctrine.orm.default_metadata_cache'));
         $alias = $container->getAlias('doctrine.orm.default_metadata_cache');
@@ -719,19 +707,19 @@ class DoctrineExtensionTest extends TestCase
         $extension = new DoctrineExtension();
 
         $config = BundleConfigurationBuilder::createBuilder()
-             ->addConnection(array(
-                 'connections' => array(
-                     'foo' => array(
-                         'shards' => array(
-                             'test' => array('id' => 1)
-                         ),
-                     ),
-                     'bar' => array(),
-                 ),
-             ))
+             ->addConnection([
+                 'connections' => [
+                     'foo' => [
+                         'shards' => [
+                             'test' => ['id' => 1],
+                         ],
+                     ],
+                     'bar' => [],
+                 ],
+             ])
             ->build();
 
-        $extension->load(array($config), $container);
+        $extension->load([$config], $container);
 
         $this->assertTrue($container->hasDefinition('doctrine.dbal.foo_shard_manager'));
         $this->assertFalse($container->hasDefinition('doctrine.dbal.bar_shard_manager'));
@@ -741,36 +729,36 @@ class DoctrineExtensionTest extends TestCase
     {
         $bundles = (array) $bundles;
 
-        $map = array();
+        $map = [];
         foreach ($bundles as $bundle) {
-            require_once __DIR__.'/Fixtures/Bundles/'.($vendor ? $vendor.'/' : '').$bundle.'/'.$bundle.'.php';
+            require_once __DIR__ . '/Fixtures/Bundles/' . ($vendor ? $vendor . '/' : '') . $bundle . '/' . $bundle . '.php';
 
-            $map[$bundle] = 'Fixtures\\Bundles\\'.($vendor ? $vendor.'\\' : '').$bundle.'\\'.$bundle;
+            $map[$bundle] = 'Fixtures\\Bundles\\' . ($vendor ? $vendor . '\\' : '') . $bundle . '\\' . $bundle;
         }
 
-        return new ContainerBuilder(new ParameterBag(array(
+        return new ContainerBuilder(new ParameterBag([
             'kernel.name' => 'app',
             'kernel.debug' => false,
             'kernel.bundles' => $map,
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
-            'kernel.root_dir' => __DIR__.'/../../', // src dir
-        )));
+            'kernel.root_dir' => __DIR__ . '/../../', // src dir
+        ]));
     }
 
     private function assertDICConstructorArguments(Definition $definition, array $args)
     {
-        $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '".$definition->getClass()."' don't match.");
+        $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '" . $definition->getClass() . "' don't match.");
     }
 
     private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null)
     {
         $calls = $definition->getMethodCalls();
         if (isset($calls[$pos][0])) {
-            $this->assertEquals($methodName, $calls[$pos][0], "Method '".$methodName."' is expected to be called at position $pos.");
+            $this->assertEquals($methodName, $calls[$pos][0], "Method '" . $methodName . "' is expected to be called at position " . $pos . '.');
 
             if ($params !== null) {
-                $this->assertEquals($params, $calls[$pos][1], "Expected parameters to methods '".$methodName."' do not match the actual parameters.");
+                $this->assertEquals($params, $calls[$pos][1], "Expected parameters to methods '" . $methodName . "' do not match the actual parameters.");
             }
         }
     }
@@ -778,38 +766,38 @@ class DoctrineExtensionTest extends TestCase
     /**
      * Assertion for the DI Container, check if the given definition contains a method call with the given parameters.
      *
-     * @param Definition $definition
      * @param string     $methodName
      * @param array|null $params
      */
     private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null)
     {
-        $calls = $definition->getMethodCalls();
+        $calls  = $definition->getMethodCalls();
         $called = false;
         foreach ($calls as $call) {
             if ($call[0] === $methodName) {
                 if ($called) {
-                    $this->fail("Method '".$methodName."' is expected to be called only once, a second call was registered though.");
+                    $this->fail("Method '" . $methodName . "' is expected to be called only once, a second call was registered though.");
                 } else {
                     $called = true;
                     if ($params !== null) {
-                        $this->assertEquals($params, $call[1], "Expected parameters to methods '".$methodName."' do not match the actual parameters.");
+                        $this->assertEquals($params, $call[1], "Expected parameters to methods '" . $methodName . "' do not match the actual parameters.");
                     }
                 }
             }
         }
-        if (!$called) {
-            $this->fail("Method '".$methodName."' is expected to be called once, definition does not contain a call though.");
+        if (! $called) {
+            $this->fail("Method '" . $methodName . "' is expected to be called once, definition does not contain a call though.");
         }
     }
 
     private function compileContainer(ContainerBuilder $container)
     {
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(class_exists(ResolveChildDefinitionsPass::class) ? new ResolveChildDefinitionsPass() : new ResolveDefinitionTemplatesPass()));
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([class_exists(ResolveChildDefinitionsPass::class) ? new ResolveChildDefinitionsPass() : new ResolveDefinitionTemplatesPass()]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
     }
-
 }
 
-class TestWrapperClass extends Connection {}
+class TestWrapperClass extends Connection
+{
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/AnnotationsBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/AnnotationsBundle.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\AnnotationsBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/Test.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\AnnotationsBundle\Entity;
 
 class Test

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomClassRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomClassRepoEntity.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -14,6 +13,8 @@ class TestCustomClassRepoEntity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     private $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomServiceRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomServiceRepoEntity.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -14,6 +13,8 @@ class TestCustomServiceRepoEntity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     private $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -14,6 +13,8 @@ class TestDefaultRepoEntity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     private $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
@@ -1,12 +1,8 @@
 <?php
 
-
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
-use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\EntityRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomServiceRepoEntity;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class TestCustomClassRepoRepository extends EntityRepository
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/RepositoryServiceBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/RepositoryServiceBundle.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\RepositoryServiceBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/AnnotationsBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/AnnotationsBundle.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\Vendor\AnnotationsBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/Entity/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/Entity/Test.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\Vendor\AnnotationsBundle\Entity;
 
 class Test

--- a/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Entity/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Entity/Test.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\XmlBundle\Entity;
 
 class Test

--- a/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/XmlBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/XmlBundle.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\XmlBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Tests/DependencyInjection/Fixtures/Bundles/YamlBundle/Entity/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/YamlBundle/Entity/Test.php
@@ -1,9 +1,9 @@
 <?php
 
-
 namespace Fixtures\Bundles\YamlBundle\Entity;
 
 class Test
 {
+    /** @var mixed */
     private $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/YamlBundle/YamlBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/YamlBundle/YamlBundle.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Fixtures\Bundles\YamlBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Tests/DependencyInjection/TestDatetimeFunction.php
+++ b/Tests/DependencyInjection/TestDatetimeFunction.php
@@ -1,11 +1,10 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
 
 class TestDatetimeFunction extends FunctionNode
 {

--- a/Tests/DependencyInjection/TestFilter.php
+++ b/Tests/DependencyInjection/TestFilter.php
@@ -1,17 +1,14 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
-use Doctrine\ORM\Query\Filter\SQLFilter;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
 
 class TestFilter extends SQLFilter
 {
     /**
      * Gets the SQL query part to add to a query.
-     *
-     * @return string The constraint SQL if there is available, empty string otherwise
      */
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {

--- a/Tests/DependencyInjection/TestNumericFunction.php
+++ b/Tests/DependencyInjection/TestNumericFunction.php
@@ -1,11 +1,10 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
 
 class TestNumericFunction extends FunctionNode
 {

--- a/Tests/DependencyInjection/TestStringFunction.php
+++ b/Tests/DependencyInjection/TestStringFunction.php
@@ -1,11 +1,10 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
 
 class TestStringFunction extends FunctionNode
 {

--- a/Tests/DependencyInjection/TestType.php
+++ b/Tests/DependencyInjection/TestType.php
@@ -1,11 +1,11 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
 
-class TestType extends \Doctrine\DBAL\Types\Type
+class TestType extends Type
 {
     public function getName()
     {

--- a/Tests/DependencyInjection/XMLSchemaTest.php
+++ b/Tests/DependencyInjection/XMLSchemaTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
@@ -9,11 +8,11 @@ class XMLSchemaTest extends TestCase
 {
     public static function dataValidateSchemaFiles()
     {
-        $schemaFiles = array();
-        $di = new \DirectoryIterator(__DIR__.'/Fixtures/config/xml');
+        $schemaFiles = [];
+        $di          = new \DirectoryIterator(__DIR__ . '/Fixtures/config/xml');
         foreach ($di as $element) {
-            if ($element->isFile() && substr($element->getFilename(), -4) === ".xml") {
-                $schemaFiles[] = array($element->getPathname());
+            if ($element->isFile() && substr($element->getFilename(), -4) === '.xml') {
+                $schemaFiles[] = [$element->getPathname()];
             }
         }
 
@@ -26,33 +25,33 @@ class XMLSchemaTest extends TestCase
     public function testValidateSchema($file)
     {
         $found = false;
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom   = new \DOMDocument('1.0', 'UTF-8');
         $dom->load($file);
 
         $xmlns = 'http://symfony.com/schema/dic/doctrine';
 
         $dbalElements = $dom->getElementsByTagNameNS($xmlns, 'dbal');
         if ($dbalElements->length) {
-            $dbalDom = new \DOMDocument('1.0', 'UTF-8');
-            $dbalNode = $dbalDom->importNode($dbalElements->item(0));
+            $dbalDom    = new \DOMDocument('1.0', 'UTF-8');
+            $dbalNode   = $dbalDom->importNode($dbalElements->item(0));
             $configNode = $dbalDom->createElementNS($xmlns, 'config');
             $configNode->appendChild($dbalNode);
             $dbalDom->appendChild($configNode);
 
-            $ret = $dbalDom->schemaValidate(__DIR__.'/../../Resources/config/schema/doctrine-1.0.xsd');
+            $ret = $dbalDom->schemaValidate(__DIR__ . '/../../Resources/config/schema/doctrine-1.0.xsd');
             $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
             $found = true;
         }
 
         $ormElements = $dom->getElementsByTagNameNS($xmlns, 'orm');
         if ($ormElements->length) {
-            $ormDom = new \DOMDocument('1.0', 'UTF-8');
-            $ormNode = $ormDom->importNode($ormElements->item(0));
+            $ormDom     = new \DOMDocument('1.0', 'UTF-8');
+            $ormNode    = $ormDom->importNode($ormElements->item(0));
             $configNode = $ormDom->createElementNS($xmlns, 'config');
             $configNode->appendChild($ormNode);
             $ormDom->appendChild($configNode);
 
-            $ret = $ormDom->schemaValidate(__DIR__.'/../../Resources/config/schema/doctrine-1.0.xsd');
+            $ret = $ormDom->schemaValidate(__DIR__ . '/../../Resources/config/schema/doctrine-1.0.xsd');
             $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
             $found = true;
         }

--- a/Tests/DependencyInjection/XmlDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/XmlDoctrineExtensionTest.php
@@ -1,17 +1,16 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\Config\FileLocator;
 
 class XmlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
 {
     protected function loadFromFile(ContainerBuilder $container, $file)
     {
-        $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/config/xml'));
-        $loadXml->load($file.'.xml');
+        $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/xml'));
+        $loadXml->load($file . '.xml');
     }
 }

--- a/Tests/DependencyInjection/YamlDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/YamlDoctrineExtensionTest.php
@@ -1,17 +1,16 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\Config\FileLocator;
 
 class YamlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
 {
     protected function loadFromFile(ContainerBuilder $container, $file)
     {
-        $loadYaml = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/config/yml'));
-        $loadYaml->load($file.'.yml');
+        $loadYaml = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/yml'));
+        $loadYaml->load($file . '.yml');
     }
 }

--- a/Tests/Mapping/ContainerAwareEntityListenerResolverTest.php
+++ b/Tests/Mapping/ContainerAwareEntityListenerResolverTest.php
@@ -20,7 +20,7 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
 
     protected function setUp()
     {
-        if (!interface_exists('\Doctrine\ORM\Mapping\EntityListenerResolver')) {
+        if (! interface_exists('\Doctrine\ORM\Mapping\EntityListenerResolver')) {
             $this->markTestSkipped('Entity listeners are not supported in this Doctrine version');
         }
 
@@ -32,8 +32,8 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
 
     public function testResolveClass()
     {
-        $className  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
-        $object     = $this->resolver->resolve($className);
+        $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
+        $object    = $this->resolver->resolve($className);
 
         $this->assertInstanceOf($className, $object);
         $this->assertSame($object, $this->resolver->resolve($className));
@@ -41,8 +41,8 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
 
     public function testRegisterClassAndResolve()
     {
-        $className  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
-        $object     = new $className();
+        $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
+        $object    = new $className();
 
         $this->resolver->register($object);
 
@@ -51,9 +51,9 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
 
     public function testRegisterServiceAndResolve()
     {
-        $className  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
-        $serviceId  = 'app.entity_listener';
-        $object     = new $className();
+        $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
+        $serviceId = 'app.entity_listener';
+        $object    = new $className();
 
         $this->resolver->registerService($className, $serviceId);
         $this->container
@@ -79,8 +79,8 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
      */
     public function testRegisterMissingServiceAndResolve()
     {
-        $className  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
-        $serviceId  = 'app.entity_listener';
+        $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
+        $serviceId = 'app.entity_listener';
 
         $this->resolver->registerService($className, $serviceId);
         $this->container
@@ -95,8 +95,8 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
 
     public function testClearOne()
     {
-        $className1  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
-        $className2  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener2';
+        $className1 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
+        $className2 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener2';
 
         $obj1 = $this->resolver->resolve($className1);
         $obj2 = $this->resolver->resolve($className2);
@@ -118,8 +118,8 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
 
     public function testClearAll()
     {
-        $className1  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
-        $className2  = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener2';
+        $className1 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
+        $className2 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener2';
 
         $obj1 = $this->resolver->resolve($className1);
         $obj2 = $this->resolver->resolve($className2);

--- a/Tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/Tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Doctrine Bundle
- *
- * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Mapping;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\ClassMetadataCollection;
@@ -22,7 +13,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
     {
         parent::setUp();
 
-        if (!class_exists('Doctrine\\ORM\\Version')) {
+        if (! class_exists('Doctrine\\ORM\\Version')) {
             $this->markTestSkipped('Doctrine ORM is not available.');
         }
     }
@@ -33,22 +24,22 @@ class DisconnectedMetadataFactoryTest extends TestCase
      */
     public function testCannotFindNamespaceAndPathForMetadata()
     {
-        $class = new ClassMetadataInfo(__CLASS__);
-        $collection = new ClassMetadataCollection(array($class));
+        $class      = new ClassMetadataInfo(__CLASS__);
+        $collection = new ClassMetadataCollection([$class]);
 
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
-        $factory = new DisconnectedMetadataFactory($registry);
+        $factory  = new DisconnectedMetadataFactory($registry);
 
         $factory->findNamespaceAndPathForMetadata($collection);
     }
 
     public function testFindNamespaceAndPathForMetadata()
     {
-        $class = new ClassMetadataInfo('\Vendor\Package\Class');
-        $collection = new ClassMetadataCollection(array($class));
+        $class      = new ClassMetadataInfo('\Vendor\Package\Class');
+        $collection = new ClassMetadataCollection([$class]);
 
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
-        $factory = new DisconnectedMetadataFactory($registry);
+        $factory  = new DisconnectedMetadataFactory($registry);
 
         $factory->findNamespaceAndPathForMetadata($collection, '/path/to/code');
 

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
-
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -24,21 +23,23 @@ class ProfilerTest extends BaseTestCase
 {
     /** @var DebugStack */
     private $logger;
+
     /** @var \Twig_Environment */
     private $twig;
+
     /** @var DoctrineDataCollector */
     private $collector;
 
     public function setUp()
     {
         $this->logger = new DebugStack();
-        $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
+        $registry     = $this->getMockBuilder(ManagerRegistry::class)->getMock();
         $registry->expects($this->once())->method('getManagers')->willReturn([]);
         $this->collector = new DoctrineDataCollector($registry);
         $this->collector->addLogger('foo', $this->logger);
 
-        $twigLoaderFilesystem = new \Twig_Loader_Filesystem(__DIR__.'/../Resources/views/Collector');
-        $twigLoaderFilesystem->addPath(__DIR__.'/../vendor/symfony/web-profiler-bundle/Resources/views', 'WebProfiler');
+        $twigLoaderFilesystem = new \Twig_Loader_Filesystem(__DIR__ . '/../Resources/views/Collector');
+        $twigLoaderFilesystem->addPath(__DIR__ . '/../vendor/symfony/web-profiler-bundle/Resources/views', 'WebProfiler');
         $this->twig = new \Twig_Environment($twigLoaderFilesystem, ['debug' => true, 'strict_variables' => true]);
 
         $this->twig->addExtension(new CodeExtension('', '', ''));
@@ -80,7 +81,7 @@ class ProfilerTest extends BaseTestCase
             'queries' => $this->logger->queries,
         ]);
 
-        $output = str_replace(["\e[37m", "\e[0m", "\e[32;1m", "\e[34;1m"], "", $output);
+        $output = str_replace(["\e[37m", "\e[0m", "\e[32;1m", "\e[34;1m"], '', $output);
         $this->assertContains("SELECT * FROM foo WHERE bar IN ('foo', 'bar');", $output);
     }
 }

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
@@ -10,7 +9,7 @@ class RegistryTest extends TestCase
     public function testGetDefaultConnectionName()
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $registry = new Registry($container, array(), array(), 'default', 'default');
+        $registry  = new Registry($container, [], [], 'default', 'default');
 
         $this->assertEquals('default', $registry->getDefaultConnectionName());
     }
@@ -18,35 +17,35 @@ class RegistryTest extends TestCase
     public function testGetDefaultEntityManagerName()
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $registry = new Registry($container, array(), array(), 'default', 'default');
+        $registry  = new Registry($container, [], [], 'default', 'default');
 
         $this->assertEquals('default', $registry->getDefaultManagerName());
     }
 
     public function testGetDefaultConnection()
     {
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $conn      = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.dbal.default_connection'))
                   ->will($this->returnValue($conn));
 
-        $registry = new Registry($container, array('default' => 'doctrine.dbal.default_connection'), array(), 'default', 'default');
+        $registry = new Registry($container, ['default' => 'doctrine.dbal.default_connection'], [], 'default', 'default');
 
         $this->assertSame($conn, $registry->getConnection());
     }
 
     public function testGetConnection()
     {
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $conn      = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.dbal.default_connection'))
                   ->will($this->returnValue($conn));
 
-        $registry = new Registry($container, array('default' => 'doctrine.dbal.default_connection'), array(), 'default', 'default');
+        $registry = new Registry($container, ['default' => 'doctrine.dbal.default_connection'], [], 'default', 'default');
 
         $this->assertSame($conn, $registry->getConnection('default'));
     }
@@ -58,7 +57,7 @@ class RegistryTest extends TestCase
     public function testGetUnknownConnection()
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $registry = new Registry($container, array(), array(), 'default', 'default');
+        $registry  = new Registry($container, [], [], 'default', 'default');
 
         $registry->getConnection('default');
     }
@@ -66,35 +65,35 @@ class RegistryTest extends TestCase
     public function testGetConnectionNames()
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $registry = new Registry($container, array('default' => 'doctrine.dbal.default_connection'), array(), 'default', 'default');
+        $registry  = new Registry($container, ['default' => 'doctrine.dbal.default_connection'], [], 'default', 'default');
 
-        $this->assertEquals(array('default' => 'doctrine.dbal.default_connection'), $registry->getConnectionNames());
+        $this->assertEquals(['default' => 'doctrine.dbal.default_connection'], $registry->getConnectionNames());
     }
 
     public function testGetDefaultEntityManager()
     {
-        $em = new \stdClass();
+        $em        = new \stdClass();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))
                   ->will($this->returnValue($em));
 
-        $registry = new Registry($container, array(), array('default' => 'doctrine.orm.default_entity_manager'), 'default', 'default');
+        $registry = new Registry($container, [], ['default' => 'doctrine.orm.default_entity_manager'], 'default', 'default');
 
         $this->assertSame($em, $registry->getManager());
     }
 
     public function testGetEntityManager()
     {
-        $em = new \stdClass();
+        $em        = new \stdClass();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))
                   ->will($this->returnValue($em));
 
-        $registry = new Registry($container, array(), array('default' => 'doctrine.orm.default_entity_manager'), 'default', 'default');
+        $registry = new Registry($container, [], ['default' => 'doctrine.orm.default_entity_manager'], 'default', 'default');
 
         $this->assertSame($em, $registry->getManager('default'));
     }
@@ -106,7 +105,7 @@ class RegistryTest extends TestCase
     public function testGetUnknownEntityManager()
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $registry = new Registry($container, array(), array(), 'default', 'default');
+        $registry  = new Registry($container, [], [], 'default', 'default');
 
         $registry->getManager('default');
     }
@@ -118,7 +117,7 @@ class RegistryTest extends TestCase
     public function testResetUnknownEntityManager()
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $registry = new Registry($container, array(), array(), 'default', 'default');
+        $registry  = new Registry($container, [], [], 'default', 'default');
 
         $registry->resetManager('default');
     }

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -15,17 +15,13 @@ class ContainerRepositoryFactoryTest extends TestCase
 {
     public function testGetRepositoryReturnsService()
     {
-        if (!interface_exists(ContainerInterface::class)) {
+        if (! interface_exists(ContainerInterface::class)) {
             $this->markTestSkipped('Symfony 3.3 is needed for this feature.');
         }
 
-        $em = $this->createEntityManager([
-            'Foo\CoolEntity' => 'my_repo',
-        ]);
-        $repo = new StubRepository($em, new ClassMetadata(''));
-        $container = $this->createContainer([
-            'my_repo' => $repo,
-        ]);
+        $em        = $this->createEntityManager(['Foo\CoolEntity' => 'my_repo']);
+        $repo      = new StubRepository($em, new ClassMetadata(''));
+        $container = $this->createContainer(['my_repo' => $repo]);
 
         $factory = new ContainerRepositoryFactory($container);
         $this->assertSame($repo, $factory->getRepository($em, 'Foo\CoolEntity'));
@@ -33,16 +29,14 @@ class ContainerRepositoryFactoryTest extends TestCase
 
     public function testGetRepositoryReturnsEntityRepository()
     {
-        if (!interface_exists(ContainerInterface::class)) {
+        if (! interface_exists(ContainerInterface::class)) {
             $this->markTestSkipped('Symfony 3.3 is needed for this feature.');
         }
 
         $container = $this->createContainer([]);
-        $em = $this->createEntityManager([
-            'Foo\BoringEntity' => null,
-        ]);
+        $em        = $this->createEntityManager(['Foo\BoringEntity' => null]);
 
-        $factory = new ContainerRepositoryFactory($container);
+        $factory    = new ContainerRepositoryFactory($container);
         $actualRepo = $factory->getRepository($em, 'Foo\BoringEntity');
         $this->assertInstanceOf(EntityRepository::class, $actualRepo);
         // test the same instance is returned
@@ -51,16 +45,16 @@ class ContainerRepositoryFactoryTest extends TestCase
 
     public function testCustomRepositoryIsReturned()
     {
-        if (!interface_exists(ContainerInterface::class)) {
+        if (! interface_exists(ContainerInterface::class)) {
             $this->markTestSkipped('Symfony 3.3 is needed for this feature.');
         }
 
         $container = $this->createContainer([]);
-        $em = $this->createEntityManager([
+        $em        = $this->createEntityManager([
             'Foo\CustomNormalRepoEntity' => StubRepository::class,
         ]);
 
-        $factory = new ContainerRepositoryFactory($container);
+        $factory    = new ContainerRepositoryFactory($container);
         $actualRepo = $factory->getRepository($em, 'Foo\CustomNormalRepoEntity');
         $this->assertInstanceOf(StubRepository::class, $actualRepo);
         // test the same instance is returned
@@ -73,19 +67,15 @@ class ContainerRepositoryFactoryTest extends TestCase
      */
     public function testServiceRepositoriesMustExtendEntityRepository()
     {
-        if (!interface_exists(ContainerInterface::class)) {
+        if (! interface_exists(ContainerInterface::class)) {
             $this->markTestSkipped('Symfony 3.3 is needed for this feature.');
         }
 
         $repo = new \stdClass();
 
-        $container = $this->createContainer([
-            'my_repo' => $repo,
-        ]);
+        $container = $this->createContainer(['my_repo' => $repo]);
 
-        $em = $this->createEntityManager([
-            'Foo\CoolEntity' => 'my_repo',
-        ]);
+        $em = $this->createEntityManager(['Foo\CoolEntity' => 'my_repo']);
 
         $factory = new ContainerRepositoryFactory($container);
         $factory->getRepository($em, 'Foo\CoolEntity');
@@ -97,7 +87,7 @@ class ContainerRepositoryFactoryTest extends TestCase
      */
     public function testRepositoryMatchesServiceInterfaceButServiceNotFound()
     {
-        if (!interface_exists(ContainerInterface::class)) {
+        if (! interface_exists(ContainerInterface::class)) {
             $this->markTestSkipped('Symfony 3.3 is needed for this feature.');
         }
 
@@ -124,9 +114,7 @@ class ContainerRepositoryFactoryTest extends TestCase
             $container = null;
         }
 
-        $em = $this->createEntityManager([
-            'Foo\CoolEntity' => 'not_a_real_class',
-        ]);
+        $em = $this->createEntityManager(['Foo\CoolEntity' => 'not_a_real_class']);
 
         $factory = new ContainerRepositoryFactory($container);
         $factory->getRepository($em, 'Foo\CoolEntity');
@@ -153,7 +141,7 @@ class ContainerRepositoryFactoryTest extends TestCase
     {
         $classMetadatas = [];
         foreach ($entityRepositoryClasses as $entityClass => $entityRepositoryClass) {
-            $metadata = new ClassMetadata($entityClass);
+            $metadata                            = new ClassMetadata($entityClass);
             $metadata->customRepositoryClassName = $entityRepositoryClass;
 
             $classMetadatas[$entityClass] = $metadata;

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
@@ -13,8 +12,8 @@ use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomClassRepoEntity;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomServiceRepoEntity;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestDefaultRepoEntity;
 use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\RepositoryServiceBundle;
 use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoRepository;
+use Fixtures\Bundles\RepositoryServiceBundle\RepositoryServiceBundle;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -25,7 +24,7 @@ class ServiceRepositoryTest extends TestCase
     {
         parent::setUp();
 
-        if (!class_exists('Doctrine\\ORM\\Version')) {
+        if (! class_exists('Doctrine\\ORM\\Version')) {
             $this->markTestSkipped('Doctrine ORM is not available.');
         }
     }
@@ -33,7 +32,7 @@ class ServiceRepositoryTest extends TestCase
     public function testRepositoryServiceWiring()
     {
         // needed for older versions of Doctrine
-        AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
+        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
 
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.name' => 'app',
@@ -41,7 +40,7 @@ class ServiceRepositoryTest extends TestCase
             'kernel.bundles' => ['RepositoryServiceBundle' => RepositoryServiceBundle::class],
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
-            'kernel.root_dir' => __DIR__.'/../../../../', // src dir
+            'kernel.root_dir' => __DIR__ . '/../../../../', // src dir
         ]));
         $container->set('annotation_reader', new AnnotationReader());
         $extension = new DoctrineExtension();
@@ -52,13 +51,16 @@ class ServiceRepositoryTest extends TestCase
                 'charset' => 'UTF8',
             ],
             'orm' => [
-                'mappings' => ['RepositoryServiceBundle' => [
+                'mappings' => [
+            'RepositoryServiceBundle' => [
                     'type' => 'annotation',
-                    'dir' => __DIR__.'/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity',
+                    'dir' => __DIR__ . '/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity',
                     'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Entity',
-                ]],
+                ],
+                ],
             ],
-        ]], $container);
+        ],
+        ], $container);
 
         $def = $container->register(TestCustomServiceRepoRepository::class, TestCustomServiceRepoRepository::class)
             ->setPublic(false);
@@ -94,7 +96,7 @@ class ServiceRepositoryTest extends TestCase
 
         // Symfony 3.2 and lower should work normally in traditional cases (tested above)
         // the code below should *not* work (by design)
-        if (!class_exists(ServiceLocatorTagPass::class)) {
+        if (! class_exists(ServiceLocatorTagPass::class)) {
             $message = '/Support for loading entities from the service container only works for Symfony 3\.3/';
             if (method_exists($this, 'expectException')) {
                 $this->expectException(\RuntimeException::class);

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -1,74 +1,74 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 
 class TestCase extends BaseTestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Doctrine\\Common\\Version')) {
+        if (! class_exists('Doctrine\\Common\\Version')) {
             $this->markTestSkipped('Doctrine is not available.');
         }
     }
 
     public function createYamlBundleTestContainer()
     {
-        $container = new ContainerBuilder(new ParameterBag(array(
+        $container = new ContainerBuilder(new ParameterBag([
             'kernel.name' => 'app',
             'kernel.debug' => false,
-            'kernel.bundles' => array('YamlBundle' => 'Fixtures\Bundles\YamlBundle\YamlBundle'),
+            'kernel.bundles' => ['YamlBundle' => 'Fixtures\Bundles\YamlBundle\YamlBundle'],
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
-            'kernel.root_dir' => __DIR__.'/../../../../', // src dir
-        )));
+            'kernel.root_dir' => __DIR__ . '/../../../../', // src dir
+        ]));
         $container->set('annotation_reader', new AnnotationReader());
         $extension = new DoctrineExtension();
         $container->registerExtension($extension);
-        $extension->load(array(array(
-            'dbal' => array(
-                'connections' => array(
-                    'default' => array(
+        $extension->load([[
+            'dbal' => [
+                'connections' => [
+                    'default' => [
                         'driver' => 'pdo_mysql',
                         'charset' => 'UTF8',
                         'platform-service' => 'my.platform',
-                    ),
-                ),
+                    ],
+                ],
                 'default_connection' => 'default',
-                'types' => array(
+                'types' => [
                     'test' => TestType::class,
-                ),
-            ), 'orm' => array(
+                ],
+            ], 'orm' => [
                 'default_entity_manager' => 'default',
-                'entity_managers' => array (
-                    'default' => array(
-                        'mappings' => array('YamlBundle' => array(
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => [
+            'YamlBundle' => [
                             'type' => 'yml',
-                            'dir' => __DIR__.'/DependencyInjection/Fixtures/Bundles/YamlBundle/Resources/config/doctrine',
+                            'dir' => __DIR__ . '/DependencyInjection/Fixtures/Bundles/YamlBundle/Resources/config/doctrine',
                             'prefix' => 'Fixtures\Bundles\YamlBundle\Entity',
-                        )),
-                    ),
-                ),
-                'resolve_target_entities' => array(
-                    'Symfony\Component\Security\Core\User\UserInterface' => 'stdClass',
-                ),
-            ),
-        )), $container);
+                        ],
+                        ],
+                    ],
+                ],
+                'resolve_target_entities' => ['Symfony\Component\Security\Core\User\UserInterface' => 'stdClass'],
+            ],
+        ],
+        ], $container);
 
         $container->setDefinition('my.platform', new Definition('Doctrine\DBAL\Platforms\MySqlPlatform'));
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(class_exists(ResolveChildDefinitionsPass::class) ? new ResolveChildDefinitionsPass() : new ResolveDefinitionTemplatesPass()));
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([class_exists(ResolveChildDefinitionsPass::class) ? new ResolveChildDefinitionsPass() : new ResolveDefinitionTemplatesPass()]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         return $container;

--- a/Tests/Twig/DoctrineExtensionTest.php
+++ b/Tests/Twig/DoctrineExtensionTest.php
@@ -1,15 +1,4 @@
 <?php
-/*
- * This file is part of the Doctrine Bundle
- *
- * The code was originally distributed inside the Symfony framework.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
-*/
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Twig;
 
@@ -20,9 +9,9 @@ class DoctrineExtensionTest extends TestCase
 {
     public function testReplaceQueryParametersWithPostgresCasting()
     {
-        $extension = new DoctrineExtension();
-        $query = 'a=? OR (1)::string OR b=?';
-        $parameters = array(1, 2);
+        $extension  = new DoctrineExtension();
+        $query      = 'a=? OR (1)::string OR b=?';
+        $parameters = [1, 2];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
         $this->assertEquals('a=1 OR (1)::string OR b=2', $result);
@@ -30,12 +19,12 @@ class DoctrineExtensionTest extends TestCase
 
     public function testReplaceQueryParametersWithStartingIndexAtOne()
     {
-        $extension = new DoctrineExtension();
-        $query = 'a=? OR b=?';
-        $parameters = array(
+        $extension  = new DoctrineExtension();
+        $query      = 'a=? OR b=?';
+        $parameters = [
             1 => 1,
-            2 => 2
-        );
+            2 => 2,
+        ];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
         $this->assertEquals('a=1 OR b=2', $result);
@@ -43,12 +32,12 @@ class DoctrineExtensionTest extends TestCase
 
     public function testReplaceQueryParameters()
     {
-        $extension = new DoctrineExtension();
-        $query = 'a=? OR b=?';
-        $parameters = array(
+        $extension  = new DoctrineExtension();
+        $query      = 'a=? OR b=?';
+        $parameters = [
             1,
-            2
-        );
+            2,
+        ];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
         $this->assertEquals('a=1 OR b=2', $result);
@@ -56,12 +45,12 @@ class DoctrineExtensionTest extends TestCase
 
     public function testReplaceQueryParametersWithNamedIndex()
     {
-        $extension = new DoctrineExtension();
-        $query = 'a=:a OR b=:b';
-        $parameters = array(
+        $extension  = new DoctrineExtension();
+        $query      = 'a=:a OR b=:b';
+        $parameters = [
             'a' => 1,
-            'b' => 2
-        );
+            'b' => 2,
+        ];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
         $this->assertEquals('a=1 OR b=2', $result);
@@ -80,7 +69,7 @@ class DoctrineExtensionTest extends TestCase
 
     public function testEscapeArrayParameter()
     {
-        $this->assertEquals("1, NULL, 'test', foo", DoctrineExtension::escapeFunction(array(1, null, 'test', new DummyClass('foo'))));
+        $this->assertEquals("1, NULL, 'test', foo", DoctrineExtension::escapeFunction([1, null, 'test', new DummyClass('foo')]));
     }
 
     public function testEscapeObjectParameter()
@@ -102,6 +91,7 @@ class DoctrineExtensionTest extends TestCase
 
 class DummyClass
 {
+    /** @var string */
     protected $str;
 
     public function __construct($str)

--- a/Twig/DoctrineExtension.php
+++ b/Twig/DoctrineExtension.php
@@ -1,15 +1,11 @@
 <?php
 
-
 namespace Doctrine\Bundle\DoctrineBundle\Twig;
 
 use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * This class contains the needed functions in order to do the query highlighting
- *
- * @author Florin Patan <florinpatan@gmail.com>
- * @author Christophe Coevoet <stof@notk.org>
  */
 class DoctrineExtension extends \Twig_Extension
 {
@@ -27,29 +23,29 @@ class DoctrineExtension extends \Twig_Extension
      */
     public function getFilters()
     {
-        return array(
-            new \Twig_SimpleFilter('doctrine_minify_query', array($this, 'minifyQuery'), array('deprecated' => true)),
-            new \Twig_SimpleFilter('doctrine_pretty_query', array($this, 'formatQuery'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFilter('doctrine_replace_query_parameters', array($this, 'replaceQueryParameters')),
-        );
+        return [
+            new \Twig_SimpleFilter('doctrine_minify_query', [$this, 'minifyQuery'], ['deprecated' => true]),
+            new \Twig_SimpleFilter('doctrine_pretty_query', [$this, 'formatQuery'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFilter('doctrine_replace_query_parameters', [$this, 'replaceQueryParameters']),
+        ];
     }
 
     /**
      * Get the possible combinations of elements from the given array
      *
-     * @param array   $elements
-     * @param integer $combinationsLevel
+     * @param array $elements
+     * @param int   $combinationsLevel
      *
      * @return array
      */
     private function getPossibleCombinations(array $elements, $combinationsLevel)
     {
         $baseCount = count($elements);
-        $result = array();
+        $result    = [];
 
-        if (1 === $combinationsLevel) {
+        if ($combinationsLevel === 1) {
             foreach ($elements as $element) {
-                $result[] = array($element);
+                $result[] = [$element];
             }
 
             return $result;
@@ -59,19 +55,19 @@ class DoctrineExtension extends \Twig_Extension
 
         foreach ($nextLevelElements as $nextLevelElement) {
             $lastElement = $nextLevelElement[$combinationsLevel - 2];
-            $found = false;
+            $found       = false;
 
             foreach ($elements as $key => $element) {
-                if ($element == $lastElement) {
+                if ($element === $lastElement) {
                     $found = true;
                     continue;
                 }
 
-                if ($found == true && $key < $baseCount) {
-                    $tmp = $nextLevelElement;
-                    $newCombination = array_slice($tmp, 0);
+                if ($found === true && $key < $baseCount) {
+                    $tmp              = $nextLevelElement;
+                    $newCombination   = array_slice($tmp, 0);
                     $newCombination[] = $element;
-                    $result[] = array_slice($newCombination, 0);
+                    $result[]         = array_slice($newCombination, 0);
                 }
             }
         }
@@ -92,9 +88,9 @@ class DoctrineExtension extends \Twig_Extension
         array_shift($parameters);
         $result = '';
 
-        $maxLength = $this->maxCharWidth;
+        $maxLength  = $this->maxCharWidth;
         $maxLength -= count($parameters) * 5;
-        $maxLength = $maxLength / count($parameters);
+        $maxLength  = $maxLength / count($parameters);
 
         foreach ($parameters as $key => $value) {
             $isLarger = false;
@@ -108,7 +104,7 @@ class DoctrineExtension extends \Twig_Extension
             }
             $value = self::escapeFunction($value);
 
-            if (!is_numeric($value)) {
+            if (! is_numeric($value)) {
                 $value = substr($value, 1, -1);
             }
 
@@ -116,7 +112,7 @@ class DoctrineExtension extends \Twig_Extension
                 $value .= ' [...]';
             }
 
-            $result .= ' '.$combination[$key].' '.$value;
+            $result .= ' ' . $combination[$key] . ' ' . $value;
         }
 
         return trim($result);
@@ -125,9 +121,9 @@ class DoctrineExtension extends \Twig_Extension
     /**
      * Attempt to compose the best scenario minified query so that a user could find it without expanding it
      *
-     * @param string  $query
-     * @param array   $keywords
-     * @param integer $required
+     * @param string $query
+     * @param array  $keywords
+     * @param int    $required
      *
      * @return string
      */
@@ -136,7 +132,7 @@ class DoctrineExtension extends \Twig_Extension
         // Extract the mandatory keywords and consider the rest as optional keywords
         $mandatoryKeywords = array_splice($keywords, 0, $required);
 
-        $combinations = array();
+        $combinations      = [];
         $combinationsCount = count($keywords);
 
         // Compute all the possible combinations of keywords to match the query for
@@ -149,8 +145,8 @@ class DoctrineExtension extends \Twig_Extension
         foreach ($combinations as $combination) {
             $combination = array_merge($mandatoryKeywords, $combination);
 
-            $regexp = implode('(.*) ', $combination).' (.*)';
-            $regexp = '/^'.$regexp.'/is';
+            $regexp = implode('(.*) ', $combination) . ' (.*)';
+            $regexp = '/^' . $regexp . '/is';
 
             if (preg_match($regexp, $query, $matches)) {
                 $result = $this->shrinkParameters($matches, $combination);
@@ -160,8 +156,8 @@ class DoctrineExtension extends \Twig_Extension
         }
 
         // Try and match the simplest query form that contains only the mandatory keywords
-        $regexp = implode(' (.*)', $mandatoryKeywords).' (.*)';
-        $regexp = '/^'.$regexp.'/is';
+        $regexp = implode(' (.*)', $mandatoryKeywords) . ' (.*)';
+        $regexp = '/^' . $regexp . '/is';
 
         if (preg_match($regexp, $query, $matches)) {
             $result = $this->shrinkParameters($matches, $mandatoryKeywords);
@@ -184,29 +180,29 @@ class DoctrineExtension extends \Twig_Extension
      */
     public function minifyQuery($query)
     {
-        $result = '';
-        $keywords = array();
+        $result   = '';
+        $keywords = [];
         $required = 1;
 
         // Check if we can match the query against any of the major types
         switch (true) {
             case stripos($query, 'SELECT') !== false:
-                $keywords = array('SELECT', 'FROM', 'WHERE', 'HAVING', 'ORDER BY', 'LIMIT');
+                $keywords = ['SELECT', 'FROM', 'WHERE', 'HAVING', 'ORDER BY', 'LIMIT'];
                 $required = 2;
                 break;
 
             case stripos($query, 'DELETE') !== false:
-                $keywords = array('DELETE', 'FROM', 'WHERE', 'ORDER BY', 'LIMIT');
+                $keywords = ['DELETE', 'FROM', 'WHERE', 'ORDER BY', 'LIMIT'];
                 $required = 2;
                 break;
 
             case stripos($query, 'UPDATE') !== false:
-                $keywords = array('UPDATE', 'SET', 'WHERE', 'ORDER BY', 'LIMIT');
+                $keywords = ['UPDATE', 'SET', 'WHERE', 'ORDER BY', 'LIMIT'];
                 $required = 2;
                 break;
 
             case stripos($query, 'INSERT') !== false:
-                $keywords = array('INSERT', 'INTO', 'VALUE', 'VALUES');
+                $keywords = ['INSERT', 'INTO', 'VALUE', 'VALUES'];
                 $required = 2;
                 break;
 
@@ -216,7 +212,7 @@ class DoctrineExtension extends \Twig_Extension
         }
 
         // If we had a match then we should minify it
-        if ($result == '') {
+        if ($result === '') {
             $result = $this->composeMiniQuery($query, $keywords, $required);
         }
 
@@ -239,12 +235,12 @@ class DoctrineExtension extends \Twig_Extension
 
         switch (true) {
             // Check if result is non-unicode string using PCRE_UTF8 modifier
-            case is_string($result) && !preg_match('//u', $result):
-                $result = '0x'. strtoupper(bin2hex($result));
+            case is_string($result) && ! preg_match('//u', $result):
+                $result = '0x' . strtoupper(bin2hex($result));
                 break;
 
             case is_string($result):
-                $result = "'".addslashes($result)."'";
+                $result = "'" . addslashes($result) . "'";
                 break;
 
             case is_array($result):
@@ -259,7 +255,7 @@ class DoctrineExtension extends \Twig_Extension
                 $result = addslashes((string) $result);
                 break;
 
-            case null === $result:
+            case $result === null:
                 $result = 'NULL';
                 break;
 
@@ -274,8 +270,8 @@ class DoctrineExtension extends \Twig_Extension
     /**
      * Return a query with the parameters replaced
      *
-     * @param string      $query
-     * @param array|Data  $parameters
+     * @param string     $query
+     * @param array|Data $parameters
      *
      * @return string
      */
@@ -288,7 +284,7 @@ class DoctrineExtension extends \Twig_Extension
 
         $i = 0;
 
-        if (!array_key_exists(0, $parameters) && array_key_exists(1, $parameters)) {
+        if (! array_key_exists(0, $parameters) && array_key_exists(1, $parameters)) {
             $i = 1;
         }
 
@@ -296,11 +292,11 @@ class DoctrineExtension extends \Twig_Extension
             '/\?|((?<!:):[a-z0-9_]+)/i',
             function ($matches) use ($parameters, &$i) {
                 $key = substr($matches[0], 1);
-                if (!array_key_exists($i, $parameters) && (false === $key || !array_key_exists($key, $parameters))) {
+                if (! array_key_exists($i, $parameters) && ($key === false || ! array_key_exists($key, $parameters))) {
                     return $matches[0];
                 }
 
-                $value = array_key_exists($i, $parameters) ? $parameters[$i] : $parameters[$key];
+                $value  = array_key_exists($i, $parameters) ? $parameters[$i] : $parameters[$key];
                 $result = DoctrineExtension::escapeFunction($value);
                 $i++;
 
@@ -322,16 +318,16 @@ class DoctrineExtension extends \Twig_Extension
      */
     public function formatQuery($sql, $highlightOnly = false)
     {
-        \SqlFormatter::$pre_attributes = 'class="highlight highlight-sql"';
-        \SqlFormatter::$quote_attributes = 'class="string"';
+        \SqlFormatter::$pre_attributes            = 'class="highlight highlight-sql"';
+        \SqlFormatter::$quote_attributes          = 'class="string"';
         \SqlFormatter::$backtick_quote_attributes = 'class="string"';
-        \SqlFormatter::$reserved_attributes = 'class="keyword"';
-        \SqlFormatter::$boundary_attributes = 'class="symbol"';
-        \SqlFormatter::$number_attributes = 'class="number"';
-        \SqlFormatter::$word_attributes = 'class="word"';
-        \SqlFormatter::$error_attributes = 'class="error"';
-        \SqlFormatter::$comment_attributes = 'class="comment"';
-        \SqlFormatter::$variable_attributes = 'class="variable"';
+        \SqlFormatter::$reserved_attributes       = 'class="keyword"';
+        \SqlFormatter::$boundary_attributes       = 'class="symbol"';
+        \SqlFormatter::$number_attributes         = 'class="number"';
+        \SqlFormatter::$word_attributes           = 'class="word"';
+        \SqlFormatter::$error_attributes          = 'class="error"';
+        \SqlFormatter::$comment_attributes        = 'class="comment"';
+        \SqlFormatter::$variable_attributes       = 'class="variable"';
 
         if ($highlightOnly) {
             $html = \SqlFormatter::highlight($sql);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
+
+    <file>.</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+
+    <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+        <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>Tests/*</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>Tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty">
+        <exclude-pattern>Tests/DependencyInjection/Fixtures/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification">
+        <exclude-pattern>DependencyInjection/*</exclude-pattern>
+        <exclude-pattern>Twig/DoctrineExtension.php</exclude-pattern>
+        <exclude-pattern>Tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification">
+        <exclude-pattern>DependencyInjection/*</exclude-pattern>
+        <exclude-pattern>Twig/DoctrineExtension.php</exclude-pattern>
+        <exclude-pattern>Tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification">
+        <exclude-pattern>DependencyInjection/*</exclude-pattern>
+        <exclude-pattern>Twig/DoctrineExtension.php</exclude-pattern>
+        <exclude-pattern>Tests/*</exclude-pattern>
+    </rule>
+</ruleset>


### PR DESCRIPTION
- disable sniffs incompatible with PHP 5.5,
- disable `array` type specification where not needed,
- `doctrine/coding-standard` is not a direct dev-dependency in composer.json because of the PHP 5.5 nonsense - thus only installed on Travis.

Since there is no CS rule/stage currently, I was wondering whether it should follow Doctrine CS or Symfony CS. Since the bundle resides under `doctrine`, I thought Doctrine CS is more appropriate, but feel free to discuss or reject in favor of Symfony CS. 😎 

CS stage separately: https://travis-ci.org/doctrine/DoctrineBundle/jobs/334826059