### PR TITLE
Deprecate type comment attribute from configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->children()
                                 ->scalarNode('class')->isRequired()->end()
-                                ->booleanNode('commented')->defaultTrue()->end()
+                                ->booleanNode('commented')->defaultNull()->end()
                             ->end()
                         ->end()
                     ->end()

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -3,9 +3,13 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestCommentedType;
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ORM\Version;
 use Exception;
 
@@ -29,11 +33,11 @@ class ConnectionFactoryTest extends TestCase
     {
         $typesConfig  = [];
         $factory      = new ConnectionFactory($typesConfig);
-        $params       = ['driverClass' => '\\Doctrine\\Bundle\\DoctrineBundle\\Tests\\FakeDriver'];
+        $params       = ['driverClass' => FakeDriver::class];
         $config       = null;
         $eventManager = null;
         $mappingTypes = [0];
-        $exception    = new DriverException('', $this->getMockBuilder(Driver\AbstractDriverException::class)->disableOriginalConstructor()->getMock());
+        $exception    = new DriverException('', $this->createMock(Driver\AbstractDriverException::class));
 
         // put the mock into the fake driver
         FakeDriver::$exception = $exception;
@@ -43,7 +47,115 @@ class ConnectionFactoryTest extends TestCase
         } catch (Exception $e) {
             $this->assertTrue(strpos($e->getMessage(), 'can circumvent this by setting') > 0);
             throw $e;
+        } finally {
+            FakeDriver::$exception = null;
         }
+    }
+
+    /**
+     * @dataProvider getValidTypeConfigurations
+     */
+    public function testRegisterTypes(array $type, int $expectedCalls) : void
+    {
+        $factory      = new ConnectionFactory(['test' => $type]);
+        $params       = ['driverClass' => FakeDriver::class];
+        $config       = null;
+        $eventManager = null;
+        $mappingTypes = [];
+
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform
+            ->expects($this->exactly($expectedCalls))
+            ->method('markDoctrineTypeCommented')
+            ->with($this->isInstanceOf($type['class']));
+
+        FakeDriver::$platform = $platform;
+
+        try {
+            $factory->createConnection($params, $config, $eventManager, $mappingTypes);
+        } finally {
+            FakeDriver::$platform = null;
+        }
+    }
+
+    public static function getValidTypeConfigurations() : array
+    {
+        return [
+            'uncommentedTypeMarkedNotCommented' => [
+                'type' => [
+                    'class' => TestType::class,
+                    'commented' => false,
+                ],
+                'expectedCalls' => 0,
+            ],
+            'commentedTypeNotMarked' => [
+                'type' => [
+                    'class' => TestCommentedType::class,
+                    'commented' => null,
+                ],
+                'expectedCalls' => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The type "test" was implicitly marked as commented due to the configuration. This is deprecated and will be removed in DoctrineBundle 2.0. Either set the "commented" attribute in the configuration to "false" or mark the type as commented in "Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType::requiresSQLCommentHint()."
+     */
+    public function testRegisterUncommentedTypeNotMarked() : void
+    {
+        $this->testRegisterTypes(
+            [
+                'class' => TestType::class,
+                'commented' => null,
+            ],
+            1
+        );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The type "test" was marked as commented in its configuration but not in the type itself. This is deprecated and will be removed in DoctrineBundle 2.0. Please update the return value of "Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType::requiresSQLCommentHint()."
+     */
+    public function testRegisterUncommentedTypeMarkedCommented() : void
+    {
+        $this->testRegisterTypes(
+            [
+                'class' => TestType::class,
+                'commented' => true,
+            ],
+            1
+        );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The type "test" was explicitly marked as commented in its configuration. This is no longer necessary and will be removed in DoctrineBundle 2.0. Please remove the "commented" attribute from the type configuration.
+     */
+    public function testRegisterCommentedTypeMarkedCommented() : void
+    {
+        $this->testRegisterTypes(
+            [
+                'class' => TestCommentedType::class,
+                'commented' => true,
+            ],
+            0
+        );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The type "test" was marked as uncommented in its configuration but commented in the type itself. This is deprecated and will be removed in DoctrineBundle 2.0. Please update the return value of "Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestCommentedType::requiresSQLCommentHint()" or remove the "commented" attribute from the type configuration.
+     */
+    public function testRegisterCommentedTypeMarkedNotCommented() : void
+    {
+        $this->testRegisterTypes(
+            [
+                'class' => TestCommentedType::class,
+                'commented' => false,
+            ],
+            0
+        );
     }
 }
 
@@ -62,6 +174,9 @@ class FakeDriver implements Driver
      */
     public static $exception;
 
+    /** @var AbstractPlatform|null */
+    public static $platform;
+
     /**
      * This method gets called to determine the database version which in our case leeds to the problem.
      * So we have to fake the exception a driver would normally throw.
@@ -70,7 +185,11 @@ class FakeDriver implements Driver
      */
     public function getDatabasePlatform()
     {
-        throw self::$exception;
+        if (self::$exception !== null) {
+            throw self::$exception;
+        }
+
+        return static::$platform ?? new MySqlPlatform();
     }
 
     // ----- below this line follow only dummy methods to satisfy the interface requirements ----

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -522,7 +522,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('dbal_types');
 
         $this->assertEquals(
-            ['test' => ['class' => TestType::class, 'commented' => true]],
+            ['test' => ['class' => TestType::class, 'commented' => null]],
             $container->getParameter('doctrine.dbal.connection_factory.types')
         );
         $this->assertEquals('%doctrine.dbal.connection_factory.types%', $container->getDefinition('doctrine.dbal.connection_factory')->getArgument(0));

--- a/Tests/DependencyInjection/TestCommentedType.php
+++ b/Tests/DependencyInjection/TestCommentedType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class TestCommentedType extends Type
+{
+    public function getName()
+    {
+        return 'test';
+    }
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return '';
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -48,7 +48,10 @@ class TestCase extends BaseTestCase
                 ],
                 'default_connection' => 'default',
                 'types' => [
-                    'test' => TestType::class,
+                    'test' => [
+                        'class' => TestType::class,
+                        'commented' => false,
+                    ],
                 ],
             ], 'orm' => [
                 'default_entity_manager' => 'default',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Supersedes #628.

The `commented` attribute will be removed in 2.0. To allow people to migrate properly and not have to deal with deprecations until actually switching to 2.0, the default value of `commented` changes from `true` to `null` so we know whether a type was explicitly marked as commented or not. The connection factory now takes into account whether a type itself requires a comment and only explicitly marks it as commented if 

Depending on the scenario, appropriate deprecation notices will be thrown according to the table below:

| Type commented | No `commented` attribute | `commented: true` | `commented: false` |
| --- | --- | --- | --- |
| Yes | No change | Deprecation notice to remove attribute | Deprecation notice to remove attribute |
| No | Implicitly marked commented to preserve BC, deprecation notice to update type or add `commented: false` | Deprecation notice: update type to be commented | No deprecation notice - `commented` attribute will have to be dropped for 2.0. |

Note that users that want to use a type without comments will have to explicitly specify `commented: false` in the configuration. At the same time, we will not be triggering a deprecation notice for this case. This is because in order to maintain BC, not setting the `commented` option will implicitly mark the type as commented, even when the type itself doesn't do so. Users that want to have uncommented types will have to remove the `commented` attribute when upgrading to DoctrineBundle 2.0. If anyone has a suggestion how to best solve this, please let me know as I didn't find any alternative.