### PR TITLE
Add new pool option to XSD

### DIFF
--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -164,6 +164,7 @@
 
         <xsd:attribute name="type" type="xsd:string" />
         <xsd:attribute name="id" type="xsd:string" />
+        <xsd:attribute name="pool" type="xsd:string" />
         <xsd:attribute name="namespace" type="xsd:string" />
     </xsd:complexType>
 


### PR DESCRIPTION
#948 added support for the `pool` option in the cache configuration, but this was never added to the schema. This PR adds the `pool` option to the XSD.