### PR TITLE
Fix non existent service when using symfony cache pools

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -739,7 +739,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 break;
 
             case 'pool':
-                $serviceId = $this->createPoolCacheDefinition($container, $aliasId, $driverMap['pool']);
+                $serviceId = $this->createPoolCacheDefinition($container, $driverMap['pool']);
                 break;
 
             case 'provider':
@@ -862,7 +862,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $transportFactoryDefinition->addTag('messenger.transport_factory');
     }
 
-    private function createPoolCacheDefinition(ContainerBuilder $container, string $aliasId, string $poolName) : string
+    private function createPoolCacheDefinition(ContainerBuilder $container, string $poolName) : string
     {
         if (! class_exists(DoctrineProvider::class)) {
             throw new LogicException('Using the "pool" cache type is only supported when symfony/cache is installed.');
@@ -870,7 +870,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $serviceId = sprintf('doctrine.orm.cache.pool.%s', $poolName);
 
-        $definition = $container->register($aliasId, DoctrineProvider::class);
+        $definition = $container->register($serviceId, DoctrineProvider::class);
         $definition->addArgument(new Reference($poolName));
         $definition->setPrivate(true);
 


### PR DESCRIPTION
Thanks for publishing `1.11.0` version.

When updating to `1.11.0` and simplifying my previous hacky configuration by using the new method for declaring cache configuration based on the symfony cache pools, I got one error.

```
The service "doctrine.orm.default_entity_manager" has a dependency on a non-existent service "doctrine.orm.cache.pool.my_cache_pool".
```

By looking at the code, the `createPoolCacheDefinition` returns a service id, which will be aliased later, but this service id was never registered on the container (instead it was its alias).

I updated the code so that the service id is registered and could later be aliased.
 