### PR TITLE
Fix exception when configuration is used without doctrine/orm nor doctrine/common

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -302,8 +302,6 @@ class Configuration implements ConfigurationInterface
      */
     private function addOrmSection(ArrayNodeDefinition $node)
     {
-        $generationModes = $this->getAutoGenerateModes();
-
         $node
             ->children()
                 ->arrayNode('orm')
@@ -341,7 +339,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('auto_generate_proxy_classes')->defaultValue(false)
                             ->info('Auto generate mode possible values are: "NEVER", "ALWAYS", "FILE_NOT_EXISTS", "EVAL"')
                             ->validate()
-                                ->ifTrue(static function ($v) use ($generationModes) {
+                                ->ifTrue(function ($v) {
+                                    $generationModes = $this->getAutoGenerateModes();
+
                                     if (is_int($v) && in_array($v, $generationModes['values']/*array(0, 1, 2, 3)*/)) {
                                         return false;
                                     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    /**
+     * Whether or not this test should preserve the global state when
+     * running in a separate PHP process.
+     *
+     * PHPUnit hack to avoid currently loaded classes to leak to
+     * testGetConfigTreeBuilderDoNotUseDoctrineCommon that is run in separate process.
+     *
+     * @var bool
+     */
+    protected $preserveGlobalState = false;
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetConfigTreeBuilderDoNotUseDoctrineCommon()
+    {
+        $configuration = new Configuration(true);
+        $configuration->getConfigTreeBuilder();
+        $this->assertFalse(class_exists('Doctrine\Common\Proxy\AbstractProxyFactory', false));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | https://github.com/symfony/symfony/issues/29390

Hi there is a **ReflectionException Class Doctrine\Common\Proxy\AbstractProxyFactory does not exist** when the `DoctrineBundle` is used without `doctrine/common` being installed. 

Consider this scenario

1. Here are deps in the `composer.json` of my project:

```php
"require": {
    "php": "^7.1.3",
    "ext-ctype": "*",
    "ext-iconv": "*",
    "symfony/console": "4.2.*",
    "symfony/flex": "^1.1",
    "symfony/framework-bundle": "4.2.*",
    "symfony/yaml": "4.2.*"
},
```

2. I install `DoctrineBundle` with `require doctrine/doctrine-bundle`.

3. I activate `DoctrineBundle` in `Kernel`. This entails **ReflectionException Class Doctrine\Common\Proxy\AbstractProxyFactory does not exist** exception.

So when people only need `doctrine/dbal` and `doctrine/doctrine-bundle` in theirs projects are forced to install `doctrine/common` just to avoid this exctption.

This PR resolves the issue.

Cheers.
