### PR TITLE
Updated the value of path option to match the official recipe

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -957,8 +957,8 @@ can configure. The following block shows all possible configuration keys:
                 driver_class:             MyNamespace\MyDriverImpl
                 options:
                     foo: bar
-                path:                     "%kernel.data_dir%/data.sqlite" # SQLite specific
-                memory:                   true                            # SQLite specific
+                path:                     "%kernel.project_dir%/var/data.db" # SQLite specific
+                memory:                   true                               # SQLite specific
                 unix_socket:              /tmp/mysql.sock
                 persistent:               true
                 MultipleActiveResultSets: true                # pdo_sqlsrv driver specific
@@ -1007,8 +1007,8 @@ can configure. The following block shows all possible configuration keys:
                 password="secret"
                 driver="pdo_mysql"
                 driver-class="MyNamespace\MyDriverImpl"
-                path="%kernel.data_dir%/data.sqlite" <!-- SQLite specific -->
-                memory="true"                        <!-- SQLite specific -->
+                path="%kernel.project_dir%/var/data.db" <!-- SQLite specific -->
+                memory="true"                           <!-- SQLite specific -->
                 unix-socket="/tmp/mysql.sock"
                 persistent="true"
                 multiple-active-result-sets="true" <!-- pdo_sqlsrv driver specific -->


### PR DESCRIPTION
This problem was spotted by @nicolas-grekas. He suggested to use instead the same value as in the official recipe (https://github.com/symfony/recipes/blob/master/doctrine/doctrine-bundle/1.6/manifest.json). I fully agree with that and I hope you do too. Thanks.