### PR TITLE
Fix doctrine:mapping:import to work in Symfony 4 (no bundle)

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -1,33 +1,18 @@
 <?php
 
-/*
- * This file is part of the Doctrine Bundle
- *
- * The code was originally distributed inside the Symfony framework.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
+use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
-use Doctrine\ORM\Tools\Console\MetadataFilter;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Import Doctrine ORM metadata mapping information from an existing database.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
@@ -68,7 +53,7 @@ Use the <info>--force</info> option, if you want to override existing mapping fi
 
 <info>php %command.full_name% "MyCustomBundle" xml --force</info>
 EOT
-            );
+        );
     }
 
     /**
@@ -89,21 +74,21 @@ EOT
             $namespace = $input->getOption('root-namespace');
         }
 
-        $type = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
-        if ('annotation' === $type) {
+        $type     = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
+        if ($type === 'annotation') {
             $destPath .= '/Entity';
         } else {
             $destPath .= '/Resources/config/doctrine';
         }
-        if ('yaml' === $type) {
+        if ($type === 'yaml') {
             $type = 'yml';
         }
 
-        $cme = new ClassMetadataExporter();
+        $cme      = new ClassMetadataExporter();
         $exporter = $cme->getExporter($type);
         $exporter->setOverwriteExistingFiles($input->getOption('force'));
 
-        if ('annotation' === $type) {
+        if ($type === 'annotation') {
             $entityGenerator = $this->getEntityGenerator();
             $exporter->setEntityGenerator($entityGenerator);
         }
@@ -123,16 +108,17 @@ EOT
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {
-                $className = $class->name;
-                $class->name = $namespace.'\\Entity\\'.$className;
-                if ('annotation' === $type) {
-                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.php';
+                $className   = $class->name;
+                $class->name = $namespace . '\\Entity\\' . $className;
+                if ($type === 'annotation') {
+                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.php';
                 } else {
-                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.orm.'.$type;
+                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.orm.' . $type;
                 }
                 $output->writeln(sprintf('  > writing <comment>%s</comment>', $path));
                 $code = $exporter->exportClassMetadata($class);
-                if (!is_dir($dir = dirname($path))) {
+                $dir  = dirname($path);
+                if (! is_dir($dir)) {
                     mkdir($dir, 0775, true);
                 }
                 file_put_contents($path, $code);

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -1,18 +1,33 @@
 <?php
 
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
-use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\ORM\Tools\Console\MetadataFilter;
 
 /**
  * Import Doctrine ORM metadata mapping information from an existing database.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
@@ -29,6 +44,8 @@ class ImportMappingDoctrineCommand extends DoctrineCommand
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command')
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be mapped.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force to overwrite existing mapping files.')
+            ->addOption('bundle-less', null, InputOption::VALUE_NONE, 'Bundle argument will be used as destination path')
+            ->addOption('root-namespace', null, InputOption::VALUE_REQUIRED, 'Specify root namespace')
             ->setDescription('Imports mapping information from an existing database')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command imports mapping information
@@ -51,7 +68,7 @@ Use the <info>--force</info> option, if you want to override existing mapping fi
 
 <info>php %command.full_name% "MyCustomBundle" xml --force</info>
 EOT
-        );
+            );
     }
 
     /**
@@ -59,24 +76,34 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('bundle'));
+        if ($input->getOption('bundle-less')) {
+            $destPath = $input->getArgument('bundle');
+            $namespace = 'App';
+        } else {
+            $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('bundle'));
+            $destPath = $bundle->getPath();
+            $namespace = $bundle->getNamespace();
+        }
 
-        $destPath = $bundle->getPath();
-        $type     = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
-        if ($type === 'annotation') {
+        if ($input->getOption('root-namespace')) {
+            $namespace = $input->getOption('root-namespace');
+        }
+
+        $type = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
+        if ('annotation' === $type) {
             $destPath .= '/Entity';
         } else {
             $destPath .= '/Resources/config/doctrine';
         }
-        if ($type === 'yaml') {
+        if ('yaml' === $type) {
             $type = 'yml';
         }
 
-        $cme      = new ClassMetadataExporter();
+        $cme = new ClassMetadataExporter();
         $exporter = $cme->getExporter($type);
         $exporter->setOverwriteExistingFiles($input->getOption('force'));
 
-        if ($type === 'annotation') {
+        if ('annotation' === $type) {
             $entityGenerator = $this->getEntityGenerator();
             $exporter->setEntityGenerator($entityGenerator);
         }
@@ -96,17 +123,16 @@ EOT
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {
-                $className   = $class->name;
-                $class->name = $bundle->getNamespace() . '\\Entity\\' . $className;
-                if ($type === 'annotation') {
-                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.php';
+                $className = $class->name;
+                $class->name = $namespace.'\\Entity\\'.$className;
+                if ('annotation' === $type) {
+                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.php';
                 } else {
-                    $path = $destPath . '/' . str_replace('\\', '.', $className) . '.orm.' . $type;
+                    $path = $destPath.'/'.str_replace('\\', '.', $className).'.orm.'.$type;
                 }
                 $output->writeln(sprintf('  > writing <comment>%s</comment>', $path));
                 $code = $exporter->exportClassMetadata($class);
-                $dir  = dirname($path);
-                if (! is_dir($dir)) {
+                if (!is_dir($dir = dirname($path))) {
                     mkdir($dir, 0775, true);
                 }
                 file_put_contents($path, $code);

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -67,15 +67,15 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $type     = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
+        $type = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
         if ($type === 'yaml') {
             $type = 'yml';
         }
 
         $bundles = $this->getContainer()->getParameter('kernel.bundles');
         if (isset($bundles[$input->getArgument('name')])) {
-            $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('name'));
-            $namespace = $bundle->getNamespace(). '\\Entity';
+            $bundle    = $this->getApplication()->getKernel()->getBundle($input->getArgument('name'));
+            $namespace = $bundle->getNamespace() . '\\Entity';
 
             $destPath = $bundle->getPath();
             if ($type === 'annotation') {
@@ -86,7 +86,8 @@ EOT
         } else {
             // assume a namespace has been passed
             $namespace = $input->getArgument('name');
-            if (null === $destPath = $input->getOption('path')) {
+            $destPath  = $input->getOption('path');
+            if ($destPath === null) {
                 throw new \InvalidArgumentException('The --path option is required when passing a namespace (e.g. --path=src). If you intended to pass a bundle name, check your spelling.');
             }
         }

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -23,19 +23,25 @@ class ImportMappingDoctrineCommand extends DoctrineCommand
     {
         $this
             ->setName('doctrine:mapping:import')
-            ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to import the mapping information to')
+            ->addArgument('name', InputArgument::REQUIRED, 'The bundle or namespace to import the mapping information to')
             ->addArgument('mapping-type', InputArgument::OPTIONAL, 'The mapping type to export the imported mapping information to')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command')
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be mapped.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force to overwrite existing mapping files.')
-            ->addOption('bundle-less', null, InputOption::VALUE_NONE, 'Bundle argument will be used as destination path')
-            ->addOption('root-namespace', null, InputOption::VALUE_REQUIRED, 'Specify root namespace')
+            ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path where the files would be generated (not used when a bundle is passed).')
             ->setDescription('Imports mapping information from an existing database')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command imports mapping information
 from an existing database:
 
+Generate annotation mappings into the src/ directory using App as the namespace:
+<info>php %command.full_name% App\\\Entity annotation --path=src/Entity</info>
+
+Generate annotation mappings into the config/doctrine/ directory using App as the namespace:
+<info>php %command.full_name% App\\\Entity xml --path=config/doctrine</info>
+
+Generate XML mappings into a bundle:
 <info>php %command.full_name% "MyCustomBundle" xml</info>
 
 You can also optionally specify which entity manager to import from with the
@@ -61,27 +67,28 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($input->getOption('bundle-less')) {
-            $destPath = $input->getArgument('bundle');
-            $namespace = 'App';
-        } else {
-            $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('bundle'));
-            $destPath = $bundle->getPath();
-            $namespace = $bundle->getNamespace();
-        }
-
-        if ($input->getOption('root-namespace')) {
-            $namespace = $input->getOption('root-namespace');
-        }
-
         $type     = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
-        if ($type === 'annotation') {
-            $destPath .= '/Entity';
-        } else {
-            $destPath .= '/Resources/config/doctrine';
-        }
         if ($type === 'yaml') {
             $type = 'yml';
+        }
+
+        $bundles = $this->getContainer()->getParameter('kernel.bundles');
+        if (isset($bundles[$input->getArgument('name')])) {
+            $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('name'));
+            $namespace = $bundle->getNamespace(). '\\Entity';
+
+            $destPath = $bundle->getPath();
+            if ($type === 'annotation') {
+                $destPath .= '/Entity';
+            } else {
+                $destPath .= '/Resources/config/doctrine';
+            }
+        } else {
+            // assume a namespace has been passed
+            $namespace = $input->getArgument('name');
+            if (null === $destPath = $input->getOption('path')) {
+                throw new \InvalidArgumentException('The --path option is required when passing a namespace (e.g. --path=src). If you intended to pass a bundle name, check your spelling.');
+            }
         }
 
         $cme      = new ClassMetadataExporter();
@@ -109,7 +116,7 @@ EOT
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));
             foreach ($metadata as $class) {
                 $className   = $class->name;
-                $class->name = $namespace . '\\Entity\\' . $className;
+                $class->name = $namespace . '\\' . $className;
                 if ($type === 'annotation') {
                     $path = $destPath . '/' . str_replace('\\', '.', $className) . '.php';
                 } else {

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -67,15 +67,16 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $type = $input->getArgument('mapping-type') ? $input->getArgument('mapping-type') : 'xml';
+        $type = $input->getArgument('mapping-type') ?: 'xml';
         if ($type === 'yaml') {
             $type = 'yml';
         }
 
-        $bundles = $this->getContainer()->getParameter('kernel.bundles');
-        if (isset($bundles[$input->getArgument('name')])) {
-            $bundle    = $this->getApplication()->getKernel()->getBundle($input->getArgument('name'));
-            $namespace = $bundle->getNamespace() . '\\Entity';
+        $namespaceOrBundle = $input->getArgument('name');
+        $bundles           = $this->getContainer()->getParameter('kernel.bundles');
+        if (isset($bundles[$namespaceOrBundle])) {
+            $bundle    = $this->getApplication()->getKernel()->getBundle($namespaceOrBundle);
+            $namespace = $bundle->getNamespace() . '\Entity';
 
             $destPath = $bundle->getPath();
             if ($type === 'annotation') {
@@ -85,7 +86,7 @@ EOT
             }
         } else {
             // assume a namespace has been passed
-            $namespace = $input->getArgument('name');
+            $namespace = $namespaceOrBundle;
             $destPath  = $input->getOption('path');
             if ($destPath === null) {
                 throw new \InvalidArgumentException('The --path option is required when passing a namespace (e.g. --path=src). If you intended to pass a bundle name, check your spelling.');

--- a/Tests/Command/ImportMappingDoctrineCommandTest.php
+++ b/Tests/Command/ImportMappingDoctrineCommandTest.php
@@ -15,14 +15,10 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class ImportMappingDoctrineCommandTest extends TestCase
 {
-    /**
-     * @var Kernel|null
-     */
+    /** @var Kernel|null */
     private $kernel;
 
