### PR TITLE
Fix bug in config/packages/doctrine.yml

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -707,6 +707,7 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->children()
                 ->scalarNode('type')->defaultValue('array')->end()
+                ->scalarNode('directory')->defaultValue('%kernel.project_dir%/cache')->end()
                 ->scalarNode('id')->end()
                 ->scalarNode('pool')->end()
                 ->scalarNode('host')->end()


### PR DESCRIPTION
Since following configuration doesn't work (and it should, since [php_file cache is implemented](https://www.doctrine-project.org/projects/doctrine-cache/en/latest/index.html#phpfilecache)). I've introduced simple fix in Configuration file.
```
doctrine:
    orm:
        result_cache_driver:
                type: php_file
                directory: '%kernel.project_dir%/cache'
```