### PR TITLE
[Messenger] Wire the transaction middleware factory when component is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,12 @@ jobs:
     - php: 7.1
       env: stability=RC SYMFONY_DEPRECATIONS_HELPER=weak SYMFONY_VERSION="3.4.*"
       install:
-        - composer config minimum-stability RC
+        - travis_retry composer update -n --prefer-dist
+
+    - php: 7.1
+      env: stability=dev SYMFONY_DEPRECATIONS_HELPER=weak SYMFONY_VERSION="4.1.*"
+      install:
+        - composer require --dev "symfony/messenger" --no-update
         - travis_retry composer update -n --prefer-dist
 
     - php: 7.2

--- a/DependencyInjection/Compiler/MessengerPass.php
+++ b/DependencyInjection/Compiler/MessengerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Class for Symfony Messenger component integrations
+ */
+class MessengerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // Remove wired services if the Messenger component actually isn't enabled:
+        if (!$container->hasAlias('message_bus') || !is_subclass_of($container->findDefinition('message_bus')->getClass(), MessageBusInterface::class)) {
+            $container->removeDefinition('doctrine.orm.messenger.middleware_factory.transaction');
+            $container->removeDefinition('messenger.middleware.doctrine_transaction_middleware');
+        }
+    }
+}

--- a/DependencyInjection/Compiler/MessengerPass.php
+++ b/DependencyInjection/Compiler/MessengerPass.php
@@ -16,10 +16,12 @@ class MessengerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        // Remove wired services if the Messenger component actually isn't enabled:
-        if (!$container->hasAlias('message_bus') || !is_subclass_of($container->findDefinition('message_bus')->getClass(), MessageBusInterface::class)) {
-            $container->removeDefinition('doctrine.orm.messenger.middleware_factory.transaction');
-            $container->removeDefinition('messenger.middleware.doctrine_transaction_middleware');
+        if ($container->hasAlias('message_bus') && is_subclass_of($container->findDefinition('message_bus')->getClass(), MessageBusInterface::class)) {
+            return;
         }
+
+        // Remove wired services if the Messenger component actually isn't enabled:
+        $container->removeDefinition('doctrine.orm.messenger.middleware_factory.transaction');
+        $container->removeDefinition('messenger.middleware.doctrine_transaction_middleware');
     }
 }

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\MessengerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Proxy\Autoloader;
@@ -38,6 +39,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new DoctrineValidationPass('orm'));
         $container->addCompilerPass(new EntityListenerPass());
         $container->addCompilerPass(new ServiceRepositoryCompilerPass());
