### PR TITLE
Ignore deprecation for RegistryInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
 
     # Test against latest Symfony 4.4 dev
     - php: 7.3
-      env: SYMFONY_VERSION="4.4.*@dev"
+      env: SYMFONY_VERSION="4.4.*@dev" SYMFONY_DEPRECATIONS_HELPER=1
       install:
         - composer config minimum-stability dev
         - composer require --dev "symfony/messenger:4.4.*@dev" --no-update


### PR DESCRIPTION
We can't remove usage of that interface without breaking BC, so the tests running against Symfony 4.4 will have to ignore that single deprecation. The interface will be dropped from the class declaration for 2.0, along with the deprecated methods.