### PR TITLE
Fix installation instruction

### DIFF
--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -9,7 +9,7 @@ command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    $ composer require doctrine/doctrine-bundle
+    $ composer require doctrine/orm doctrine/doctrine-bundle
 
 This command requires you to have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.


### PR DESCRIPTION
Once performing
```
composer require doctrine/doctrine-bundle
```

The following error is displayed:
```
root@2ace7d652d14:/var/www/symfony/app# composer require doctrine/doctrine-bundle
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Using version ^1.10 for doctrine/doctrine-bundle
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Restricting packages listed in "symfony/symfony" to "4.2.*"
Package operations: 5 installs, 0 updates, 0 removals
  - Installing symfony/doctrine-bridge (v4.2.8): Loading from cache
  - Installing doctrine/doctrine-cache-bundle (1.3.5): Loading from cache
  - Installing jdorn/sql-formatter (v1.2.17): Loading from cache
  - Installing doctrine/dbal (v2.9.2): Loading from cache
  - Installing doctrine/doctrine-bundle (1.10.2): Loading from cache
Writing lock file
Generating autoload files
Symfony operations: 2 recipes (e68882c51e0bc8d592356b5ff5936fa1)
  - Configuring doctrine/doctrine-cache-bundle (>=1.3.5): From auto-generated recipe
  - Configuring doctrine/doctrine-bundle (>=1.6): From github.com/symfony/recipes:master
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In Configuration.php line 313:
!!                                                                               
!!    The doctrine/orm package is required when the doctrine.orm config is set.  
!!                                                                               
!!  
!!  
Script @auto-scripts was called via post-update-cmd

Installation failed, reverting ./composer.json to its original content.

```

Mentioned to require `doctrine/orm` first.