### PR TITLE
Fix schema filters

### DIFF
--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Common\Util\ClassUtils;
@@ -36,6 +37,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new DoctrineValidationPass('orm'));
         $container->addCompilerPass(new EntityListenerPass());
         $container->addCompilerPass(new ServiceRepositoryCompilerPass());
+        $container->addCompilerPass(new DbalSchemaFilterPass());
     }
 
     /**

--- a/Tests/BundleTest.php
+++ b/Tests/BundleTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
@@ -21,16 +22,20 @@ class BundleTest extends TestCase
 
         $foundEventListener = false;
         $foundValidation    = false;
+        $foundSchemaFilter  = false;
 
         foreach ($passes as $pass) {
             if ($pass instanceof RegisterEventListenersAndSubscribersPass) {
                 $foundEventListener = true;
             } elseif ($pass instanceof DoctrineValidationPass) {
                 $foundValidation = true;
+            } elseif ($pass instanceof DbalSchemaFilterPass) {
+                $foundSchemaFilter = true;
             }
         }
 
         $this->assertTrue($foundEventListener, 'RegisterEventListenersAndSubscribersPass was not found');
         $this->assertTrue($foundValidation, 'DoctrineValidationPass was not found');
+        $this->assertTrue($foundSchemaFilter, 'DbalSchemaFilterPass was not found');
     }
 }


### PR DESCRIPTION
Schema filters were broken on doctrine/dbal 2.9 and higher by https://github.com/doctrine/DoctrineBundle/pull/935. The compiler pass registration was missing.