### PR TITLE
Fix empty auto mapping

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -813,7 +813,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     private function loadValidatorLoader(string $entityManagerName, ContainerBuilder $container) : void
     {
-        if (! interface_exists(LoaderInterface::class) || ! class_exists(DoctrineLoader::class)) {
+        $autoMapping = $container->hasParameter('validator.auto_mapping') ? $container->getParameter('validator.auto_mapping') : false;
+
+        if (! $autoMapping || ! interface_exists(LoaderInterface::class) || ! class_exists(DoctrineLoader::class)) {
             return;
         }
 

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -70,7 +70,7 @@ class ContainerTest extends TestCase
         }
         $this->assertInstanceOf(DoctrineExtractor::class, $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
 
-        if (class_exists(DoctrineLoader::class)) {
+        if (class_exists(DoctrineLoader::class) && $container->getParameter('validator.auto_mapping')) {
             $this->assertInstanceOf(DoctrineLoader::class, $container->get('doctrine.orm.default_entity_manager.validator_loader'));
         } else {
             $this->assertFalse($container->has('doctrine.orm.default_entity_manager.validator_loader'));

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -57,11 +57,13 @@ class DoctrineDataCollectorTest extends TestCase
             'sql' => 'SELECT * FROM foo WHERE bar = :bar',
             'params' => [':bar' => 1],
             'executionMS' => 32,
+            'types' => [],
         ];
         $logger->queries[] = [
             'sql' => 'SELECT * FROM foo WHERE bar = :bar',
             'params' => [':bar' => 2],
             'executionMS' => 25,
+            'types' => [],
         ];
         $collector         = $this->createCollector([]);
         $collector->addLogger('default', $logger);
@@ -75,6 +77,7 @@ class DoctrineDataCollectorTest extends TestCase
             'sql' => 'SELECT * FROM bar',
             'params' => [],
             'executionMS' => 25,
+            'types' => [],
         ];
         $collector->collect(new Request(), new Response());
         $groupedQueries = $collector->getGroupedQueries();

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1019,6 +1019,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
             'kernel.root_dir' => __DIR__ . '/../../', // src dir
+            'validator.auto_mapping' => ['App\Entity\Foo' => ['services' => []]],
         ]));
     }
 

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -62,6 +62,7 @@ class ProfilerTest extends BaseTestCase
                 'sql' => 'SELECT * FROM foo WHERE bar IN (?, ?)',
                 'params' => ['foo', 'bar'],
                 'executionMS' => 1,
+                'types' => [],
             ],
         ];
 

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -44,6 +44,7 @@ class ServiceRepositoryTest extends TestCase
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
             'kernel.root_dir' => __DIR__ . '/../../../../', // src dir
+            'validator.auto_mapping' => ['App\Entity\Foo' => ['services' => []]],
         ]));
         $container->set('annotation_reader', new AnnotationReader());
         $extension = new DoctrineExtension();

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -33,6 +33,7 @@ class TestCase extends BaseTestCase
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
             'kernel.root_dir' => __DIR__ . '/../../../../', // src dir
+            'validator.auto_mapping' => ['App\Entity\Foo' => ['services' => []]],
         ]));
         $container->set('annotation_reader', new AnnotationReader());
         $extension = new DoctrineExtension();


### PR DESCRIPTION
Even if the auto-mapping was disabled or not present in the framework configuration, it was still enabled since the Doctrine bundle would register a tagged validator loader.
This PR fixes it.