### PR TITLE
Add support for validator auto-mapping

### DIFF
--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -19,6 +19,7 @@ use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Bridge\Doctrine\Logger\DbalLogger;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
+use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 
 class ContainerTest extends TestCase
@@ -68,5 +69,11 @@ class ContainerTest extends TestCase
             $this->assertInstanceOf(ClassMetadataFactory::class, $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
         }
         $this->assertInstanceOf(DoctrineExtractor::class, $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
+
+        if (class_exists(DoctrineLoader::class)) {
+            $this->assertInstanceOf(DoctrineLoader::class, $container->get('doctrine.orm.default_entity_manager.validator_loader'));
+        } else {
+            $this->assertFalse($container->has('doctrine.orm.default_entity_manager.validator_loader'));
+        }
     }
 }

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -2,8 +2,23 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\DBAL\Configuration as DBALConfiguration;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Version;
+use Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer;
+use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
+use Symfony\Bridge\Doctrine\Logger\DbalLogger;
+use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 
 class ContainerTest extends TestCase
@@ -23,25 +38,25 @@ class ContainerTest extends TestCase
     {
         $container = $this->createYamlBundleTestContainer();
 
-        $this->assertInstanceOf('Symfony\Bridge\Doctrine\Logger\DbalLogger', $container->get('doctrine.dbal.logger'));
-        $this->assertInstanceOf('Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector', $container->get('data_collector.doctrine'));
-        $this->assertInstanceOf('Doctrine\DBAL\Configuration', $container->get('doctrine.dbal.default_connection.configuration'));
-        $this->assertInstanceOf('Doctrine\Common\EventManager', $container->get('doctrine.dbal.default_connection.event_manager'));
-        $this->assertInstanceOf('Doctrine\DBAL\Connection', $container->get('doctrine.dbal.default_connection'));
-        $this->assertInstanceOf('Doctrine\Common\Annotations\Reader', $container->get('doctrine.orm.metadata.annotation_reader'));
-        $this->assertInstanceOf('Doctrine\ORM\Configuration', $container->get('doctrine.orm.default_configuration'));
-        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain', $container->get('doctrine.orm.default_metadata_driver'));
-        $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $container->get('doctrine.orm.default_metadata_cache'));
-        $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $container->get('doctrine.orm.default_query_cache'));
-        $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $container->get('doctrine.orm.default_result_cache'));
-        $this->assertInstanceOf('Doctrine\ORM\EntityManager', $container->get('doctrine.orm.default_entity_manager'));
-        $this->assertInstanceOf('Doctrine\DBAL\Connection', $container->get('database_connection'));
-        $this->assertInstanceOf('Doctrine\ORM\EntityManager', $container->get('doctrine.orm.entity_manager'));
-        $this->assertInstanceOf('Doctrine\Common\EventManager', $container->get('doctrine.orm.default_entity_manager.event_manager'));
-        $this->assertInstanceOf('Doctrine\Common\EventManager', $container->get('doctrine.dbal.event_manager'));
-        $this->assertInstanceOf('Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer', $container->get('doctrine.orm.proxy_cache_warmer'));
-        $this->assertInstanceOf('Doctrine\Common\Persistence\ManagerRegistry', $container->get('doctrine'));
-        $this->assertInstanceOf('Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator', $container->get('doctrine.orm.validator.unique'));
+        $this->assertInstanceOf(DbalLogger::class, $container->get('doctrine.dbal.logger'));
+        $this->assertInstanceOf(DoctrineDataCollector::class, $container->get('data_collector.doctrine'));
+        $this->assertInstanceOf(DBALConfiguration::class, $container->get('doctrine.dbal.default_connection.configuration'));
+        $this->assertInstanceOf(EventManager::class, $container->get('doctrine.dbal.default_connection.event_manager'));
+        $this->assertInstanceOf(Connection::class, $container->get('doctrine.dbal.default_connection'));
+        $this->assertInstanceOf(Reader::class, $container->get('doctrine.orm.metadata.annotation_reader'));
+        $this->assertInstanceOf(Configuration::class, $container->get('doctrine.orm.default_configuration'));
+        $this->assertInstanceOf(MappingDriverChain::class, $container->get('doctrine.orm.default_metadata_driver'));
+        $this->assertInstanceOf(ArrayCache::class, $container->get('doctrine.orm.default_metadata_cache'));
+        $this->assertInstanceOf(ArrayCache::class, $container->get('doctrine.orm.default_query_cache'));
+        $this->assertInstanceOf(ArrayCache::class, $container->get('doctrine.orm.default_result_cache'));
+        $this->assertInstanceOf(EntityManager::class, $container->get('doctrine.orm.default_entity_manager'));
+        $this->assertInstanceOf(Connection::class, $container->get('database_connection'));
+        $this->assertInstanceOf(EntityManager::class, $container->get('doctrine.orm.entity_manager'));
+        $this->assertInstanceOf(EventManager::class, $container->get('doctrine.orm.default_entity_manager.event_manager'));
+        $this->assertInstanceOf(EventManager::class, $container->get('doctrine.dbal.event_manager'));
+        $this->assertInstanceOf(ProxyCacheWarmer::class, $container->get('doctrine.orm.proxy_cache_warmer'));
+        $this->assertInstanceOf(ManagerRegistry::class, $container->get('doctrine'));
+        $this->assertInstanceOf(UniqueEntityValidator::class, $container->get('doctrine.orm.validator.unique'));
 
         $this->assertSame($container->get('my.platform'), $container->get('doctrine.dbal.default_connection')->getDatabasePlatform());
 
@@ -50,8 +65,8 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->has('doctrine.dbal.default_connection.events.mysqlsessioninit'));
 
         if (! interface_exists(PropertyInitializableExtractorInterface::class)) {
-            $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory', $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
+            $this->assertInstanceOf(ClassMetadataFactory::class, $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
         }
-        $this->assertInstanceOf('Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor', $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
+        $this->assertInstanceOf(DoctrineExtractor::class, $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
     }
 }


### PR DESCRIPTION
Adds support for symfony/symfony#27735 in the bundle.

Related config:

```yaml
framework:
    validation:
        auto_mapping:
            App\Entity\: []
```