### PR TITLE
Unset parameters for sharded databases as well

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -63,13 +63,13 @@ EOT
             $shards = $params['shards'];
             // Default select global
             $params = array_merge($params, $params['global']);
-            unset($params['global']['dbname']);
+            unset($params['global']['dbname'], $params['global']['path'], $params['global']['url']);
             if ($input->getOption('shard')) {
                 foreach ($shards as $i => $shard) {
                     if ($shard['id'] === (int) $input->getOption('shard')) {
                         // Select sharded database
                         $params = array_merge($params, $shard);
-                        unset($params['shards'][$i]['dbname'], $params['id']);
+                        unset($params['shards'][$i]['dbname'], $params['shards'][$i]['path'], $params['shards'][$i]['url'], $params['id']);
                         break;
                     }
                 }

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -51,6 +51,7 @@ class CreateDatabaseDoctrineTest extends TestCase
             'global' => [
                 'driver' => 'pdo_sqlite',
                 'dbname' => 'test',
+                'path' => sys_get_temp_dir() . '/global',
             ],
             'shards' => [
                 'foo' => [


### PR DESCRIPTION
Creating a new database for the global database of a sharded configuration fails, because the command tries to connect to the database that doesn't exist yet.

The cause of this is that the dbname, url and path parameters are not unset for sharded databases, while they are unset for 'normal' connections.