### PR TITLE
Don't rewrite defaultTableOptions in sharded or master/slave connections

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -286,6 +286,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'global' => true,
                 'shards' => true,
                 'serverVersion' => true,
+                'defaultTableOptions' => true,
                 // included by safety but should have been unset already
                 'logging' => true,
                 'profiling' => true,

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -251,6 +251,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'master' => true,
                 'shards' => true,
                 'serverVersion' => true,
+                'defaultTableOptions' => true,
                 // included by safety but should have been unset already
                 'logging' => true,
                 'profiling' => true,

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -118,7 +118,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'mysql_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
-                'defaultTableOptions' => [],
             ],
             $param['master']
         );
@@ -133,6 +132,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             ],
             $param['slaves']['slave1']
         );
+        $this->assertEquals(['engine' => 'InnoDB'], $param['defaultTableOptions']);
     }
 
     public function testDbalLoadPoolShardingConnection()
@@ -152,7 +152,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'mysql_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
-                'defaultTableOptions' => [],
             ],
             $param['global']
         );
@@ -168,6 +167,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             ],
             $param['shards'][0]
         );
+        $this->assertEquals(['engine' => 'InnoDB'], $param['defaultTableOptions']);
     }
 
     public function testDbalLoadSavepointsForNestedTransactions()

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_pool_sharding_connection.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_pool_sharding_connection.xml
@@ -9,6 +9,7 @@
     <config>
         <dbal dbname="mysql_db" user="mysql_user" password="mysql_s3cr3t" unix-socket="/path/to/mysqld.sock" shard-choser-service="foo.shard_choser">
             <shard id="1" dbname="shard_db" user="shard_user" password="shard_s3cr3t" unix-socket="/path/to/mysqld_shard.sock" />
+            <default-table-option name="engine">InnoDB</default-table-option>
         </dbal>
     </config>
 </srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_master_slave_connection.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_master_slave_connection.xml
@@ -9,6 +9,7 @@
     <config>
         <dbal dbname="mysql_db" user="mysql_user" password="mysql_s3cr3t" unix-socket="/path/to/mysqld.sock" keep-slave="true">
             <slave name="slave1" dbname="slave_db" user="slave_user" password="slave_s3cr3t" unix-socket="/path/to/mysqld_slave.sock" />
+            <default-table-option name="engine">InnoDB</default-table-option>
         </dbal>
     </config>
 </srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_pool_sharding_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_pool_sharding_connection.yml
@@ -5,6 +5,8 @@ doctrine:
         password: mysql_s3cr3t
         unix_socket: /path/to/mysqld.sock
         shard_choser_service: foo.shard_choser
+        default_table_options:
+            engine: InnoDB
         shards:
             -
                 id: 1

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_master_slave_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_master_slave_connection.yml
@@ -5,6 +5,8 @@ doctrine:
         password: mysql_s3cr3t
         unix_socket: /path/to/mysqld.sock
         keep_slave: true
+        default_table_options:
+            engine: InnoDB
         slaves:
             slave1:
                 user: slave_user


### PR DESCRIPTION
Fixes #900. Supersedes #901.

The schema tool always reads `defaultTableOptions` from the root options, so we may not move it to the `global` or `master` sub-array in sharded or master/slave connections.