### PR TITLE
Wire messenger transport factory

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -367,13 +367,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $container->registerForAutoconfiguration(ServiceEntityRepositoryInterface::class)
             ->addTag(ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
 
-        // If the Messenger component is installed and the doctrine transaction middleware is available, wire it:
-        if (! interface_exists(MessageBusInterface::class) || ! class_exists(DoctrineTransactionMiddleware::class)) {
-            return;
-        }
-
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('messenger.xml');
+        $this->loadMessengerServices($container);
     }
 
     /**
@@ -792,5 +786,16 @@ class DoctrineExtension extends AbstractDoctrineExtension
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
         return new Configuration($container->getParameter('kernel.debug'));
+    }
+
+    private function loadMessengerServices(ContainerBuilder $container) : void
+    {
+        // If the Messenger component is installed and the doctrine transaction middleware is available, wire it:
+        if (! interface_exists(MessageBusInterface::class) || ! class_exists(DoctrineTransactionMiddleware::class)) {
+            return;
+        }
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('messenger.xml');
     }
 }

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory;
 
 /**
  * DoctrineExtension is an extension for the Doctrine DBAL and ORM library.
@@ -797,5 +798,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('messenger.xml');
+
+        if (! class_exists(DoctrineTransportFactory::class)) {
+            return;
+        }
+
+        $transportFactoryDefinition = $container->getDefinition('messenger.transport.doctrine.factory');
+        $transportFactoryDefinition->addTag('messenger.transport_factory');
     }
 }

--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -11,5 +11,13 @@
         <service id="messenger.middleware.doctrine_transaction" class="Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware" abstract="true" public="false">
             <argument type="service" id="doctrine" />
         </service>
+
+        <!--
+        The following service isn't tagged as transport factory because the class may not exist.
+        The tag is added conditionally in DoctrineExtension.
+        -->
+        <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory" public="false">
+            <argument type="service" id="doctrine" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Supersedes #868.

This adds a service for the DoctrineTransportFactory class to the messenger integration config, but doesn't tag it as transport factory. This way, there shouldn't be any errors due to the class not being present in older versions of symfony/messenger.
The tag is then added in DoctrineExtension if the class in question actually exists.

I'm not sure how to best test this since all we're checking is whether the service has a tag; this information is no longer available in the compiled container. Any suggestions?