### PR TITLE
Fix wrong query structure in tests

### DIFF
--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -56,11 +56,13 @@ class DoctrineDataCollectorTest extends TestCase
         $logger->queries[] = [
             'sql' => 'SELECT * FROM foo WHERE bar = :bar',
             'params' => [':bar' => 1],
+            'types' => null,
             'executionMS' => 32,
         ];
         $logger->queries[] = [
             'sql' => 'SELECT * FROM foo WHERE bar = :bar',
             'params' => [':bar' => 2],
+            'types' => null,
             'executionMS' => 25,
         ];
         $collector         = $this->createCollector([]);
@@ -74,6 +76,7 @@ class DoctrineDataCollectorTest extends TestCase
         $logger->queries[] = [
             'sql' => 'SELECT * FROM bar',
             'params' => [],
+            'types' => null,
             'executionMS' => 25,
         ];
         $collector->collect(new Request(), new Response());

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -61,6 +61,7 @@ class ProfilerTest extends BaseTestCase
             [
                 'sql' => 'SELECT * FROM foo WHERE bar IN (?, ?)',
                 'params' => ['foo', 'bar'],
+                'types' => null,
                 'executionMS' => 1,
             ],
         ];


### PR DESCRIPTION
With https://github.com/symfony/symfony/pull/32163, the `DoctrineDataCollector` class ensures the `types` property of the query is an array. However, in our tests where we use a mock of the DebugStack, we did not add any type information whatsoever, leading to an error in our tests.