### PR TITLE
Add PostgreSQL SSL options support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -226,6 +226,16 @@ class Configuration implements ConfigurationInterface
                         'If the file exists, the server\'s certificate will be verified to be signed by one of these authorities.'
                     )
                 ->end()
+                ->scalarNode('sslcert')
+                    ->info(
+                        'The path to the SSL client certificate file for PostgreSQL.'
+                    )
+                ->end()
+                ->scalarNode('sslkey')
+                    ->info(
+                        'The path to the SSL client key file for PostgreSQL.'
+                    )
+                ->end()
                 ->booleanNode('pooled')->info('True to use a pooled server with the oci8/pdo_oracle driver')->end()
                 ->booleanNode('MultipleActiveResultSets')->info('Configuring MultipleActiveResultSets for the pdo_sqlsrv driver')->end()
                 ->booleanNode('use_savepoints')->info('Use savepoints for nested transactions')->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -236,6 +236,11 @@ class Configuration implements ConfigurationInterface
                         'The path to the SSL client key file for PostgreSQL.'
                     )
                 ->end()
+                ->scalarNode('sslcrl')
+                    ->info(
+                        'The file name of the SSL certificate revocation list for PostgreSQL.'
+                    )
+                ->end()
                 ->booleanNode('pooled')->info('True to use a pooled server with the oci8/pdo_oracle driver')->end()
                 ->booleanNode('MultipleActiveResultSets')->info('Configuring MultipleActiveResultSets for the pdo_sqlsrv driver')->end()
                 ->booleanNode('use_savepoints')->info('Use savepoints for nested transactions')->end()

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -61,6 +61,8 @@
         <xsd:attribute name="session-mode" type="xsd:string" />
         <xsd:attribute name="sslmode" type="xsd:string" />
         <xsd:attribute name="sslrootcert" type="xsd:string" />
+        <xsd:attribute name="sslcert" type="xsd:string" />
+        <xsd:attribute name="sslkey" type="xsd:string" />
         <xsd:attribute name="pooled" type="xsd:string" />
         <xsd:attribute name="multiple-active-result-sets" type="xsd:string" />
         <xsd:attribute name="connectstring" type="xsd:string" />

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -63,6 +63,7 @@
         <xsd:attribute name="sslrootcert" type="xsd:string" />
         <xsd:attribute name="sslcert" type="xsd:string" />
         <xsd:attribute name="sslkey" type="xsd:string" />
+        <xsd:attribute name="sslcrl" type="xsd:string" />
         <xsd:attribute name="pooled" type="xsd:string" />
         <xsd:attribute name="multiple-active-result-sets" type="xsd:string" />
         <xsd:attribute name="connectstring" type="xsd:string" />

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -75,6 +75,10 @@ Configuration Reference
                         # The name of a file containing the private key for the client SSL certificate.
                         sslkey:               ~
 
+                        # PostgreSQL specific (LIBPQ-CONNECT-SSLCRL).
+                        # The name of a file containing the SSL certificate revocation list (CRL).
+                        sslcrl:               ~
+
                         # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                         pooled:               ~
 
@@ -173,6 +177,10 @@ Configuration Reference
                                 # The name of a file containing the private key for the client SSL certificate.
                                 sslkey:               ~
 
+                                # PostgreSQL specific (LIBPQ-CONNECT-SSLCRL).
+                                # The name of a file containing the SSL certificate revocation list (CRL).
+                                sslcrl:               ~
+
                                 # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                                 pooled:               ~
 
@@ -228,6 +236,10 @@ Configuration Reference
                             # PostgreSQL specific (LIBPQ-CONNECT-SSLKEY).
                             # The name of a file containing the private key for the client SSL certificate.
                             sslkey:               ~
+
+                            # PostgreSQL specific (LIBPQ-CONNECT-SSLCRL).
+                            # The name of a file containing the SSL certificate revocation list (CRL).
+                            sslcrl:               ~
 
                             # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                             pooled:               ~
@@ -427,6 +439,7 @@ Configuration Reference
                     <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                     <!-- sslcert: The name of a file containing a client SSL certificate -->
                     <!-- sslkey: The name of a file containing the private key used for the client SSL certificate -->
+                    <!-- sslcrl: The name of a file containing the SSL certificate revocation list (CRL) -->
                     <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                     <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                     <!-- use-savepoints: Enable savepoints for nested transactions -->
@@ -451,6 +464,7 @@ Configuration Reference
                         sslrootcert=""
                         sslcert=""
                         sslkey=""
+                        sslcrl=""
                         pooled=""
                         MultipleActiveResultSets=""
                         use-savepoints="true"
@@ -491,6 +505,7 @@ Configuration Reference
                         <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                         <!-- sslcert: The name of a file containing a client SSL certificate -->
                         <!-- sslkey: The name of a file containing the private key used for the client SSL certificate -->
+                        <!-- sslcrl: The name of a file containing the SSL certificate revocation list (CRL) -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                         <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                         <doctrine:slave
@@ -514,6 +529,7 @@ Configuration Reference
                             sslrootcert=""
                             sslcert=""
                             sslkey=""
