### PR TITLE
Keep defaultTableOptions when MasterSlaveConnection

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -251,6 +251,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'master' => true,
                 'shards' => true,
                 'serverVersion' => true,
+                'defaultTableOptions' => true,
                 // included by safety but should have been unset already
                 'logging' => true,
                 'profiling' => true,


### PR DESCRIPTION
Hi, i have open an issue to explain : https://github.com/doctrine/DoctrineBundle/issues/900

I figure out that the defaultTableOptions is not keep when we use MasterSlaveConnection.