### PR TITLE
[1.10] Don't fail build for the 3 known Twig deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ php:
 env:
   global:
     - deps=no
+    - SYMFONY_DEPRECATIONS_HELPER=3
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"


### PR DESCRIPTION
Twig deprecations were fixed in #929 but can't be fixed in 1.10 due to the change to twig requirements in composer.json. Thus, the build now allows three deprecations in general before failing the build.