### PR TITLE
Require latest version of symfony/messenger for coverage tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
     - stage: Coverage
       php: 7.3
       install:
-        - composer require --dev "symfony/messenger:4.2.*" --no-update
+        - composer require --dev "symfony/messenger" --no-update
         - travis_retry composer update -n --prefer-dist
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}


### PR DESCRIPTION
This fixes an issue where coverage tests fail because of a deprecated class that is still used due to the older messenger version