### PR TITLE
[Messenger] Wire the Doctrine transport factory when component is enabled

### DIFF
--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -11,5 +11,11 @@
         <service id="messenger.middleware.doctrine_transaction" class="Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware" abstract="true" public="false">
             <argument type="service" id="doctrine" />
         </service>
+
+        <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory">
+            <argument type="service" id="doctrine" />
+
+            <tag name="messenger.transport_factory" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
This is related to this PR : https://github.com/symfony/symfony/pull/29007

