### PR TITLE
Support user defined repositories

### DIFF
--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -50,8 +50,8 @@ final class ContainerRepositoryFactory implements RepositoryFactory
             if ($this->container && $this->container->has($customRepositoryName)) {
                 $repository = $this->container->get($customRepositoryName);
 
-                if (! $repository instanceof EntityRepository) {
-                    throw new \RuntimeException(sprintf('The service "%s" must extend EntityRepository (or a base class, like ServiceEntityRepository).', $repositoryServiceId));
+                if (! $repository instanceof ObjectRepository) {
+                    throw new \RuntimeException(sprintf('The service "%s" must implement ObjectRepository (or extend a base class, like ServiceEntityRepository).', $repositoryServiceId));
                 }
 
                 return $repository;

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -88,7 +88,7 @@ class ContainerRepositoryFactoryTest extends TestCase
             $this->markTestSkipped('Symfony 3.3 is needed for this feature.');
         }
 
-        $repo = new StubCustomRepository();
+        $repo = $this->getMockBuilder(ObjectRepository::class)->getMock();
 
         $container = $this->createContainer(['my_repo' => $repo]);
 
@@ -97,7 +97,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $factory = new ContainerRepositoryFactory($container);
         $factory->getRepository($em, 'Foo\CoolEntity');
         $actualRepo = $factory->getRepository($em, 'Foo\CoolEntity');
-        $this->assertInstanceOf(StubCustomRepository::class, $actualRepo);
+        $this->assertSame($repo, $actualRepo);
     }
 
 
@@ -188,13 +188,4 @@ class StubRepository extends EntityRepository
 
 class StubServiceRepository extends EntityRepository implements ServiceEntityRepositoryInterface
 {
-}
-
-class StubCustomRepository implements ObjectRepository
-{
-    public function find($id) {}
-    public function findAll() {}
-    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null) {}
-    public function findOneBy(array $criteria) {}
-    public function getClassName() {}
 }


### PR DESCRIPTION
A verification was done with EntityRepository inheritance. This commit drop it in favor of a check on interface ObjectRepository which allow the user to define its own complete repository.

Closes https://github.com/doctrine/DoctrineBundle/issues/856