### PR TITLE
Custom doctrine repositories as services per default

### DIFF
--- a/DependencyInjection/Compiler/FallbackServiceRepositoryCompilePass.php
+++ b/DependencyInjection/Compiler/FallbackServiceRepositoryCompilePass.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FallbackServiceRepositoryCompilePass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @throws \Exception
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach (array_keys($container->getDefinitions()) as $id) {
+            if (!preg_match('/^doctrine\.orm\.[^.]+_entity_manager$/', $id)) {
+                continue;
+            }
+
+            $this->processMetadata(
+                $container,
+                $id,
+                $container->get($id)->getMetadataFactory()
+            );
+        }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string $entityManagerServiceId
+     * @param ClassMetadataFactory $factory
+     */
+    protected function processMetadata(
+        ContainerBuilder $container,
+        $entityManagerServiceId,
+        ClassMetadataFactory $factory
+    ) {
+        foreach ($factory->getAllMetadata() as $metadata) {
+            $repositoryClassName = null;
+            if ($metadata->customRepositoryClassName) {
+                $repositoryClassName = $metadata->customRepositoryClassName;
+            }
+
+            if ($repositoryClassName === null) {
+                continue;
+            }
+
+            if (!$container->has($repositoryClassName)) {
+                $repositoryDefinition = new Definition(
+                    $repositoryClassName,
+                    [
+                        $metadata->getName()
+                    ]
+                );
+                $repositoryDefinition->setFactory([
+                    new Reference($entityManagerServiceId),
+                    'getRepository'
+                ]);
+                $repositoryDefinition->addTag(ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+                $container->setDefinition(
+                    $repositoryClassName,
+                    $repositoryDefinition
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Injecting doctrine repositories as service instead of the entity manager is best practice in Symfony. On the other hand the service definitions to do this look the same for 99.9% percent of the cases:

```
    AppBundle\Entity\MyCustomRepository:
        class: AppBundle\Entity\MyCustomRepository
        factory: [ "@doctrine.orm.default_entity_manager", "getRepository" ]
        arguments:
          - AppBundle\Entity\MyCustom
```

This was ok for the time where we had no Symfony autowiring as the services had to be defined explicitly all the time. Now there is autowiring and the developers are used to not define they're services on they're own anymore if the want to stick to the default. So we should also support this in the DoctrineBundle.

This PR adds a CompilerPass that checks if custom repositories have already been defined explicitly and if not creates the basic definition automatically. With this you can autowire the repositories without any future action needed.