### PR TITLE
Fix type error

### DIFF
--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -98,7 +98,7 @@ class ProfilerController implements ContainerAwareInterface
             $params = $params->getValue(true);
         }
 
-        return $connection->executeQuery('EXPLAIN ' . $query['sql'], $params, $query['types'])
+        return $connection->executeQuery('EXPLAIN ' . $query['sql'], $params, $query['types'] ?? [])
             ->fetchAll(PDO::FETCH_ASSOC);
     }
 }


### PR DESCRIPTION
Having `SET sql_mode=(SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', ''))` query and when clicking on explain currently it throws:

`Argument 2 passed to Doctrine\DBAL\Connection::resolveParams() must be of the type array, null given, called in /vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php on line 911`