### PR TITLE
Add ContainerEntityListenerResolver + load listeners lazy by default

### DIFF
--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -55,9 +55,10 @@ class EntityListenerPass implements CompilerPassInterface
 
                 $lazyByAttribute = isset($attributes['lazy']) && $attributes['lazy'];
                 if ($lazyByAttribute && ! $resolverSupportsLazyListeners) {
-                    throw new InvalidArgumentException(
-                        sprintf('Lazy-loaded entity listeners can only be resolved by a resolver implementing %s.', EntityListenerServiceResolver::class)
-                    );
+                    throw new InvalidArgumentException(sprintf(
+                        'Lazy-loaded entity listeners can only be resolved by a resolver implementing %s.',
+                        EntityListenerServiceResolver::class
+                    ));
                 }
 
                 if (! isset($attributes['lazy']) && $resolverSupportsLazyListeners || $lazyByAttribute) {

--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
+use Doctrine\Bundle\DoctrineBundle\Mapping\EntityListenerServiceResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -44,19 +45,18 @@ class EntityListenerPass implements CompilerPassInterface
                     $this->attachToListener($container, $name, $id, $attributes);
                 }
 
-                $interface = 'Doctrine\\Bundle\\DoctrineBundle\\Mapping\\EntityListenerServiceResolver';
-                $class     = $resolver->getClass();
+                $class = $resolver->getClass();
 
                 if (substr($class, 0, 1) === '%') {
                     // resolve container parameter first
                     $class = $container->getParameterBag()->resolveValue($resolver->getClass());
                 }
-                $resolverSupportsLazyListeners = is_a($class, $interface, true);
+                $resolverSupportsLazyListeners = is_a($class, EntityListenerServiceResolver::class, true);
 
                 $lazyByAttribute = isset($attributes['lazy']) && $attributes['lazy'];
                 if ($lazyByAttribute && ! $resolverSupportsLazyListeners) {
                     throw new InvalidArgumentException(
-                        sprintf('Lazy-loaded entity listeners can only be resolved by a resolver implementing %s.', $interface)
+                        sprintf('Lazy-loaded entity listeners can only be resolved by a resolver implementing %s.', EntityListenerServiceResolver::class)
                     );
                 }
 

