### PR TITLE
Fix getting service repository from factory with different em

### DIFF
--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -53,6 +53,9 @@ final class ContainerRepositoryFactory implements RepositoryFactory
                 if (! $repository instanceof EntityRepository) {
                     throw new \RuntimeException(sprintf('The service "%s" must extend EntityRepository (or a base class, like ServiceEntityRepository).', $repositoryServiceId));
                 }
+                if ($repository instanceof ServiceEntityRepositoryInterface) {
+                    $repository->setEntityManager($entityManager);
+                }
 
                 return $repository;
             }

--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 
 /**
@@ -29,5 +30,17 @@ class ServiceEntityRepository extends EntityRepository implements ServiceEntityR
         $manager = $registry->getManagerForClass($entityClass);
 
         parent::__construct($manager, $manager->getClassMetadata($entityClass));
+    }
+
+    /**
+     * @param EntityManagerInterface $em
+     *
+     * @return ServiceEntityRepository
+     */
+    public function setEntityManager(EntityManagerInterface $em)
+    {
+        $this->_em = $em;
+
+        return $this;
     }
 }

--- a/Repository/ServiceEntityRepositoryInterface.php
+++ b/Repository/ServiceEntityRepositoryInterface.php
@@ -2,9 +2,17 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
+use Doctrine\ORM\EntityManagerInterface;
+
 /**
  * This interface signals that your repository should be loaded from the container.
  */
 interface ServiceEntityRepositoryInterface
 {
+    /**
+     * @param EntityManagerInterface $em
+     *
+     * @return mixed
+     */
+    public function setEntityManager(EntityManagerInterface $em);
 }


### PR DESCRIPTION
There is the problem, when is multiple entity managers, and try to get repository with diferent from default:

`$this->getDoctrine()->getRepository(Customer::class, 'master')`

it will use the default one inside repository.