### PR TITLE
Update CreateDatabaseDoctrineCommand.php

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -72,7 +72,7 @@ EOT
             }
         }
 
-        $hasPath = isset($params['path']);
+        $hasPath = !empty($params['path']);
         $name    = $hasPath ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);
         if (! $name) {
             throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");


### PR DESCRIPTION
Setting the path dynamically, which is useful to switch between in memory and path based SQLite dbs, with an env var requires setting the key `path` on the params. Isset returns true in this case even if the path is empty. `!empty` is a better check with this in mind.