### PR TITLE
Allow to typehint `ConnectionRegistry`

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -64,6 +64,7 @@
             <argument>%doctrine.default_entity_manager%</argument>
         </service>
         <service id="Doctrine\Common\Persistence\ManagerRegistry" alias="doctrine" public="false" />
+        <service id="Doctrine\Common\Persistence\ConnectionRegistry" alias="doctrine" public="false" />
         <service id="Symfony\Bridge\Doctrine\RegistryInterface" alias="doctrine" public="false" />
 
         <service id="doctrine.twig.doctrine_extension" class="Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension" public="false">


### PR DESCRIPTION
This would allow to typehint the `ConnectionRegistry` interface to be able to get a connection.