### PR TITLE
Import mapping for bundle less

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -1,33 +1,18 @@
 <?php
 
-/*
- * This file is part of the Doctrine Bundle
- *
- * The code was originally distributed inside the Symfony framework.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
+use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
-use Doctrine\ORM\Tools\Console\MetadataFilter;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Import Doctrine ORM metadata mapping information from an existing database.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
@@ -68,7 +53,7 @@ Use the <info>--force</info> option, if you want to override existing mapping fi
 
 <info>php %command.full_name% "MyCustomBundle" xml --force</info>
 EOT
-            );
+        );
     }
 
     /**
@@ -89,21 +74,21 @@ EOT
             $namespace = $input->getOption('root-namespace');
         }
 
-        $type = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
-        if ('annotation' === $type) {
+        $type     = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
+        if ($type === 'annotation') {
             $destPath .= '/Entity';
         } else {
             $destPath .= '/Resources/config/doctrine';
         }
-        if ('yaml' === $type) {
+        if ($type === 'yaml') {
             $type = 'yml';
         }
 
-        $cme = new ClassMetadataExporter();
+        $cme      = new ClassMetadataExporter();
         $exporter = $cme->getExporter($type);
         $exporter->setOverwriteExistingFiles($input->getOption('force'));
 
-        if ('annotation' === $type) {
+        if ($type === 'annotation') {
             $entityGenerator = $this->getEntityGenerator();
             $exporter->setEntityGenerator($entityGenerator);
         }
@@ -123,16 +108,17 @@ EOT
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {
-                $className = $class->name;
-                $class->name = $namespace.'\\Entity\\'.$className;
-                if ('annotation' === $type) {
-                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.php';
+                $className   = $class->name;
+                $class->name = $namespace . '\\Entity\\' . $className;
+                if ($type === 'annotation') {
+                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.php';
                 } else {
-                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.orm.'.$type;
+                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.orm.' . $type;
                 }
                 $output->writeln(sprintf('  > writing <comment>%s</comment>', $path));
                 $code = $exporter->exportClassMetadata($class);
-                if (!is_dir($dir = dirname($path))) {
+                $dir  = dirname($path);
+                if (! is_dir($dir)) {
                     mkdir($dir, 0775, true);
                 }
                 file_put_contents($path, $code);

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -1,18 +1,33 @@
 <?php
 
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
-use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\ORM\Tools\Console\MetadataFilter;
 
 /**
  * Import Doctrine ORM metadata mapping information from an existing database.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
@@ -29,6 +44,8 @@ class ImportMappingDoctrineCommand extends DoctrineCommand
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command')
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be mapped.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force to overwrite existing mapping files.')
+            ->addOption('bundle-less', null, InputOption::VALUE_NONE, 'Bundle argument will be used as destination path')
+            ->addOption('root-namespace', null, InputOption::VALUE_REQUIRED, 'Specify root namespace')
             ->setDescription('Imports mapping information from an existing database')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command imports mapping information
@@ -51,7 +68,7 @@ Use the <info>--force</info> option, if you want to override existing mapping fi
 
 <info>php %command.full_name% "MyCustomBundle" xml --force</info>
 EOT
-        );
+            );
     }
 
     /**
@@ -59,24 +76,34 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('bundle'));
+        if ($input->getOption('bundle-less')) {
+            $destPath = $input->getArgument('bundle');
+            $namespace = 'App';
+        } else {
+            $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('bundle'));
+            $destPath = $bundle->getPath();
+            $namespace = $bundle->getNamespace();
+        }
 
-        $destPath = $bundle->getPath();
-        $type     = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
-        if ($type === 'annotation') {
+        if ($input->getOption('root-namespace')) {
+            $namespace = $input->getOption('root-namespace');
+        }
+
+        $type = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
+        if ('annotation' === $type) {
             $destPath .= '/Entity';
         } else {
             $destPath .= '/Resources/config/doctrine';
         }
-        if ($type === 'yaml') {
+        if ('yaml' === $type) {
             $type = 'yml';
         }
 
-        $cme      = new ClassMetadataExporter();
+        $cme = new ClassMetadataExporter();
         $exporter = $cme->getExporter($type);
         $exporter->setOverwriteExistingFiles($input->getOption('force'));
 
-        if ($type === 'annotation') {
+        if ('annotation' === $type) {
             $entityGenerator = $this->getEntityGenerator();
             $exporter->setEntityGenerator($entityGenerator);
         }
@@ -96,17 +123,16 @@ EOT
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {
-                $className   = $class->name;
-                $class->name = $bundle->getNamespace() . '\\Entity\\' . $className;
-                if ($type === 'annotation') {
-                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.php';
+                $className = $class->name;
+                $class->name = $namespace.'\\Entity\\'.$className;
+                if ('annotation' === $type) {
+                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.php';
                 } else {
-                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.orm.' . $type;
+                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.orm.'.$type;
                 }
                 $output->writeln(sprintf('  > writing <comment>%s</comment>', $path));
                 $code = $exporter->exportClassMetadata($class);
-                $dir  = dirname($path);
-                if (! is_dir($dir)) {
+                if (!is_dir($dir = dirname($path))) {
                     mkdir($dir, 0775, true);
                 }
                 file_put_contents($path, $code);


### PR DESCRIPTION
This pull request is to support bundle-less Symfony application.
There are two new options added:
- --bundle-less - if enabled, the command will use bundle argument as a path to the application source code
- --root-namespace - if provided it will use namespace when creating new classes (default for bundle-less will be App so don't have to provide it by default)

Example usage if we want to import annotation style entities:
`php bin/console doctrine:mapping:import --bundle-less src annotation`
This will create entity classes in src/Entity/ directory using App\Entity namespace.

`php bin/console doctrine:mapping:import --bundle-less --root-namespace=Foo src annotation`
This will create entity classes in src/Entity/ directory using Foo\Entity namespace.

The default behaviour of this command is not affected when not using --bundle-less option.