-    /**
-     * @var CommandTester|null
-     */
+    /** @var CommandTester|null */
     private $commandTester;
 
     public function setup()
@@ -35,28 +31,26 @@ class ImportMappingDoctrineCommandTest extends TestCase
             ->getConnection();
         $connection->executeQuery('CREATE TABLE product (id integer primary key, name varchar(20), hint text)');
 
-        $application = new Application($this->kernel);
-        $command = $application->find('doctrine:mapping:import');
+        $application         = new Application($this->kernel);
+        $command             = $application->find('doctrine:mapping:import');
         $this->commandTester = new CommandTester($command);
     }
 
     public function tearDown()
     {
         $fs = new Filesystem();
-        if (null !== $this->kernel) {
+        if ($this->kernel !== null) {
             $fs->remove($this->kernel->getCacheDir());
         }
 
-        $fs->remove(sys_get_temp_dir().'/import_mapping_bundle');
+        $fs->remove(sys_get_temp_dir() . '/import_mapping_bundle');
     }
 
     public function testExecuteXmlWithBundle()
     {
-        $this->commandTester->execute([
-            'name' => 'ImportMappingTestFooBundle',
-        ]);
+        $this->commandTester->execute(['name' => 'ImportMappingTestFooBundle']);
 
-        $expectedMetadataPath = sys_get_temp_dir().'/import_mapping_bundle/Resources/config/doctrine/Product.orm.xml';
+        $expectedMetadataPath = sys_get_temp_dir() . '/import_mapping_bundle/Resources/config/doctrine/Product.orm.xml';
         $this->assertFileExists($expectedMetadataPath);
         $this->assertContains('"Doctrine\Bundle\DoctrineBundle\Tests\Command\Entity\Product"', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
     }
@@ -68,7 +62,7 @@ class ImportMappingDoctrineCommandTest extends TestCase
             'mapping-type' => 'annotation',
         ]);
 
