### PR TITLE
 Port commands for Symfony 4.2 (follows #876)

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -46,7 +46,7 @@ EOT
     {
         $connectionName = $input->getOption('connection');
         if (empty($connectionName)) {
-            $connectionName = $this->doctrine->getDefaultConnectionName();
+            $connectionName = $this->getDoctrine()->getDefaultConnectionName();
         }
         $connection = $this->getDoctrineConnection($connectionName);
 

--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Database tool allows you to easily create your configured databases.
+ *
+ * @final
  */
 class CreateDatabaseDoctrineCommand extends DoctrineCommand
 {
@@ -44,7 +46,7 @@ EOT
     {
         $connectionName = $input->getOption('connection');
         if (empty($connectionName)) {
-            $connectionName = $this->getContainer()->get('doctrine')->getDefaultConnectionName();
+            $connectionName = $this->doctrine->getDefaultConnectionName();
         }
         $connection = $this->getDoctrineConnection($connectionName);
 

--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -17,6 +17,9 @@ use Symfony\Component\Console\Command\Command;
  */
 abstract class DoctrineCommand extends Command
 {
+    /**
+     * @var ManagerRegistry
+     */
     protected $doctrine;
 
     public function __construct(ManagerRegistry $doctrine)

--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -2,18 +2,30 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\EntityGenerator;
 use LogicException;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Base class for Doctrine console commands to extend from.
+ *
+ * @internal
  */
-abstract class DoctrineCommand extends ContainerAwareCommand
+abstract class DoctrineCommand extends Command
 {
+    protected $doctrine;
+
+    public function __construct(ManagerRegistry $doctrine)
+    {
+        parent::__construct();
+
+        $this->doctrine = $doctrine;
+    }
+
     /**
      * get a doctrine entity generator
      *
@@ -42,7 +54,7 @@ abstract class DoctrineCommand extends ContainerAwareCommand
      */
     protected function getEntityManager($name, $shardId = null)
     {
-        $manager = $this->getContainer()->get('doctrine')->getManager($name);
+        $manager = $this->doctrine->getManager($name);
 
         if ($shardId) {
             if (! $manager->getConnection() instanceof PoolingShardConnection) {
@@ -64,6 +76,6 @@ abstract class DoctrineCommand extends ContainerAwareCommand
      */
     protected function getDoctrineConnection($name)
     {
-        return $this->getContainer()->get('doctrine')->getConnection($name);
+        return $this->doctrine->getConnection($name);
     }
 }

--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -17,9 +17,7 @@ use Symfony\Component\Console\Command\Command;
  */
 abstract class DoctrineCommand extends Command
 {
-    /**
-     * @var ManagerRegistry
-     */
+    /** @var ManagerRegistry */
     protected $doctrine;
 
     public function __construct(ManagerRegistry $doctrine)

--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\EntityGenerator;
 use LogicException;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Base class for Doctrine console commands to extend from.
@@ -17,14 +18,46 @@ use Symfony\Component\Console\Command\Command;
  */
 abstract class DoctrineCommand extends Command
 {
-    /** @var ManagerRegistry */
-    protected $doctrine;
+    /** @var ManagerRegistry|null */
+    private $doctrine;
 
-    public function __construct(ManagerRegistry $doctrine)
+    /** @var ContainerInterface|null */
+    private $container;
+
+    public function __construct(ManagerRegistry $doctrine = null)
     {
         parent::__construct();
 
         $this->doctrine = $doctrine;
+    }
+
+    /**
+     * @deprecated
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @deprecated
+     *
+     * @return ContainerInterface
+     *
+     * @throws LogicException
+     */
+    protected function getContainer()
+    {
+        if ($this->container === null) {
+            $application = $this->getApplication();
+            if ($application === null) {
+                throw new LogicException('The container cannot be retrieved as the application instance is not yet set.');
+            }
+
+            $this->container = $application->getKernel()->getContainer();
+        }
+
+        return $this->container;
     }
 
     /**
@@ -55,7 +88,7 @@ abstract class DoctrineCommand extends Command
      */
     protected function getEntityManager($name, $shardId = null)
     {
-        $manager = $this->doctrine->getManager($name);
+        $manager = $this->getDoctrine()->getManager($name);
 
         if ($shardId) {
             if (! $manager->getConnection() instanceof PoolingShardConnection) {
@@ -77,6 +110,14 @@ abstract class DoctrineCommand extends Command
      */
     protected function getDoctrineConnection($name)
     {
-        return $this->doctrine->getConnection($name);
+        return $this->getDoctrine()->getConnection($name);
+    }
+
+    /**
+     * @return ManagerRegistry
+     */
+    protected function getDoctrine()
+    {
+        return $this->doctrine ?: $this->doctrine = $this->getContainer()->get('doctrine');
     }
 }

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Database tool allows you to easily drop your configured databases.
+ *
+ * @final
  */
 class DropDatabaseDoctrineCommand extends DoctrineCommand
 {
@@ -53,7 +55,7 @@ EOT
     {
         $connectionName = $input->getOption('connection');
         if (empty($connectionName)) {
-            $connectionName = $this->getContainer()->get('doctrine')->getDefaultConnectionName();
+            $connectionName = $this->doctrine->getDefaultConnectionName();
         }
         $connection = $this->getDoctrineConnection($connectionName);
 

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -55,7 +55,7 @@ EOT
     {
         $connectionName = $input->getOption('connection');
         if (empty($connectionName)) {
-            $connectionName = $this->doctrine->getDefaultConnectionName();
+            $connectionName = $this->getDoctrine()->getDefaultConnectionName();
         }
         $connection = $this->getDoctrineConnection($connectionName);
 

--- a/Command/GenerateEntitiesDoctrineCommand.php
+++ b/Command/GenerateEntitiesDoctrineCommand.php
@@ -13,6 +13,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Generate entity classes from mapping information
+ *
+ * @final
  */
 class GenerateEntitiesDoctrineCommand extends DoctrineCommand
 {
@@ -81,7 +83,7 @@ EOT
             '       If you wish to generate your entities, use <info>make:entity --regenerate</info> from MakerBundle instead.',
         ]);
 
-        $manager = new DisconnectedMetadataFactory($this->getContainer()->get('doctrine'));
+        $manager = new DisconnectedMetadataFactory($this->doctrine);
 
         try {
             $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('name'));
@@ -93,7 +95,7 @@ EOT
             $pos  = strpos($name, ':');
 
             if ($pos !== false) {
-                $name = $this->getContainer()->get('doctrine')->getAliasNamespace(substr($name, 0, $pos)) . '\\' . substr($name, $pos + 1);
+                $name = $this->doctrine->getAliasNamespace(substr($name, 0, $pos)) . '\\' . substr($name, $pos + 1);
             }
 
             if (class_exists($name)) {

--- a/Command/GenerateEntitiesDoctrineCommand.php
+++ b/Command/GenerateEntitiesDoctrineCommand.php
@@ -83,7 +83,7 @@ EOT
             '       If you wish to generate your entities, use <info>make:entity --regenerate</info> from MakerBundle instead.',
         ]);
 
-        $manager = new DisconnectedMetadataFactory($this->doctrine);
+        $manager = new DisconnectedMetadataFactory($this->getDoctrine());
 
         try {
             $bundle = $this->getApplication()->getKernel()->getBundle($input->getArgument('name'));
@@ -95,7 +95,7 @@ EOT
             $pos  = strpos($name, ':');
 
             if ($pos !== false) {
-                $name = $this->doctrine->getAliasNamespace(substr($name, 0, $pos)) . '\\' . substr($name, $pos + 1);
+                $name = $this->getDoctrine()->getAliasNamespace(substr($name, 0, $pos)) . '\\' . substr($name, $pos + 1);
             }
 
             if (class_exists($name)) {

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -20,9 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private $bundles;
 
     /**

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
@@ -14,9 +15,23 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Import Doctrine ORM metadata mapping information from an existing database.
+ *
+ * @final
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
+    private $bundles;
+
+    /**
+     * @param string[] $bundles
+     */
+    public function __construct(ManagerRegistry $doctrine, array $bundles)
+    {
+        parent::__construct($doctrine);
+
+        $this->bundles = $bundles;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -74,8 +89,7 @@ EOT
         }
 
         $namespaceOrBundle = $input->getArgument('name');
-        $bundles           = $this->getContainer()->getParameter('kernel.bundles');
-        if (isset($bundles[$namespaceOrBundle])) {
+        if (isset($this->bundles[$namespaceOrBundle])) {
             $bundle    = $this->getApplication()->getKernel()->getBundle($namespaceOrBundle);
             $namespace = $bundle->getNamespace() . '\Entity';
 

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -20,6 +20,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
+    /**
+     * @var string[]
+     */
     private $bundles;
 
     /**

--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -29,7 +29,7 @@ class ServiceEntityRepository extends EntityRepository implements ServiceEntityR
     {
         $manager = $registry->getManagerForClass($entityClass);
 
-        if (null === $manager) {
+        if ($manager === null) {
             throw new LogicException(sprintf(
                 'Could not find the entity manager for class "%s". Check your Doctrine configuration to make sure it is configured to load this entity’s metadata.',
                 $entityClass

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -72,10 +72,14 @@
 
         <!-- commands -->
         <service id="doctrine.database_create_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
             <tag name="console.command" command="doctrine:database:create" />
         </service>
 
         <service id="doctrine.database_drop_command" class="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
             <tag name="console.command" command="doctrine:database:drop" />
         </service>
 
@@ -83,25 +87,8 @@
             <tag name="console.command" command="doctrine:generate:entities" />
         </service>
 
-        <service id="doctrine.mapping_import_command" class="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
-            <tag name="console.command" command="doctrine:mapping:import" />
-        </service>
-
         <service id="doctrine.query_sql_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand">
             <tag name="console.command" command="doctrine:query:sql" />
-        </service>
-
-
-        <service id="doctrine.create_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
-            <argument type="service" id="doctrine" />
-
-            <tag name="console.command" command="doctrine:database:create" />
-        </service>
-
-        <service id="doctrine.drop_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
-            <argument type="service" id="doctrine" />
-
-            <tag name="console.command" command="doctrine:database:drop" />
         </service>
 
     </services>

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -91,5 +91,18 @@
             <tag name="console.command" command="doctrine:query:sql" />
         </service>
 
+
+        <service id="doctrine.create_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
+            <tag name="console.command" command="doctrine:database:create" />
+        </service>
+
+        <service id="doctrine.drop_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
+            <tag name="console.command" command="doctrine:database:drop" />
+        </service>
+
     </services>
 </container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -213,17 +213,5 @@
             <tag name="console.command" command="doctrine:generate:entities" />
         </service>
 
-        <service id="doctrine.create_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
-            <argument type="service" id="doctrine" />
-
-            <tag name="console.command" command="doctrine:database:create" />
-        </service>
-
-        <service id="doctrine.drop_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
-            <argument type="service" id="doctrine" />
-
-            <tag name="console.command" command="doctrine:database:drop" />
-        </service>
-
     </services>
 </container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -200,5 +200,30 @@
             <tag name="console.command" command="doctrine:schema:validate" />
         </service>
 
+        <service id="doctrine.import_mapping_command" class="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
+            <argument type="service" id="doctrine" />
+            <argument>%kernel.bundles%</argument>
+
+            <tag name="console.command" command="doctrine:mapping:import" />
+        </service>
+
+        <service id="doctrine.generate_entities_command" class="Doctrine\Bundle\DoctrineBundle\Command\GenerateEntitiesDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
+            <tag name="console.command" command="doctrine:generate:entities" />
+        </service>
+
+        <service id="doctrine.create_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
+            <tag name="console.command" command="doctrine:database:create" />
+        </service>
+
+        <service id="doctrine.drop_database_command" class="Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
+            <tag name="console.command" command="doctrine:database:drop" />
+        </service>
+
     </services>
 </container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -200,7 +200,7 @@
             <tag name="console.command" command="doctrine:schema:validate" />
         </service>
 
-        <service id="doctrine.import_mapping_command" class="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
+        <service id="doctrine.mapping_import_command" class="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
             <argument type="service" id="doctrine" />
             <argument>%kernel.bundles%</argument>
 

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -26,11 +26,12 @@ class CreateDatabaseDoctrineTest extends TestCase
             'driver' => 'pdo_sqlite',
         ];
 
+        $container = $this->getMockContainer($connectionName, $params);
+
         $application = new Application();
-        $application->add(new CreateDatabaseDoctrineCommand());
+        $application->add(new CreateDatabaseDoctrineCommand($container->get('doctrine')));
 
         $command = $application->find('doctrine:database:create');
-        $command->setContainer($this->getMockContainer($connectionName, $params));
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(
@@ -65,11 +66,12 @@ class CreateDatabaseDoctrineTest extends TestCase
             ],
         ];
 
+        $container = $this->getMockContainer($connectionName, $params);
+
         $application = new Application();
-        $application->add(new CreateDatabaseDoctrineCommand());
+        $application->add(new CreateDatabaseDoctrineCommand($container->get('doctrine')));
 
         $command = $application->find('doctrine:database:create');
-        $command->setContainer($this->getMockContainer($connectionName, $params));
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), '--shard' => 1]);
@@ -91,7 +93,7 @@ class CreateDatabaseDoctrineTest extends TestCase
     private function getMockContainer($connectionName, $params = null)
     {
         // Mock the container and everything you'll need here
-        $mockDoctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ConnectionRegistry')
+        $mockDoctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
             ->getMock();
 
         $mockDoctrine->expects($this->any())

--- a/Tests/Command/DropDatabaseDoctrineTest.php
+++ b/Tests/Command/DropDatabaseDoctrineTest.php
@@ -20,11 +20,12 @@ class DropDatabaseDoctrineTest extends TestCase
             'driver' => 'pdo_sqlite',
         ];
 
+        $container = $this->getMockContainer($connectionName, $params);
+
         $application = new Application();
-        $application->add(new DropDatabaseDoctrineCommand());
+        $application->add(new DropDatabaseDoctrineCommand($container->get('doctrine')));
 
         $command = $application->find('doctrine:database:drop');
-        $command->setContainer($this->getMockContainer($connectionName, $params));
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(
@@ -50,11 +51,12 @@ class DropDatabaseDoctrineTest extends TestCase
             'driver' => 'pdo_sqlite',
         ];
 
+        $container = $this->getMockContainer($connectionName, $params);
+
         $application = new Application();
-        $application->add(new DropDatabaseDoctrineCommand());
+        $application->add(new DropDatabaseDoctrineCommand($container->get('doctrine')));
 
         $command = $application->find('doctrine:database:drop');
-        $command->setContainer($this->getMockContainer($connectionName, $params));
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(
@@ -81,7 +83,7 @@ class DropDatabaseDoctrineTest extends TestCase
     private function getMockContainer($connectionName, $params = null)
     {
         // Mock the container and everything you'll need here
-        $mockDoctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ConnectionRegistry')
+        $mockDoctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
             ->getMock();
 
         $mockDoctrine->expects($this->any())

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -49,7 +49,7 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->has('doctrine.dbal.default_connection.events.mysqlsessioninit'));
 
         if (interface_exists('Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface') && class_exists('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor')) {
-            if (!interface_exists(PropertyInitializableExtractorInterface::class)) {
+            if (! interface_exists(PropertyInitializableExtractorInterface::class)) {
                 $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory', $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
             }
             $this->assertInstanceOf('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor', $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));


### PR DESCRIPTION
Follows (and needs) #876.

It works, but it introduces several BC breaks:

* Commands doesn't extend `ContainerAwareCommand` anymore (as this class is deprecated)
* Some constructor parameters are now mandatory (because we use DI instead of injection the container)

Making the commands fully BC would be possible by using hacks like [this one](https://github.com/symfony/panther/blob/master/src/PantherTestCase.php#L19-L29) to introduce some conditional inheritance, but I'm not sure that it is worth it: `ContainerAwareCommand` commands were designed to be initialized by the framework itself.

Also, to prevent future similar issues, I marked these commands `@final`, and the abstract `DoctrineCommand` as `@internal`.