+                            sslcrl=""
                             pooled=""
                             MultipleActiveResultSets=""
                         />
@@ -531,6 +547,7 @@ Configuration Reference
                         <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                         <!-- sslcert: The name of a file containing a client SSL certificate -->
                         <!-- sslkey: The name of a file containing the private key used for the client SSL certificate -->
+                        <!-- sslcrl: The name of a file containing the SSL certificate revocation list (CRL) -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                         <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                         <doctrine:shard
@@ -554,6 +571,7 @@ Configuration Reference
                             sslrootcert=""
                             sslcert=""
                             sslkey=""
+                            sslcrl=""
                             pooled=""
                             MultipleActiveResultSets=""
                         />
@@ -936,6 +954,7 @@ can configure. The following block shows all possible configuration keys:
                 sslrootcert:              postgresql-ca.pem   # PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT)
                 sslcert:                  postgresql-cert.pem # PostgreSQL specific (LIBPQ-CONNECT-SSLCERT)
                 sslkey:                   postgresql-key.pem  # PostgreSQL specific (LIBPQ-CONNECT-SSLKEY)
+                sslcrl:                   postgresql.crl      # PostgreSQL specific (LIBPQ-CONNECT-SSLCRL)
                 wrapper_class:            MyDoctrineDbalConnectionWrapper
                 charset:                  UTF8
                 logging:                  "%kernel.debug%"
@@ -984,6 +1003,7 @@ can configure. The following block shows all possible configuration keys:
                 sslrootcert="postgresql-ca.pem"    <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT) -->
                 sslcert="postgresql-cert.pem"      <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLCERT) -->
                 sslkey="postgresql-key.pem"        <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLKEY) -->
+                sslcrl="postgresql.crl"            <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLCRL) -->
                 wrapper-class="MyDoctrineDbalConnectionWrapper"
                 charset="UTF8"
                 logging="%kernel.debug%"

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -67,6 +67,14 @@ Configuration Reference
                         # If the file exists, the server's certificate will be verified to be signed by one of these authorities.
                         sslrootcert:          ~
 
+                        # PostgreSQL specific (LIBPQ-CONNECT-SSLCERT).
+                        # The name of a file containing the client SSL certificate.
+                        sslcert:              ~
+
+                        # PostgreSQL specific (LIBPQ-CONNECT-SSLKEY).
+                        # The name of a file containing the private key for the client SSL certificate.
+                        sslkey:               ~
+
                         # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                         pooled:               ~
 
@@ -157,6 +165,14 @@ Configuration Reference
                                 # If the file exists, the server's certificate will be verified to be signed by one of these authorities.
                                 sslrootcert:          ~
 
+                                # PostgreSQL specific (LIBPQ-CONNECT-SSLCERT).
+                                # The name of a file containing the client SSL certificate.
+                                sslcert:              ~
+
+                                # PostgreSQL specific (LIBPQ-CONNECT-SSLKEY).
+                                # The name of a file containing the private key for the client SSL certificate.
+                                sslkey:               ~
+
                                 # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                                 pooled:               ~
 
@@ -204,6 +220,14 @@ Configuration Reference
                             # The name of a file containing SSL certificate authority (CA) certificate(s).
                             # If the file exists, the server's certificate will be verified to be signed by one of these authorities.
                             sslrootcert:          ~
+
+                            # PostgreSQL specific (LIBPQ-CONNECT-SSLCERT).
+                            # The name of a file containing the client SSL certificate.
+                            sslcert:              ~
+
+                            # PostgreSQL specific (LIBPQ-CONNECT-SSLKEY).
+                            # The name of a file containing the private key for the client SSL certificate.
+                            sslkey:               ~
 
                             # Oracle specific (SERVER=POOLED). True to use a pooled server with the oci8/pdo_oracle driver
                             pooled:               ~
@@ -401,6 +425,8 @@ Configuration Reference
                     <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
                     <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
                     <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
+                    <!-- sslcert: The name of a file containing a client SSL certificate -->
+                    <!-- sslkey: The name of a file containing the private key used for the client SSL certificate -->
                     <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                     <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                     <!-- use-savepoints: Enable savepoints for nested transactions -->
@@ -423,6 +449,8 @@ Configuration Reference
                         server=""
                         sslmode=""
                         sslrootcert=""
+                        sslcert=""
+                        sslkey=""
                         pooled=""
                         MultipleActiveResultSets=""
                         use-savepoints="true"
@@ -461,6 +489,8 @@ Configuration Reference
                         <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
                         <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
                         <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
+                        <!-- sslcert: The name of a file containing a client SSL certificate -->
+                        <!-- sslkey: The name of a file containing the private key used for the client SSL certificate -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                         <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                         <doctrine:slave
@@ -482,6 +512,8 @@ Configuration Reference
                             server=""
                             sslmode=""
                             sslrootcert=""
+                            sslcert=""
+                            sslkey=""
                             pooled=""
                             MultipleActiveResultSets=""
                         />
