### PR TITLE
[EntityListener] Fallback on __invoke method if it exists

### DIFF
--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -105,6 +105,8 @@ class EntityListenerPass implements CompilerPassInterface
 
         if (isset($attributes['method'])) {
             $args[] = $attributes['method'];
+        } elseif (! method_exists($serviceDef->getClass(), $attributes['event']) && method_exists($serviceDef->getClass(), '__invoke')) {
+            $args[] = '__invoke';
         }
 
         $container->findDefinition($listenerId)->addMethodCall('addEntityListener', $args);

--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -69,9 +69,10 @@ definition:
                         name: doctrine.orm.entity_listener
                         event: preUpdate
                         entity: App\Entity\User
-                        # Entity manager name is optional
+                        # entity_manager attribute is optional
                         entity_manager: custom
-
+                        # method attribute is optional
+                        method: validateEmail
     .. code-block:: xml
 
         <?xml version="1.0" ?>
@@ -82,16 +83,22 @@ definition:
             <services>
                 <service id="user_listener" class="UserListener">
                     <!-- entity_manager attribute is optional -->
-                    <tag 
+                    <!-- method attribute is optional -->
+                    <tag
                         name="doctrine.orm.entity_listener" 
                         event="preUpdate"
                         entity="App\Entity\User"
                         entity_manager="custom"
+                        method="validateEmail"
                     />
                 </service>
             </services>
         </container>
 
+If you don't specify the ``method`` attribute, it falls back on the subscribed event name.
+
+Starting with Doctrine bundle 1.12, if this method does not exist but if your entity listener is invokable, it falls
+back on the ``__invoke()`` method.
 
 See also
 https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html#entity-listeners

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -856,13 +856,19 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->compileContainer($container);
 
         $listener = $container->getDefinition('doctrine.orm.em1_entity_listener_resolver');
-        $this->assertDICDefinitionMethodCallOnce($listener, 'registerService', ['EntityListener1', 'entity_listener1']);
+        $this->assertDICDefinitionMethodCallCount($listener, 'registerService', [
+            ['EntityListener1', 'entity_listener1'],
+            ['Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\InvokableEntityListener', 'invokable_entity_listener'],
+            ['Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\InvokableEntityListener', 'invokable_entity_listener'],
+        ], 3);
 
         $listener = $container->getDefinition('doctrine.orm.em2_entity_listener_resolver');
         $this->assertDICDefinitionMethodCallOnce($listener, 'registerService', ['EntityListener2', 'entity_listener2']);
 
         $attachListener = $container->getDefinition('doctrine.orm.em1_listeners.attach_entity_listeners');
-        $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', ['My/Entity1', 'EntityListener1', 'postLoad']);
+        $this->assertDICDefinitionMethodCallAt(0, $attachListener, 'addEntityListener', ['My/Entity1', 'EntityListener1', 'postLoad']);
+        $this->assertDICDefinitionMethodCallAt(1, $attachListener, 'addEntityListener', ['My/Entity1', 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\InvokableEntityListener', 'loadClassMetadata', '__invoke']);
+        $this->assertDICDefinitionMethodCallAt(2, $attachListener, 'addEntityListener', ['My/Entity1', 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\InvokableEntityListener', 'postPersist']);
 
         $attachListener = $container->getDefinition('doctrine.orm.em2_listeners.attach_entity_listeners');
         $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', ['My/Entity2', 'EntityListener2', 'preFlush', 'preFlushHandler']);

--- a/Tests/DependencyInjection/Fixtures/InvokableEntityListener.php
+++ b/Tests/DependencyInjection/Fixtures/InvokableEntityListener.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+final class InvokableEntityListener
+{
+    public function __invoke() : void
+    {
+    }
+
+    public function postPersist() : void
+    {
+    }
+}

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_attach_entity_listener_tag.xml
@@ -14,6 +14,11 @@
         <service id="entity_listener2" class="EntityListener2">
             <tag name="doctrine.orm.entity_listener" entity_manager="em2" entity="My/Entity2" event="preFlush" method="preFlushHandler" />
         </service>
+
+        <service id="invokable_entity_listener" class="Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\InvokableEntityListener">
+            <tag name="doctrine.orm.entity_listener" entity="My/Entity1" event="loadClassMetadata" />
+            <tag name="doctrine.orm.entity_listener" entity="My/Entity1" event="postPersist" />
+        </service>
     </services>
 
     <doctrine:config>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_attach_entity_listener_tag.yml
@@ -9,6 +9,12 @@ services:
         tags:
             - { name: doctrine.orm.entity_listener, entity_manager: em2, entity: My/Entity2, event: preFlush, method: preFlushHandler}
 
+    invokable_entity_listener:
+        class: Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\InvokableEntityListener
+        tags:
+            - { name: doctrine.orm.entity_listener, entity: My/Entity1, event: loadClassMetadata }
+            - { name: doctrine.orm.entity_listener, entity: My/Entity1, event: postPersist }
+
 doctrine:
     dbal:
         default_connection: default


### PR DESCRIPTION
It will allow to fall back on the `__invoke` method by default with no breaking change.