-        $expectedMetadataPath = sys_get_temp_dir().'/import_mapping_bundle/Entity/Product.php';
+        $expectedMetadataPath = sys_get_temp_dir() . '/import_mapping_bundle/Entity/Product.php';
         $this->assertFileExists($expectedMetadataPath);
         $this->assertContains('namespace Doctrine\Bundle\DoctrineBundle\Tests\Command\Entity;', file_get_contents($expectedMetadataPath), 'File contains correct namespace');
     }
@@ -79,19 +73,17 @@ class ImportMappingDoctrineCommandTest extends TestCase
      */
     public function testExecuteThrowsExceptionWithNamespaceAndNoPath()
     {
-        $this->commandTester->execute([
-            'name' => 'Some\\Namespace',
-        ]);
+        $this->commandTester->execute(['name' => 'Some\\Namespace']);
     }
 
     public function testExecuteXmlWithNamespace()
     {
         $this->commandTester->execute([
             'name' => 'Some\\Namespace\\Entity',
-            '--path' => $this->kernel->getRootDir().'/config/doctrine',
+            '--path' => $this->kernel->getRootDir() . '/config/doctrine',
         ]);
 
-        $expectedMetadataPath = $this->kernel->getRootDir().'/config/doctrine/Product.orm.xml';
+        $expectedMetadataPath = $this->kernel->getRootDir() . '/config/doctrine/Product.orm.xml';
         $this->assertFileExists($expectedMetadataPath);
         $this->assertContains('"Some\Namespace\Entity\Product"', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
     }
@@ -100,11 +92,11 @@ class ImportMappingDoctrineCommandTest extends TestCase
     {
         $this->commandTester->execute([
             'name' => 'Some\\Namespace\\Entity',
-            '--path' => $this->kernel->getRootDir().'/src/Entity',
+            '--path' => $this->kernel->getRootDir() . '/src/Entity',
             'mapping-type' => 'annotation',
         ]);
 
-        $expectedMetadataPath = $this->kernel->getRootDir().'/src/Entity/Product.php';
+        $expectedMetadataPath = $this->kernel->getRootDir() . '/src/Entity/Product.php';
         $this->assertFileExists($expectedMetadataPath);
         $this->assertContains('namespace Some\Namespace\Entity;', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
     }
@@ -123,15 +115,13 @@ class ImportMappingTestingKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(function(ContainerBuilder $container) {
-            $container->loadFromExtension('framework', [
-                'secret' => 'F00'
-            ]);
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => 'F00']);
 
             $container->loadFromExtension('doctrine', [
                 'dbal' => [
                     'driver' => 'pdo_sqlite',
-                    'path' => $this->getCacheDir().'/testing.db',
+                    'path' => $this->getCacheDir() . '/testing.db',
                 ],
                 'orm' => [],
             ]);
@@ -143,7 +133,7 @@ class ImportMappingTestingKernel extends Kernel
 
     public function getRootDir()
     {
-        return sys_get_temp_dir().'/sf_kernel_'.spl_object_hash($this);
+        return sys_get_temp_dir() . '/sf_kernel_' . spl_object_hash($this);
     }
 }
 
@@ -151,6 +141,6 @@ class ImportMappingTestFooBundle extends Bundle
 {
     public function getPath()
     {
-        return sys_get_temp_dir().'/import_mapping_bundle';
+        return sys_get_temp_dir() . '/import_mapping_bundle';
     }
 }

--- a/Tests/Command/ImportMappingDoctrineCommandTest.php
+++ b/Tests/Command/ImportMappingDoctrineCommandTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Kernel;
+
+class ImportMappingDoctrineCommandTest extends TestCase
+{
+    /**
+     * @var Kernel|null
+     */
+    private $kernel;
+
+    /**
+     * @var CommandTester|null
+     */
+    private $commandTester;
+
+    public function setup()
+    {
+        $this->kernel = new ImportMappingTestingKernel('test', true);
+        $this->kernel->boot();
+
+        $connection = $this->kernel->getContainer()
+            ->get('doctrine')
+            ->getConnection();
+        $connection->executeQuery('CREATE TABLE product (id integer primary key, name varchar(20), hint text)');
+
+        $application = new Application($this->kernel);
+        $command = $application->find('doctrine:mapping:import');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function tearDown()
+    {
+        $fs = new Filesystem();
+        if (null !== $this->kernel) {
+            $fs->remove($this->kernel->getCacheDir());
+        }
+
+        $fs->remove(sys_get_temp_dir().'/import_mapping_bundle');
+    }
+
+    public function testExecuteXmlWithBundle()
+    {
+        $this->commandTester->execute([
+            'name' => 'ImportMappingTestFooBundle',
+        ]);
+
+        $expectedMetadataPath = sys_get_temp_dir().'/import_mapping_bundle/Resources/config/doctrine/Product.orm.xml';
+        $this->assertFileExists($expectedMetadataPath);
+        $this->assertContains('"Doctrine\Bundle\DoctrineBundle\Tests\Command\Entity\Product"', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
+    }
+
+    public function testExecuteAnnotationsWithBundle()
+    {
+        $this->commandTester->execute([
+            'name' => 'ImportMappingTestFooBundle',
+            'mapping-type' => 'annotation',
+        ]);
+
+        $expectedMetadataPath = sys_get_temp_dir().'/import_mapping_bundle/Entity/Product.php';
+        $this->assertFileExists($expectedMetadataPath);
+        $this->assertContains('namespace Doctrine\Bundle\DoctrineBundle\Tests\Command\Entity;', file_get_contents($expectedMetadataPath), 'File contains correct namespace');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /The \-\-path option is required/
+     */
+    public function testExecuteThrowsExceptionWithNamespaceAndNoPath()
+    {
+        $this->commandTester->execute([
+            'name' => 'Some\\Namespace',
+        ]);
+    }
+
+    public function testExecuteXmlWithNamespace()
+    {
+        $this->commandTester->execute([
+            'name' => 'Some\\Namespace\\Entity',
+            '--path' => $this->kernel->getRootDir().'/config/doctrine',
+        ]);
+
+        $expectedMetadataPath = $this->kernel->getRootDir().'/config/doctrine/Product.orm.xml';
+        $this->assertFileExists($expectedMetadataPath);
+        $this->assertContains('"Some\Namespace\Entity\Product"', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
+    }
+
+    public function testExecuteAnnotationsWithNamespace()
+    {
+        $this->commandTester->execute([
+            'name' => 'Some\\Namespace\\Entity',
+            '--path' => $this->kernel->getRootDir().'/src/Entity',
+            'mapping-type' => 'annotation',
+        ]);
+
+        $expectedMetadataPath = $this->kernel->getRootDir().'/src/Entity/Product.php';
+        $this->assertFileExists($expectedMetadataPath);
+        $this->assertContains('namespace Some\Namespace\Entity;', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
+    }
+}
+
+class ImportMappingTestingKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineBundle(),
+            new ImportMappingTestFooBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function(ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'secret' => 'F00'
+            ]);
+
+            $container->loadFromExtension('doctrine', [
+                'dbal' => [
+                    'driver' => 'pdo_sqlite',
+                    'path' => $this->getCacheDir().'/testing.db',
+                ],
+                'orm' => [],
+            ]);
+
+            // Register a NullLogger to avoid getting the stderr default logger of FrameworkBundle
+            $container->register('logger', 'Psr\Log\NullLogger');
+        });
+    }
+
+    public function getRootDir()
+    {
+        return sys_get_temp_dir().'/sf_kernel_'.spl_object_hash($this);
+    }
+}
+
+class ImportMappingTestFooBundle extends Bundle
+{
+    public function getPath()
+    {
+        return sys_get_temp_dir().'/import_mapping_bundle';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^5.5.9|^7.0",
-        "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+        "symfony/framework-bundle": "^2.7.22|~3.0|~4.0",
         "symfony/console": "~2.7|~3.0|~4.0",
         "symfony/dependency-injection": "~2.7|~3.0|~4.0",
         "doctrine/dbal": "^2.5.12",


### PR DESCRIPTION
Hi guys!

This replaces and builds off of #779, which fixes #736.

It's VERY simple: the first argument can now be a bundle (like before) or a namespace:

A) If it's a bundle, everything works 100% like before.
B) If it's *not* a bundle, we assume it's the namespace. Then, there's no magic: we require them to explicitly pass us the path where the files should be generated. No fancy guess work.

Unfortunately, this is very difficult to test. So, I've purposefully made the diff very light and consistent. I've tested this in a REAL app, by copying the first 3 examples in the `setHelp()` to test everything. It all works perfectly.

Thanks!