@@ -497,6 +529,8 @@ Configuration Reference
                         <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
                         <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
                         <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
+                        <!-- sslcert: The name of a file containing a client SSL certificate -->
+                        <!-- sslkey: The name of a file containing the private key used for the client SSL certificate -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                         <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
                         <doctrine:shard
@@ -518,6 +552,8 @@ Configuration Reference
                             server=""
                             sslmode=""
                             sslrootcert=""
+                            sslcert=""
+                            sslkey=""
                             pooled=""
                             MultipleActiveResultSets=""
                         />
@@ -898,6 +934,8 @@ can configure. The following block shows all possible configuration keys:
                 sessionMode:              2                   # oci8 driver specific (session_mode)
                 sslmode:                  require             # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE)
                 sslrootcert:              postgresql-ca.pem   # PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT)
+                sslcert:                  postgresql-cert.pem # PostgreSQL specific (LIBPQ-CONNECT-SSLCERT)
+                sslkey:                   postgresql-key.pem  # PostgreSQL specific (LIBPQ-CONNECT-SSLKEY)
                 wrapper_class:            MyDoctrineDbalConnectionWrapper
                 charset:                  UTF8
                 logging:                  "%kernel.debug%"
@@ -944,6 +982,8 @@ can configure. The following block shows all possible configuration keys:
                 sessionMode"2"                     <!-- oci8 driver specific (session_mode) -->
                 sslmode="require"                  <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLMODE) -->
                 sslrootcert="postgresql-ca.pem"    <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT) -->
+                sslcert="postgresql-cert.pem"      <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLCERT) -->
+                sslkey="postgresql-key.pem"        <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLKEY) -->
                 wrapper-class="MyDoctrineDbalConnectionWrapper"
                 charset="UTF8"
                 logging="%kernel.debug%"

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -70,6 +70,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('postgresql-ca.pem', $config['sslrootcert']);
         $this->assertSame('postgresql-cert.pem', $config['sslcert']);
         $this->assertSame('postgresql-key.pem', $config['sslkey']);
+        $this->assertSame('postgresql.crl', $config['sslcrl']);
         $this->assertSame('utf8', $config['charset']);
 
         // doctrine.dbal.sqlanywhere_connection

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -68,6 +68,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('pgsql_s3cr3t', $config['password']);
         $this->assertSame('require', $config['sslmode']);
         $this->assertSame('postgresql-ca.pem', $config['sslrootcert']);
+        $this->assertSame('postgresql-cert.pem', $config['sslcert']);
+        $this->assertSame('postgresql-key.pem', $config['sslkey']);
         $this->assertSame('utf8', $config['charset']);
 
         // doctrine.dbal.sqlanywhere_connection

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -47,6 +47,8 @@
                 password="pgsql_s3cr3t"
                 sslmode="require"
                 sslrootcert="postgresql-ca.pem"
+                sslcert="postgresql-cert.pem"
+                sslkey="postgresql-key.pem"
                 charset="utf8" />
             <connection
                 name="sqlanywhere"

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -49,6 +49,7 @@
                 sslrootcert="postgresql-ca.pem"
                 sslcert="postgresql-cert.pem"
                 sslkey="postgresql-key.pem"
+                sslcrl="postgresql.crl"
                 charset="utf8" />
             <connection
                 name="sqlanywhere"

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -38,6 +38,7 @@ doctrine:
                 sslrootcert: postgresql-ca.pem
                 sslcert: postgresql-cert.pem
                 sslkey: postgresql-key.pem
+                sslcrl: postgresql.crl
                 charset: utf8
             sqlanywhere:
                 driver: sqlanywhere

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -36,6 +36,8 @@ doctrine:
                 password: pgsql_s3cr3t
                 sslmode: require
                 sslrootcert: postgresql-ca.pem
+                sslcert: postgresql-cert.pem
+                sslkey: postgresql-key.pem
                 charset: utf8
             sqlanywhere:
                 driver: sqlanywhere


### PR DESCRIPTION
I was trying to setup an SSL connection to a PostgreSQL database, using the pdo_pgsql driver. According to [the documentation](https://www.doctrine-project.org/projects/doctrine-dbal/en/2.7/reference/configuration.html#pdo-pgsql), the following SSL options should be supported:

* sslmode
* sslrootcert 
* sslcert
* sslkey
* sslcrl

Although, when setting the configuration as such (with the given parameters set in parameters.yml file):

```
doctrine:
  dbal:
    sslmode: 'verify-ca'
    sslrootcert: '%database_sslrootcert_path%'
    sslcert: '%database_sslcert_path%'
    sslkey: '%database_sslkey_path%'
```
I would get the following exception from the Symfony Config component:

```
In ArrayNode.php line 311:
                                                                                    
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]     
  Unrecognized options "sslcert, sslkey" under "doctrine.dbal.connections.default"
```

This patch allows for these options to be actually set/used and results in a working SSL connection.

I'm not sure if/how I should write any tests for this change, but please give me some pointers if these need to be added.