### PR TITLE
[2.0] No longer implement deprecated RegistryInterface

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -2,16 +2,14 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMException;
 use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * References all Doctrine connections and entity managers in a given Container.
  */
-class Registry extends ManagerRegistry implements RegistryInterface
+class Registry extends ManagerRegistry
 {
     /**
      * @param string[] $connections
@@ -24,92 +22,6 @@ class Registry extends ManagerRegistry implements RegistryInterface
         $this->container = $container;
 
         parent::__construct('ORM', $connections, $entityManagers, $defaultConnection, $defaultEntityManager, 'Doctrine\ORM\Proxy\Proxy');
-    }
-
-    /**
-     * Gets the default entity manager name.
-     *
-     * @deprecated
-     *
-     * @return string The default entity manager name
-     */
-    public function getDefaultEntityManagerName()
-    {
-        @trigger_error('getDefaultEntityManagerName is deprecated since Symfony 2.1. Use getDefaultManagerName instead', E_USER_DEPRECATED);
-
-        return $this->getDefaultManagerName();
-    }
-
-    /**
-     * Gets a named entity manager.
-     *
-     * @deprecated
-     *
-     * @param string $name The entity manager name (null for the default one)
-     *
-     * @return EntityManager
-     */
-    public function getEntityManager($name = null)
-    {
-        @trigger_error('getEntityManager is deprecated since Symfony 2.1. Use getManager instead', E_USER_DEPRECATED);
-
-        return $this->getManager($name);
-    }
-
-    /**
-     * Gets an array of all registered entity managers
-     *
-     * @deprecated
-     *
-     * @return EntityManager[] an array of all EntityManager instances
-     */
-    public function getEntityManagers()
-    {
-        @trigger_error('getEntityManagers is deprecated since Symfony 2.1. Use getManagers instead', E_USER_DEPRECATED);
-
-        return $this->getManagers();
-    }
-
-    /**
-     * Resets a named entity manager.
-     *
-     * This method is useful when an entity manager has been closed
-     * because of a rollbacked transaction AND when you think that
-     * it makes sense to get a new one to replace the closed one.
-     *
-     * Be warned that you will get a brand new entity manager as
-     * the existing one is not usable anymore. This means that any
-     * other object with a dependency on this entity manager will
-     * hold an obsolete reference. You can inject the registry instead
-     * to avoid this problem.
-     *
-     * @deprecated
-     *
-     * @param string $name The entity manager name (null for the default one)
-     */
-    public function resetEntityManager($name = null)
-    {
-        @trigger_error('resetEntityManager is deprecated since Symfony 2.1. Use resetManager instead', E_USER_DEPRECATED);
-
-        $this->resetManager($name);
-    }
-
-    /**
-     * Resolves a registered namespace alias to the full namespace.
-     *
-     * This method looks for the alias in all registered entity managers.
-     *
-     * @deprecated
-     *
-     * @param string $alias The alias
-     *
-     * @return string The full namespace
-     */
-    public function getEntityNamespace($alias)
-    {
-        @trigger_error('getEntityNamespace is deprecated since Symfony 2.1. Use getAliasNamespace instead', E_USER_DEPRECATED);
-
-        return $this->getAliasNamespace($alias);
     }
 
     /**
@@ -133,35 +45,5 @@ class Registry extends ManagerRegistry implements RegistryInterface
         }
 
         throw ORMException::unknownEntityNamespace($alias);
-    }
-
-    /**
-     * Gets all connection names.
-     *
-     * @deprecated
-     *
-     * @return string[] An array of connection names
-     */
-    public function getEntityManagerNames()
-    {
-        @trigger_error('getEntityManagerNames is deprecated since Symfony 2.1. Use getManagerNames instead', E_USER_DEPRECATED);
-
-        return $this->getManagerNames();
-    }
-
-    /**
-     * Gets the entity manager associated with a given class.
-     *
-     * @deprecated
-     *
-     * @param string $class A Doctrine Entity class name
-     *
-     * @return EntityManager|null
-     */
-    public function getEntityManagerForClass($class)
-    {
-        @trigger_error('getEntityManagerForClass is deprecated since Symfony 2.1. Use getManagerForClass instead', E_USER_DEPRECATED);
-
-        return $this->getManagerForClass($class);
     }
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
@@ -3,12 +3,12 @@
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomServiceRepoEntity;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class TestCustomServiceRepoRepository extends ServiceEntityRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, TestCustomServiceRepoEntity::class);
     }

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -26,6 +26,12 @@ Mapping
  * Dropped `ContainerAwareEntityListenerResolver`, use
    `ContainerEntityListenerResolver` instead.
 
+Registry
+--------
+
+ * `Registry` no longer implements `Symfony\Bridge\Doctrine\RegistryInterface`.
+ * Removed all deprecated entity manager specific methods from the registry.
+
 Types
 -----
 


### PR DESCRIPTION
Hot on the heels of #1000, this drops usage of the removed interface from the manager registry and drops methods that were deprecated in Symfony 2.