### PR TITLE
Add deprecation notices for container in DoctrineCommand

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -28,6 +28,14 @@ abstract class DoctrineCommand extends Command
     {
         parent::__construct();
 
+        if ($doctrine === null) {
+            @trigger_error(sprintf(
+                'The "%s" constructor expects a "%s" instance as first argument, not passing it will throw a \TypeError in DoctrineBundle 2.0.',
+                static::class,
+                ManagerRegistry::class
+            ), E_USER_DEPRECATED);
+        }
+
         $this->doctrine = $doctrine;
     }
 
@@ -36,6 +44,8 @@ abstract class DoctrineCommand extends Command
      */
     public function setContainer(ContainerInterface $container = null)
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated and will be removed in DoctrineBundle 2.0.', __METHOD__), E_USER_DEPRECATED);
+
         $this->container = $container;
     }
 
@@ -48,6 +58,8 @@ abstract class DoctrineCommand extends Command
      */
     protected function getContainer()
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated and will be removed in DoctrineBundle 2.0.', __METHOD__), E_USER_DEPRECATED);
+
         if ($this->container === null) {
             $application = $this->getApplication();
             if ($application === null) {


### PR DESCRIPTION
This adds previously removed deprecation notices (see #877) to DoctrineCommand. This helps people extending the command work around future BC breaks.