+        $container->addCompilerPass(new MessengerPass());
     }
 
     /**

--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="doctrine.orm.messenger.middleware_factory.transaction" class="Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddlewareFactory" public="false">
+            <argument type="service" id="doctrine" />
+        </service>
+
+        <!--
+        The following service isn't prefixed by the "doctrine.orm" namespace in order for end-users to just use
+        the "doctrine_transaction_middleware" shortcut in message buses middleware config
+        -->
+        <service id="messenger.middleware.doctrine_transaction_middleware" class="Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware" abstract="true" public="false">
+            <factory service="doctrine.orm.messenger.middleware_factory.transaction" method="createMiddleware" />
+            <argument /> <!-- default entity manager -->
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/Compiler/MessengerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MessengerPassTest.php
@@ -8,14 +8,24 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class MessengerPassTest extends TestCase
 {
+    protected function setUp()
+    {
+        if (interface_exists(MessageBusInterface::class)) {
+            return;
+        }
+
+        $this->markTestSkipped('Symfony Messenger component is not installed');
+    }
+
     public function testRemovesDefinitionsWhenMessengerComponentIsDisabled()
     {
-        $pass = new MessengerPass();
+        $pass      = new MessengerPass();
         $container = new ContainerBuilder();
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
+        $loader    = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
         $loader->load('messenger.xml');
 
         $pass->process($container);
@@ -26,9 +36,9 @@ class MessengerPassTest extends TestCase
 
     public function testRemoveDefinitionsWhenHasAliasButNotMessengerComponent()
     {
-        $pass = new MessengerPass();
+        $pass      = new MessengerPass();
         $container = new ContainerBuilder();
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
+        $loader    = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
         $loader->load('messenger.xml');
 
         $container->register('some_other_bus', \stdClass::class);
@@ -42,9 +52,9 @@ class MessengerPassTest extends TestCase
 
     public function testDoesNotRemoveDefinitionsWhenMessengerComponentIsEnabled()
     {
-        $pass = new MessengerPass();
+        $pass      = new MessengerPass();
         $container = new ContainerBuilder();
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
+        $loader    = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
         $loader->load('messenger.xml');
 
         $container->register('messenger.bus.default', MessageBus::class);

--- a/Tests/DependencyInjection/Compiler/MessengerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MessengerPassTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\MessengerPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Messenger\MessageBus;
+
+class MessengerPassTest extends TestCase
+{
+    public function testRemovesDefinitionsWhenMessengerComponentIsDisabled()
+    {
+        $pass = new MessengerPass();
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
+        $loader->load('messenger.xml');
+
+        $pass->process($container);
+
+        $this->assertFalse($container->hasDefinition('doctrine.orm.messenger.middleware_factory.transaction'));
+        $this->assertFalse($container->hasDefinition('messenger.middleware.doctrine_transaction_middleware'));
+    }
+
+    public function testRemoveDefinitionsWhenHasAliasButNotMessengerComponent()
+    {
+        $pass = new MessengerPass();
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
+        $loader->load('messenger.xml');
+
+        $container->register('some_other_bus', \stdClass::class);
+        $container->setAlias('message_bus', 'some_other_bus');
+
+        $pass->process($container);
+
+        $this->assertFalse($container->hasDefinition('doctrine.orm.messenger.middleware_factory.transaction'));
+        $this->assertFalse($container->hasDefinition('messenger.middleware.doctrine_transaction_middleware'));
+    }
+
+    public function testDoesNotRemoveDefinitionsWhenMessengerComponentIsEnabled()
+    {
+        $pass = new MessengerPass();
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
+        $loader->load('messenger.xml');
+
+        $container->register('messenger.bus.default', MessageBus::class);
+        $container->setAlias('message_bus', 'messenger.bus.default');
+
+        $pass->process($container);
+
+        $this->assertTrue($container->hasDefinition('doctrine.orm.messenger.middleware_factory.transaction'));
+        $this->assertTrue($container->hasDefinition('messenger.middleware.doctrine_transaction_middleware'));
+    }
+}

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class DoctrineExtensionTest extends TestCase
 {
@@ -678,6 +679,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testMessengerIntegration()
     {
+        if (! interface_exists(MessageBusInterface::class)) {
+            $this->markTestSkipped('Symfony Messenger component is not installed');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -676,6 +676,27 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('Fixtures\Bundles\Vendor\AnnotationsBundle\Entity', $calls[0][1][1]);
     }
 
+    public function testMessengerIntegration()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $config = BundleConfigurationBuilder::createBuilder()
+            ->addBaseConnection()
+            ->addEntityManager([
+                'default_entity_manager' => 'default',
+                'entity_managers' => [
+                    'default' => [],
+                ],
+            ])
+            ->build();
+        $extension->load([$config], $container);
+
+        $this->assertNotNull($container->getDefinition('doctrine.orm.messenger.middleware_factory.transaction'));
+        $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_transaction_middleware'));
+        $this->assertSame('default', $middlewarePrototype->getArgument(0));
+    }
+
     public function testCacheConfiguration()
     {
         $container = $this->getContainer();

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "twig/twig": "~1.26|~2.0",
         "satooshi/php-coveralls": "^1.0",
         "phpunit/phpunit": "^4.8.36|^5.7|^6.4",
-        "symfony/web-profiler-bundle": "~2.7|~3.0|~4.0"
+        "symfony/web-profiler-bundle": "~2.7|~3.0|~4.0",
+        "symfony/messenger": "~4.1-beta2"
     },
     "conflict": {
         "symfony/http-foundation": "<2.6"
@@ -61,5 +62,6 @@
         "branch-alias": {
             "dev-master": "1.9.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,7 @@
         "twig/twig": "~1.26|~2.0",
         "satooshi/php-coveralls": "^1.0",
         "phpunit/phpunit": "^4.8.36|^5.7|^6.4",
-        "symfony/web-profiler-bundle": "~2.7|~3.0|~4.0",
-        "symfony/messenger": "~4.1-beta2"
+        "symfony/web-profiler-bundle": "~2.7|~3.0|~4.0"
     },
     "conflict": {
         "symfony/http-foundation": "<2.6"
@@ -62,6 +61,5 @@
         "branch-alias": {
             "dev-master": "1.9.x-dev"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/symfony/symfony/pull/27128

How should we process for the CI?