### PR TITLE
Revert "Remove aliases for common interfaces"

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -63,6 +63,7 @@
             <argument>%doctrine.default_connection%</argument>
             <argument>%doctrine.default_entity_manager%</argument>
         </service>
+        <service id="Doctrine\Common\Persistence\ManagerRegistry" alias="doctrine" public="false" />
         <service id="Symfony\Bridge\Doctrine\RegistryInterface" alias="doctrine" public="false" />
 
         <service id="doctrine.twig.doctrine_extension" class="Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension" public="false">

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -75,6 +75,7 @@
     </parameters>
 
     <services>
+        <service id="Doctrine\Common\Persistence\ObjectManager" alias="doctrine.orm.entity_manager" public="false" />
         <service id="Doctrine\ORM\EntityManagerInterface" alias="doctrine.orm.entity_manager" public="false" />
 
         <!--- Deprecated Annotation Metadata Reader Service alias, use annotation_reader service -->

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -30,6 +30,8 @@ class DoctrineExtensionTest extends TestCase
         $expectedAliases = [
             DriverConnection::class => 'database_connection',
             Connection::class => 'database_connection',
+            ManagerRegistry::class => 'doctrine',
+            ObjectManager::class => 'doctrine.orm.entity_manager',
             EntityManagerInterface::class => 'doctrine.orm.entity_manager',
         ];
 

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;


### PR DESCRIPTION
This reverts #740. Fixes #803 