### PR TITLE
Use EntityManagerInterface

### DIFF
--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 
 /**
@@ -30,7 +30,7 @@ class ManagerConfigurator
      * Create a connection by name.
      *
      */
-    public function configure(EntityManager $entityManager)
+    public function configure(EntityManagerInterface $entityManager)
     {
         $this->enableFilters($entityManager);
     }
@@ -39,7 +39,7 @@ class ManagerConfigurator
      * Enables filters for a given entity manager
      *
      */
-    private function enableFilters(EntityManager $entityManager)
+    private function enableFilters(EntityManagerInterface $entityManager)
     {
         if (empty($this->enabledFilters)) {
             return;

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/doctrine-cache-bundle": "~1.2"
     },
     "require-dev": {
-        "doctrine/orm": "~2.3",
+        "doctrine/orm": "~2.4",
         "symfony/yaml": "~2.7|~3.0|~4.0",
         "symfony/validator": "~2.7|~3.0|~4.0",
         "symfony/property-info": "~2.8|~3.0|~4.0",


### PR DESCRIPTION
Let ManagerConfigurator use EntityManagerInterface instead of EntityManager, so you can use custom EntityManager implementations by extending EntityManagerDecorator.   

BC-Break: that raises the `doctrine/orm` requirement from `~2.3` to `~2.4`.