### PR TITLE
Removing deprecated call to Configuration::setSchemaAssetsFilter() + extendable

### DIFF
--- a/Dbal/RegexSchemaAssetFilter.php
+++ b/Dbal/RegexSchemaAssetFilter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Dbal;
+
+use Doctrine\DBAL\Schema\AbstractAsset;
+
+class RegexSchemaAssetFilter
+{
+    /** @var string */
+    private $filterExpression;
+
+    public function __construct(string $filterExpression)
+    {
+        $this->filterExpression = $filterExpression;
+    }
+
+    public function __invoke($assetName) : bool
+    {
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        return preg_match($this->filterExpression, $assetName);
+    }
+}

--- a/Dbal/SchemaAssetsFilterManager.php
+++ b/Dbal/SchemaAssetsFilterManager.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Dbal;
+
+/**
+ * Manages schema filters passed to Connection::setSchemaAssetsFilter()
+ */
+class SchemaAssetsFilterManager
+{
+    /** @var callable[] */
+    private $schemaAssetFilters;
+
+    /**
+     * @param callable[] $schemaAssetFilters
+     */
+    public function __construct(array $schemaAssetFilters)
+    {
+        $this->schemaAssetFilters = $schemaAssetFilters;
+    }
+
+    public function __invoke($assetName) : bool
+    {
+        foreach ($this->schemaAssetFilters as $schemaAssetFilter) {
+            if ($schemaAssetFilter($assetName) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/DependencyInjection/Compiler/DbalSchemaFilterPass.php
+++ b/DependencyInjection/Compiler/DbalSchemaFilterPass.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Doctrine\DBAL\Configuration;
+use LogicException;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Processes the doctrine.dbal.schema_filter
+ */
+class DbalSchemaFilterPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $filters = $container->findTaggedServiceIds('doctrine.dbal.schema_filter');
+
+        if (count($filters) > 0 && ! method_exists(Configuration::class, 'setSchemaAssetsFilter')) {
+            throw new LogicException('The doctrine.dbal.schema_filter tag is only supported when using doctrine/dbal 2.9 or higher.');
+        }
+
+        $connectionFilters = [];
+        foreach ($filters as $id => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                $name = isset($attributes['connection']) ? $attributes['connection'] : $container->getParameter('doctrine.default_connection');
+
+                if (! isset($connectionFilters[$name])) {
+                    $connectionFilters[$name] = [];
+                }
+
+                $connectionFilters[$name][] = new Reference($id);
+            }
+        }
+
+        foreach ($connectionFilters as $name => $references) {
+            $configurationId = sprintf('doctrine.dbal.%s_connection.configuration', $name);
+
+            if (! $container->hasDefinition($configurationId)) {
+                continue;
+            }
+
+            $definition = new ChildDefinition('doctrine.dbal.schema_asset_filter_manager');
+            $definition->setArgument(0, $references);
+
+            $id = sprintf('doctrine.dbal.%s_schema_asset_filter_manager', $name);
+            $container->setDefinition($id, $definition);
+            $container->findDefinition($configurationId)
+                ->addMethodCall('setSchemaAssetsFilter', [new Reference($id)]);
+        }
+    }
+}

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -70,6 +70,10 @@
             <tag name="twig.extension" />
         </service>
 
+        <service id="doctrine.dbal.schema_asset_filter_manager" class="Doctrine\Bundle\DoctrineBundle\Dbal\SchemaAssetsFilterManager" public="false" abstract="true">
+            <!-- schema assets filters -->
+        </service>
+
         <!-- commands -->
         <service id="doctrine.database_create_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
             <argument type="service" id="doctrine" />

--- a/Tests/Dbal/RegexSchemaAssetFilterTest.php
+++ b/Tests/Dbal/RegexSchemaAssetFilterTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Dbal;
+
+use Doctrine\Bundle\DoctrineBundle\Dbal\RegexSchemaAssetFilter;
+use PHPUnit\Framework\TestCase;
+
+class RegexSchemaAssetFilterTest extends TestCase
+{
+    public function testShouldIncludeAsset()
+    {
+        $filter = new RegexSchemaAssetFilter('~^(?!t_)~');
+
+        $this->assertTrue($filter('do_not_t_ignore_me'));
+        $this->assertFalse($filter('t_ignore_me'));
+    }
+}

--- a/Tests/Dbal/SchemaAssetsFilterManagerTest.php
+++ b/Tests/Dbal/SchemaAssetsFilterManagerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Dbal;
+
+use Doctrine\Bundle\DoctrineBundle\Dbal\RegexSchemaAssetFilter;
+use Doctrine\Bundle\DoctrineBundle\Dbal\SchemaAssetsFilterManager;
+use PHPUnit\Framework\TestCase;
+
+class SchemaAssetsFilterManagerTest extends TestCase
+{
+    public function testInvoke()
+    {
+        $filterA = new RegexSchemaAssetFilter('~^(?!t_)~');
+        $filterB = new RegexSchemaAssetFilter('~^(?!s_)~');
+
+        $manager = new SchemaAssetsFilterManager([$filterA, $filterB]);
+        $tables  = ['do_not_filter', 't_filter_me', 's_filter_me_too'];
+        $this->assertSame(
+            ['do_not_filter'],
+            array_values(array_filter($tables, $manager))
+        );
+    }
+}

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
@@ -7,6 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal schema-filter="^sf2_" />
+        <dbal default-connection="connection1">
+            <connection name="connection1" schema-filter="~^(?!t_)~" />
+            <connection name="connection2" />
+            <connection name="connection3" />
+        </dbal>
     </config>
 </srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
@@ -1,3 +1,8 @@
 doctrine:
     dbal:
-        schema_filter: ^sf2_
+        default_connection: connection1
+        connections:
+            connection1:
+                schema_filter: ~^(?!t_)~
+            connection2: []
+            connection3: []


### PR DESCRIPTION
Hi!

If you're using doctrine/dbal 2.9 or higher, this removes the deprecated call to `Configuration:: setFilterSchemaAssetsExpression()`. It also makes the "schema filter" extendable via a tag. The use-case is when a 3rd-party bundle manages a table automatically for you through DBAL and you don't want, for example, Doctrine migrations (https://github.com/doctrine/migrations/blob/cf7f94b0bcfbd7d9c240aee759dc6619bc9ad796/lib/Doctrine/Migrations/Generator/DiffGenerator.php#L117) / `doctrine:schema:update` to suggest removing that table because it's not found in the mapping metadata.

One real-world use-case will be for #868: when the Doctrine transport is added to Messenger, a table will be created for storing messages (either automatically by Messenger or manually by the user - their choice). DoctrineBundle itself could use this hook to avoid migrations trying to remove that table once it's created.

Thanks!