### PR TITLE
Register DoctrineClearEntityManagerMiddleware as a service

### DIFF
--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -14,6 +14,14 @@
 
         <!--
         The following service isn't prefixed by the "doctrine.orm" namespace in order for end-users to just use
+        the "doctrine_clear_entity_manager" shortcut in message buses middleware config
+        -->
+        <service id="messenger.middleware.doctrine_clear_entity_manager" class="Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerMiddleware" abstract="true" public="false">
+            <argument type="service" id="doctrine" />
+        </service>
+
+        <!--
+        The following service isn't prefixed by the "doctrine.orm" namespace in order for end-users to just use
         the "doctrine_ping_connection" shortcut in message buses middleware config
         -->
         <service id="messenger.middleware.doctrine_ping_connection" class="Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware" abstract="true" public="false">

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -663,6 +663,8 @@ class DoctrineExtensionTest extends TestCase
 
         $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_transaction'));
         $this->assertCount(1, $middlewarePrototype->getArguments());
+        $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_clear_entity_manager'));
+        $this->assertCount(1, $middlewarePrototype->getArguments());
         $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_ping_connection'));
         $this->assertCount(1, $middlewarePrototype->getArguments());
         $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_close_connection'));


### PR DESCRIPTION
Follow up of https://github.com/symfony/symfony/pull/31334
Similar to https://github.com/doctrine/DoctrineBundle/pull/956