### PR TITLE
Fix handling of lazy entity listeners

### DIFF
--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -52,9 +52,9 @@ class EntityListenerPass implements CompilerPassInterface
                     $this->attachToListener($container, $name, $id, $attributes);
                 }
 
-                if (isset($attributes['lazy']) && $attributes['lazy']) {
-                    $listener = $container->findDefinition($id);
+                $listener = $container->findDefinition($id);
 
+                if ($listener->isLazy() || !empty($attributes['lazy'])) {
                     if ($listener->isAbstract()) {
                         throw new InvalidArgumentException(sprintf('The service "%s" must not be abstract as this entity listener is lazy-loaded.', $id));
                     }


### PR DESCRIPTION
Discussed in https://github.com/symfony/symfony/issues/28304#issuecomment-422710505

When an entity listener is declared as lazy at the definition level (and not at the tag level), then it is registered using the `ContainerAwareEntityListenerResolver::register()`. This class in turn uses `get_class()` to create its internal map.

But `get_class()` on a lazy-proxy returns the generated class of the proxy - not the class of the listener implementation.

Makes sense?