--- a/Mapping/ContainerAwareEntityListenerResolver.php
+++ b/Mapping/ContainerAwareEntityListenerResolver.php
@@ -11,7 +11,7 @@ class ContainerAwareEntityListenerResolver extends ContainerEntityListenerResolv
 {
     public function __construct(ContainerInterface $container)
     {
-        @trigger_error(sprintf('The class "%s" is deprecated since 1.11 and will be removed in 2.0 Use "%s" instead.', self::class, 'Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver'), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The class "%s" is deprecated since 1.11 and will be removed in 2.0. Use "%s" instead.', self::class, 'Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver'), E_USER_DEPRECATED);
         parent::__construct($container);
     }
 }

--- a/Mapping/ContainerAwareEntityListenerResolver.php
+++ b/Mapping/ContainerAwareEntityListenerResolver.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
 /**
- * @deprecated since 1.11 and will be removed in 2.0. Use ContainerEntityListenerResolver instead.
+ * @deprecated since DoctrineBundle 1.11 and will be removed in 2.0. Use ContainerEntityListenerResolver instead.
  */
 class ContainerAwareEntityListenerResolver extends ContainerEntityListenerResolver
 {

--- a/Mapping/ContainerAwareEntityListenerResolver.php
+++ b/Mapping/ContainerAwareEntityListenerResolver.php
@@ -2,107 +2,16 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
-use InvalidArgumentException;
-use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ContainerAwareEntityListenerResolver implements EntityListenerServiceResolver
+/**
+ * @deprecated since 1.11 and will be removed in 2.0. Use ContainerEntityListenerResolver instead.
+ */
+class ContainerAwareEntityListenerResolver extends ContainerEntityListenerResolver
 {
-    /** @var ContainerInterface */
-    private $container;
-
-    /** @var object[] Map to store entity listener instances. */
-    private $instances = [];
-
-    /** @var string[] Map to store registered service ids */
-    private $serviceIds = [];
-
     public function __construct(ContainerInterface $container)
     {
-        $this->container = $container;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function clear($className = null)
-    {
-        if ($className === null) {
-            $this->instances = [];
-
-            return;
-        }
-
-        $className = $this->normalizeClassName($className);
-
-        if (! isset($this->instances[$className])) {
-            return;
-        }
-
-        unset($this->instances[$className]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function register($object)
-    {
-        if (! is_object($object)) {
-            throw new InvalidArgumentException(sprintf('An object was expected, but got "%s".', gettype($object)));
-        }
-
-        $className = $this->normalizeClassName(get_class($object));
-
-        $this->instances[$className] = $object;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function registerService($className, $serviceId)
-    {
-        $this->serviceIds[$this->normalizeClassName($className)] = $serviceId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function resolve($className)
-    {
-        $className = $this->normalizeClassName($className);
-
-        if (! isset($this->instances[$className])) {
-            if (isset($this->serviceIds[$className])) {
-                $this->instances[$className] = $this->resolveService($this->serviceIds[$className]);
-            } else {
-                $this->instances[$className] = new $className();
-            }
-        }
-
-        return $this->instances[$className];
-    }
-
-    /**
-     * @param string $serviceId
-     *
-     * @return object
-     */
-    private function resolveService($serviceId)
-    {
-        if (! $this->container->has($serviceId)) {
-            throw new RuntimeException(sprintf('There is no service named "%s"', $serviceId));
-        }
-
-        return $this->container->get($serviceId);
-    }
-
-    /**
-     * @param string $className
-     *
-     * @return string
-     */
-    private function normalizeClassName($className)
-    {
-        return trim($className, '\\');
+        @trigger_error(sprintf('The class "%s" is deprecated since 1.11 and will be removed in 2.0 Use "%s" instead.', self::class, 'Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver'), E_USER_DEPRECATED);
+        parent::__construct($container);
     }
 }

--- a/Mapping/ContainerAwareEntityListenerResolver.php
+++ b/Mapping/ContainerAwareEntityListenerResolver.php
@@ -2,16 +2,9 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 /**
  * @deprecated since 1.11 and will be removed in 2.0. Use ContainerEntityListenerResolver instead.
  */
 class ContainerAwareEntityListenerResolver extends ContainerEntityListenerResolver
 {
-    public function __construct(ContainerInterface $container)
-    {
-        @trigger_error(sprintf('The class "%s" is deprecated since 1.11 and will be removed in 2.0. Use "%s" instead.', self::class, 'Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver'), E_USER_DEPRECATED);
-        parent::__construct($container);
-    }
 }

--- a/Mapping/ContainerEntityListenerResolver.php
+++ b/Mapping/ContainerEntityListenerResolver.php
@@ -38,10 +38,6 @@ class ContainerEntityListenerResolver implements EntityListenerServiceResolver
 
         $className = $this->normalizeClassName($className);
 
-        if (! isset($this->instances[$className])) {
-            return;
-        }
-
         unset($this->instances[$className]);
     }
 

--- a/Mapping/ContainerEntityListenerResolver.php
+++ b/Mapping/ContainerEntityListenerResolver.php
@@ -6,6 +6,9 @@ use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
+/**
+ * @final
+ */
 class ContainerEntityListenerResolver implements EntityListenerServiceResolver
 {
     /** @var ContainerInterface */

--- a/Mapping/ContainerEntityListenerResolver.php
+++ b/Mapping/ContainerEntityListenerResolver.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 class ContainerEntityListenerResolver implements EntityListenerServiceResolver
 {
+    /** @var ContainerInterface */
     private $container;
 
     /** @var object[] Map to store entity listener instances. */
@@ -92,7 +93,7 @@ class ContainerEntityListenerResolver implements EntityListenerServiceResolver
         return $this->container->get($serviceId);
     }
 
-    private function normalizeClassName(string $className): string
+    private function normalizeClassName(string $className) : string
     {
         return trim($className, '\\');
     }

--- a/Mapping/ContainerEntityListenerResolver.php
+++ b/Mapping/ContainerEntityListenerResolver.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Mapping;
+
+use InvalidArgumentException;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class ContainerEntityListenerResolver implements EntityListenerServiceResolver
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    /** @var object[] Map to store entity listener instances. */
+    private $instances = [];
+
+    /** @var string[] Map to store registered service ids */
+    private $serviceIds = [];
+
+    /**
+     * @param ContainerInterface $container a service locator for listeners
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear($className = null)
+    {
+        if ($className === null) {
+            $this->instances = [];
+
+            return;
+        }
+
+        $className = $this->normalizeClassName($className);
+
+        if (! isset($this->instances[$className])) {
+            return;
+        }
+
+        unset($this->instances[$className]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register($object)
+    {
+        if (! is_object($object)) {
+            throw new InvalidArgumentException(sprintf('An object was expected, but got "%s".', gettype($object)));
+        }
+
+        $className = $this->normalizeClassName(get_class($object));
+
+        $this->instances[$className] = $object;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerService($className, $serviceId)
+    {
+        $this->serviceIds[$this->normalizeClassName($className)] = $serviceId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($className)
+    {
+        $className = $this->normalizeClassName($className);
+
+        if (! isset($this->instances[$className])) {
+            if (isset($this->serviceIds[$className])) {
+                $this->instances[$className] = $this->resolveService($this->serviceIds[$className]);
+            } else {
+                $this->instances[$className] = new $className();
+            }
+        }
+
+        return $this->instances[$className];
+    }
+
+    /**
+     * @param string $serviceId
+     *
+     * @return object
+     */
+    private function resolveService($serviceId)
+    {
+        if (! $this->container->has($serviceId)) {
+            throw new RuntimeException(sprintf('There is no service named "%s"', $serviceId));
+        }
+
+        return $this->container->get($serviceId);
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return string
+     */
+    private function normalizeClassName($className)
+    {
+        return trim($className, '\\');
+    }
+}

--- a/Mapping/ContainerEntityListenerResolver.php
+++ b/Mapping/ContainerEntityListenerResolver.php
@@ -8,7 +8,6 @@ use RuntimeException;
 
 class ContainerEntityListenerResolver implements EntityListenerServiceResolver
 {
-    /** @var ContainerInterface */
     private $container;
 
     /** @var object[] Map to store entity listener instances. */
@@ -82,11 +81,9 @@ class ContainerEntityListenerResolver implements EntityListenerServiceResolver
     }
 
     /**
-     * @param string $serviceId
-     *
      * @return object
      */
-    private function resolveService($serviceId)
+    private function resolveService(string $serviceId)
     {
         if (! $this->container->has($serviceId)) {
             throw new RuntimeException(sprintf('There is no service named "%s"', $serviceId));
@@ -95,12 +92,7 @@ class ContainerEntityListenerResolver implements EntityListenerServiceResolver
         return $this->container->get($serviceId);
     }
 
-    /**
-     * @param string $className
-     *
-     * @return string
-     */
-    private function normalizeClassName($className)
+    private function normalizeClassName(string $className): string
     {
         return trim($className, '\\');
     }

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -62,7 +62,7 @@
         <parameter key="doctrine.orm.quote_strategy.ansi.class">Doctrine\ORM\Mapping\AnsiQuoteStrategy</parameter>
 
         <!-- entity listener resolver -->
-        <parameter key="doctrine.orm.entity_listener_resolver.class">Doctrine\Bundle\DoctrineBundle\Mapping\ContainerAwareEntityListenerResolver</parameter>
+        <parameter key="doctrine.orm.entity_listener_resolver.class">Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver</parameter>
 
         <!-- second level cache -->
         <parameter key="doctrine.orm.second_level_cache.default_cache_factory.class">Doctrine\ORM\Cache\DefaultCacheFactory</parameter>

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -831,7 +831,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityListenerResolver', [new Reference('doctrine.orm.em2_entity_listener_resolver')]);
 
         $listener = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener1')]);
+        $this->assertDICDefinitionMethodCallOnce($listener, 'registerService', ['EntityListener', 'entity_listener1']);
 
         $listener = $container->getDefinition('entity_listener_resolver');
         $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener2')]);
@@ -849,10 +849,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->compileContainer($container);
 
         $listener = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener1')]);
+        $this->assertDICDefinitionMethodCallOnce($listener, 'registerService', ['EntityListener1', 'entity_listener1']);
 
         $listener = $container->getDefinition('doctrine.orm.em2_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener2')]);
+        $this->assertDICDefinitionMethodCallOnce($listener, 'registerService', ['EntityListener2', 'entity_listener2']);
 
         $attachListener = $container->getDefinition('doctrine.orm.em1_listeners.attach_entity_listeners');
         $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', ['My/Entity1', 'EntityListener1', 'postLoad']);
@@ -894,6 +894,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $resolver1 = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
         $this->assertDICDefinitionMethodCallOnce($resolver1, 'registerService', ['EntityListener1', 'entity_listener1']);
+        $this->assertDICDefinitionMethodCallOnce($resolver1, 'register', [new Reference('entity_listener3')]);
 
         $resolver2 = $container->findDefinition('custom_entity_listener_resolver');
         $this->assertDICDefinitionMethodCallOnce($resolver2, 'registerService', ['EntityListener2', 'entity_listener2']);

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -909,6 +909,24 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($resolver2, 'registerService', ['EntityListener2', 'entity_listener2']);
     }
 
+    public function testAttachLazyEntityListenerForCustomResolver()
+    {
+        $container = $this->getContainer([]);
+        $loader    = new DoctrineExtension();
+        $container->registerExtension($loader);
+        $container->addCompilerPass(new EntityListenerPass());
+
+        $this->loadFromFile($container, 'orm_entity_listener_custom_resolver');
+
+        $this->compileContainer($container);
+
+        $resolver = $container->getDefinition('custom_entity_listener_resolver');
+        $this->assertTrue($resolver->isPublic());
+        $this->assertEmpty($resolver->getArguments(), 'We must not change the arguments for custom services.');
+        $this->assertDICDefinitionMethodCallOnce($resolver, 'registerService', ['EntityListener', 'entity_listener']);
+        $this->assertTrue($container->getDefinition('entity_listener')->isPublic());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage EntityListenerServiceResolver

--- a/Tests/DependencyInjection/Fixtures/CustomEntityListenerServiceResolver.php
+++ b/Tests/DependencyInjection/Fixtures/CustomEntityListenerServiceResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\EntityListenerServiceResolver;
+
+class CustomEntityListenerServiceResolver implements EntityListenerServiceResolver
+{
+    /** @var EntityListenerServiceResolver */
+    private $resolver;
+
+    public function __construct(EntityListenerServiceResolver $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear($className = null)
+    {
+        $this->resolver->clear($className);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($className)
+    {
+        return $this->resolver->resolve($className);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register($object)
+    {
+        $this->resolver->register($object);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerService($className, $serviceId)
+    {
+        $this->resolver->registerService($className, $serviceId);
+    }
+}

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_lazy_entity_listener.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_lazy_entity_listener.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <services>
-        <service id="custom_entity_listener_resolver" class="Doctrine\Bundle\DoctrineBundle\Mapping\ContainerAwareEntityListenerResolver" >
+        <service id="custom_entity_listener_resolver" class="Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver" >
             <argument type="service" id="service_container"/>
         </service>
 
@@ -16,6 +16,9 @@
         </service>
         <service id="entity_listener2" class="EntityListener2">
             <tag name="doctrine.orm.entity_listener" entity_manager="em2" lazy="true" />
+        </service>
+        <service id="entity_listener3" class="EntityListener3">
+            <tag name="doctrine.orm.entity_listener" lazy="false" />
         </service>
     </services>
 

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_lazy_entity_listener.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_lazy_entity_listener.xml
@@ -20,6 +20,9 @@
         <service id="entity_listener3" class="EntityListener3">
             <tag name="doctrine.orm.entity_listener" lazy="false" />
         </service>
+        <service id="entity_listener4" class="EntityListener4">
+            <tag name="doctrine.orm.entity_listener" />
+        </service>
     </services>
 
     <doctrine:config>

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_entity_listener_custom_resolver.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_entity_listener_custom_resolver.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <services>
+        <service id="custom_entity_listener_resolver" class="Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\CustomEntityListenerServiceResolver" public="false"></service>
+
+        <service id="entity_listener" class="EntityListener" public="false">
+            <tag name="doctrine.orm.entity_listener" />
+        </service>
+    </services>
+
+    <doctrine:config>
+        <doctrine:dbal default-connection="default">
+            <doctrine:connection name="default" dbname="db" />
+        </doctrine:dbal>
+
+        <doctrine:orm default-entity-manager="em1">
+            <doctrine:entity-manager name="em1" entity-listener-resolver="custom_entity_listener_resolver" />
+        </doctrine:orm>
+    </doctrine:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_lazy_entity_listener.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_lazy_entity_listener.yml
@@ -1,6 +1,6 @@
 services:
     custom_entity_listener_resolver:
-        class: Doctrine\Bundle\DoctrineBundle\Mapping\ContainerAwareEntityListenerResolver
+        class: Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver
         arguments:
             - '@service_container'
 
@@ -13,6 +13,11 @@ services:
         class: EntityListener2
         tags:
             - { name: doctrine.orm.entity_listener, entity_manager: em2, lazy: true }
+
+    entity_listener3:
+        class: EntityListener3
+        tags:
+            - { name: doctrine.orm.entity_listener, lazy: false }
 
 doctrine:
     dbal:

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_lazy_entity_listener.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_lazy_entity_listener.yml
@@ -19,6 +19,11 @@ services:
         tags:
             - { name: doctrine.orm.entity_listener, lazy: false }
 
+    entity_listener4:
+        class: EntityListener4
+        tags:
+            - { name: doctrine.orm.entity_listener }
+
 doctrine:
     dbal:
         default_connection: default

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_entity_listener_custom_resolver.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_entity_listener_custom_resolver.yml
@@ -1,0 +1,23 @@
+services:
+    custom_entity_listener_resolver:
+        class: Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\CustomEntityListenerServiceResolver
+        public: false
+
+    entity_listener:
+        class: EntityListener
+        public: false
+        tags:
+            - { name: doctrine.orm.entity_listener }
+
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        default_entity_manager: em1
+        entity_managers:
+            em1:
+                entity_listener_resolver: custom_entity_listener_resolver

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_entity_listener_resolver.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_entity_listener_resolver.yml
@@ -1,14 +1,14 @@
 services:
     entity_listener_resolver:
-        class: \Doctrine\ORM\Mapping\DefaultEntityListenerResolver
+        class: Doctrine\ORM\Mapping\DefaultEntityListenerResolver
 
     entity_listener1:
-        class: \EntityListener
+        class: EntityListener
         tags:
             - { name: doctrine.orm.entity_listener }
 
     entity_listener2:
-        class: \EntityListener
+        class: EntityListener
         tags:
             - { name: doctrine.orm.entity_listener, entity_manager: em2 }
 

--- a/Tests/Mapping/ContainerEntityListenerResolverTest.php
+++ b/Tests/Mapping/ContainerEntityListenerResolverTest.php
@@ -2,14 +2,14 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Mapping;
 
-use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerAwareEntityListenerResolver;
+use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
-class ContainerAwareEntityListenerResolverTest extends TestCase
+class ContainerEntityListenerResolverTest extends TestCase
 {
-    /** @var ContainerAwareEntityListenerResolver */
+    /** @var ContainerEntityListenerResolver */
     private $resolver;
 
     /** @var ContainerInterface|PHPUnit_Framework_MockObject_MockObject */
@@ -19,8 +19,8 @@ class ContainerAwareEntityListenerResolverTest extends TestCase
     {
         parent::setUp();
 
-        $this->container = $this->getMockForAbstractClass('\Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->resolver  = new ContainerAwareEntityListenerResolver($this->container);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->resolver  = new ContainerEntityListenerResolver($this->container);
     }
 
     public function testResolveClass()


### PR DESCRIPTION
EUFOSSA

This implements https://github.com/doctrine/DoctrineBundle/issues/899

- rename `ContainerAwareEntityListenerResolver` into `ContainerEntityListenerResolver` + deprecate old class
- make entity listener services lazy by default (if no `lazy` tag attribute specified)
- use service locator as a smaller container for resolving services

I tested this on my huge work project which uses Symfony 3.4 and we have 3 entity listeners:

```
Information for Service "doctrine.orm.default_entity_listener_resolver"
=======================================================================

 ---------------- ------------------------------------------------------------------------ 
  Option           Value                                                                   
 ---------------- ------------------------------------------------------------------------ 
  Service ID       doctrine.orm.default_entity_listener_resolver                           
  Class            Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver  
  Tags             -                                                                       
  Calls            registerService, registerService, registerService                       
  Public           yes                                                                     
  Synthetic        no                                                                      
  Lazy             no                                                                      
  Shared           yes                                                                     
  Abstract         no                                                                      
  Autowired        no                                                                      
  Autoconfigured   no                                                                      
  Arguments        Service(service_locator.hpxy8ox)                                        
 ---------------- ------------------------------------------------------------------------ 
```