### PR TITLE
Drop oldstable dependency version support: bump *all* dependencies to current stable release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,37 +28,15 @@ script:
 
 jobs:
   include:
-    - php: 5.5
-      env: deps=low SYMFONY_DEPRECATIONS_HELPER=weak
-      install:
-        - travis_retry composer update -n --prefer-lowest --prefer-stable --prefer-dist
-
-    - php: 5.6
-      env: SYMFONY_VERSION="2.8.*"
-
-    - php: 7.0
-      env: SYMFONY_VERSION="3.2.*"
-
-    - php: 7.1
-      env: stability=RC SYMFONY_DEPRECATIONS_HELPER=weak SYMFONY_VERSION="3.4.*"
-      install:
-        - travis_retry composer update -n --prefer-dist
-
-    - php: 7.1
+    - php: 7.2
       env: stability=dev SYMFONY_DEPRECATIONS_HELPER=weak SYMFONY_VERSION="4.1.*"
       install:
         - composer require --dev "symfony/messenger" --no-update
         - travis_retry composer update -n --prefer-dist
 
-    - php: 7.2
-      env: stability=alpha
-      install:
-        - composer config minimum-stability alpha
-        - travis_retry composer update -n --prefer-dist
-
     - stage: Code Quality
       env: CODING_STANDARDS
-      php: 7.1
+      php: 7.2
       install:
         - travis_retry composer require -n --prefer-dist --dev doctrine/coding-standard:^5.0
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,8 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -24,28 +24,25 @@
         }
     ],
     "require": {
-        "php": "^5.5.9|^7.0",
-        "symfony/framework-bundle": "^2.7.22|~3.0|~4.0",
-        "symfony/console": "~2.7|~3.0|~4.0",
-        "symfony/dependency-injection": "~2.7|~3.0|~4.0",
-        "doctrine/dbal": "^2.5.12",
-        "jdorn/sql-formatter": "^1.2.16",
-        "symfony/doctrine-bridge": "~2.7|~3.0|~4.0",
-        "doctrine/doctrine-cache-bundle": "~1.2"
+        "php": "^7.2",
+        "symfony/framework-bundle": "^4.1.7",
+        "symfony/console": "^4.1.7",
+        "symfony/dependency-injection": "^4.1.7",
+        "doctrine/dbal": "^2.8.0",
+        "jdorn/sql-formatter": "^1.2.17",
+        "symfony/doctrine-bridge": "^4.1.7",
+        "doctrine/doctrine-cache-bundle": "^1.3.3"
     },
     "require-dev": {
-        "doctrine/orm": "~2.4",
-        "symfony/yaml": "~2.7|~3.0|~4.0",
-        "symfony/validator": "~2.7|~3.0|~4.0",
-        "symfony/property-info": "~2.8|~3.0|~4.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
-        "twig/twig": "~1.26|~2.0",
-        "php-coveralls/php-coveralls": "^2.1",
-        "phpunit/phpunit": "^4.8.36|^5.7|^6.4",
-        "symfony/web-profiler-bundle": "~2.7|~3.0|~4.0"
-    },
-    "conflict": {
-        "symfony/http-foundation": "<2.6"
+        "doctrine/orm": "^2.6.2",
+        "symfony/yaml": "^4.1.7",
+        "symfony/validator": "^4.1.7",
+        "symfony/property-info": "^4.1.7",
+        "symfony/phpunit-bridge": "^4.1.7",
+        "twig/twig": "^2.5.0",
+        "php-coveralls/php-coveralls": "^2.1.0",
+        "phpunit/phpunit": "^6.5.9",
+        "symfony/web-profiler-bundle": "^4.1.7"
     },
     "suggest": {
         "symfony/web-profiler-bundle": "To use the data collector.",


### PR DESCRIPTION
Ref: https://github.com/doctrine/DoctrineBundle/pull/869#issuecomment-435697515
