### PR TITLE
Add missing default_dbname configuration option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -214,6 +214,11 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('server')
                     ->info('The name of a running database server to connect to for SQL Anywhere.')
                 ->end()
+                ->scalarNode('default_dbname')
+                    ->info(
+                        'Override the default database (postgres) to connect to for PostgreSQL connexion.'
+                    )
+                ->end()
                 ->scalarNode('sslmode')
                     ->info(
                         'Determines whether or with what priority a SSL TCP/IP connection will be negotiated with ' .

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -59,6 +59,7 @@
         <xsd:attribute name="service" type="xsd:string" />
         <xsd:attribute name="servicename" type="xsd:string" />
         <xsd:attribute name="session-mode" type="xsd:string" />
+        <xsd:attribute name="default_dbname" type="xsd:string" />
         <xsd:attribute name="sslmode" type="xsd:string" />
         <xsd:attribute name="sslrootcert" type="xsd:string" />
         <xsd:attribute name="pooled" type="xsd:string" />

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -58,6 +58,10 @@ Configuration Reference
                         # SQL Anywhere specific (ServerName). The name of a running database server to connect to for SQL Anywhere.
                         server:               ~
 
+                        # PostgreSQL specific (default_dbname).
+                        # Override the default database (postgres) to connect to.
+                        default_dbname:       ~
+
                         # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE).
                         # Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
                         sslmode:              ~
@@ -90,7 +94,7 @@ Configuration Reference
                         profiling:            "%kernel.debug%"
                         server_version:       ~
                         driver_class:         ~
-                        # Allows to specify a custom wrapper implementation to use.                       
+                        # Allows to specify a custom wrapper implementation to use.
                         # Must be a subclass of Doctrine\DBAL\Connection
                         wrapper_class:        ~
                         shard_choser:         ~
@@ -148,6 +152,10 @@ Configuration Reference
                                 # SQL Anywhere specific (ServerName). The name of a running database server to connect to for SQL Anywhere.
                                 server:               ~
 
+                                # PostgreSQL specific (default_dbname).
+                                # Override the default database (postgres) to connect to.
+                                default_dbname:       ~
+
                                 # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE).
                                 # Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
                                 sslmode:              ~
@@ -195,6 +203,10 @@ Configuration Reference
 
                             # SQL Anywhere specific (ServerName). The name of a running database server to connect to for SQL Anywhere.
                             server:               ~
+
+                            # PostgreSQL specific (default_dbname).
+                            # Override the default database (postgres) to connect to.
+                            default_dbname:       ~
 
                             # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE).
                             # Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
@@ -399,6 +411,7 @@ Configuration Reference
                     <!-- servicename: Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter. -->
                     <!-- sessionMode: The session mode to use for the oci8 driver -->
                     <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
+                    <!-- default_dbname: Override the default database (postgres) to connect to for PostgreSQL. -->
                     <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
                     <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                     <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
@@ -421,6 +434,7 @@ Configuration Reference
                         servicename=""
                         sessionMode=""
                         server=""
+                        default_dbname=""
                         sslmode=""
                         sslrootcert=""
                         pooled=""
@@ -459,6 +473,7 @@ Configuration Reference
                         <!-- servicename: Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter. -->
                         <!-- sessionMode: The session mode to use for the oci8 driver -->
                         <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
+                        <!-- default_dbname: Override the default database (postgres) to connect to for PostgreSQL. -->
                         <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
                         <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
@@ -480,6 +495,7 @@ Configuration Reference
                             servicename=""
                             sessionMode=""
                             server=""
+                            default_dbname=""
                             sslmode=""
                             sslrootcert=""
                             pooled=""
@@ -495,6 +511,7 @@ Configuration Reference
                         <!-- servicename: Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter. -->
                         <!-- sessionMode: The session mode to use for the oci8 driver -->
                         <!-- server: The name of a running database server to connect to for SQL Anywhere. -->
+                        <!-- default_dbname: Override the default database (postgres) to connect to for PostgreSQL. -->
                         <!-- sslmode: Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL. -->
                         <!-- sslrootcert: The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
@@ -516,6 +533,7 @@ Configuration Reference
                             servicename=""
                             sessionMode=""
                             server=""
+                            default_dbname=""
                             sslmode=""
                             sslrootcert=""
                             pooled=""
@@ -896,6 +914,7 @@ can configure. The following block shows all possible configuration keys:
                 service:                  true                # Oracle specific (SERVICE_NAME instead of SID)
                 servicename:              MyOracleServiceName # Oracle specific (SERVICE_NAME)
                 sessionMode:              2                   # oci8 driver specific (session_mode)
+                default_dbname:           database            # PostgreSQL specific (default_dbname)
                 sslmode:                  require             # PostgreSQL specific (LIBPQ-CONNECT-SSLMODE)
                 sslrootcert:              postgresql-ca.pem   # PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT)
                 wrapper_class:            MyDoctrineDbalConnectionWrapper
@@ -942,6 +961,7 @@ can configure. The following block shows all possible configuration keys:
                 service="true"                     <!-- Oracle specific (SERVICE_NAME instead of SID) -->
                 servicename="MyOracleServiceName"  <!-- Oracle specific (SERVICE_NAME) -->
                 sessionMode"2"                     <!-- oci8 driver specific (session_mode) -->
+                default_dbname="database"          <!-- PostgreSQL specific (default_dbname) -->
                 sslmode="require"                  <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLMODE) -->
                 sslrootcert="postgresql-ca.pem"    <!-- PostgreSQL specific (LIBPQ-CONNECT-SSLROOTCERT) -->
                 wrapper-class="MyDoctrineDbalConnectionWrapper"

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -63,9 +63,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         // doctrine.dbal.pgsql_connection
         $config = $container->getDefinition('doctrine.dbal.pgsql_connection')->getArgument(0);
         $this->assertSame('pdo_pgsql', $config['driver']);
-        $this->assertSame('pgsql_db', $config['dbname']);
+        $this->assertSame('pgsql_schema', $config['dbname']);
         $this->assertSame('pgsql_user', $config['user']);
         $this->assertSame('pgsql_s3cr3t', $config['password']);
+        $this->assertSame('pgsql_db', $config['default_dbname']);
         $this->assertSame('require', $config['sslmode']);
         $this->assertSame('postgresql-ca.pem', $config['sslrootcert']);
         $this->assertSame('utf8', $config['charset']);

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -42,9 +42,10 @@
             <connection
                 name="pgsql"
                 driver="pdo_pgsql"
-                dbname="pgsql_db"
+                dbname="pgsql_schema"
                 user="pgsql_user"
                 password="pgsql_s3cr3t"
+                default_dbname="pgsql_db"
                 sslmode="require"
                 sslrootcert="postgresql-ca.pem"
                 charset="utf8" />

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -31,9 +31,10 @@ doctrine:
                 protocol: TCPIP
             pgsql:
                 driver: pdo_pgsql
-                dbname: pgsql_db
+                dbname: pgsql_schema
                 user: pgsql_user
                 password: pgsql_s3cr3t
+                default_dbname: pgsql_db
                 sslmode: require
                 sslrootcert: postgresql-ca.pem
                 charset: utf8


### PR DESCRIPTION
Hi all,

In doctrine/dbal v2.6, was introduced a parameter default_dbname for postgre driver.
The bundle do not have the configuration option availaible so here is a PR.

I'm new to contributing on doctrine so I'm open to any suggestions.