### PR TITLE
Fix PHP 5.6+only syntax that breaks the Symfony CI

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,7 +7,6 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use function method_exists;
 
 /**
  * This class contains the configuration information for the bundle


### PR DESCRIPTION
Introduced in #855