### PR TITLE
Fix php 7.4 class resolution behaviour change

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -345,6 +345,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $loader->load('orm.xml');
 
         if (class_exists(AbstractType::class)) {
+            $loader->load('orm-form.xml');
             $container->getDefinition('form.type.entity')->addTag('kernel.reset', ['method' => 'reset']);
         }
 

--- a/Resources/config/orm-form.xml
+++ b/Resources/config/orm-form.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <!-- form field factory guesser -->
+        <parameter key="form.type_guesser.doctrine.class">Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser</parameter>
+    </parameters>
+
+    <services>
+        <service id="form.type_guesser.doctrine" class="%form.type_guesser.doctrine.class%">
+            <tag name="form.type_guesser" />
+            <argument type="service" id="doctrine" />
+        </service>
+
+        <service id="form.type.entity" class="Symfony\Bridge\Doctrine\Form\Type\EntityType">
+            <tag name="form.type" alias="entity" />
+            <argument type="service" id="doctrine" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -39,9 +39,6 @@
         <!-- cache warmer -->
         <parameter key="doctrine.orm.proxy_cache_warmer.class">Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer</parameter>
 
-        <!-- form field factory guesser -->
-        <parameter key="form.type_guesser.doctrine.class">Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser</parameter>
-
         <!-- validator -->
         <parameter key="doctrine.orm.validator.unique.class">Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator</parameter>
         <parameter key="doctrine.orm.validator_initializer.class">Symfony\Bridge\Doctrine\Validator\DoctrineInitializer</parameter>
@@ -83,16 +80,6 @@
 
         <service id="doctrine.orm.proxy_cache_warmer" class="%doctrine.orm.proxy_cache_warmer.class%" public="false">
             <tag name="kernel.cache_warmer" />
-            <argument type="service" id="doctrine" />
-        </service>
-
-        <service id="form.type_guesser.doctrine" class="%form.type_guesser.doctrine.class%">
-            <tag name="form.type_guesser" />
-            <argument type="service" id="doctrine" />
-        </service>
-
-        <service id="form.type.entity" class="Symfony\Bridge\Doctrine\Form\Type\EntityType">
-            <tag name="form.type" alias="entity" />
             <argument type="service" id="doctrine" />
         </service>
 


### PR DESCRIPTION
Following Symfony issue https://github.com/symfony/symfony/issues/32995 from PHP 7.4 a difference in PHP behaviour when resolving classes with missing parent classes or interfaces raise a fatal non-recoverable error.

By moving symfony/form related code into their own service definition file and loading it conditionally, it won't fix the PHP behaviour but at least work around it gracefully.

Please note I didn't tested this code with PHP 7.4 yet.

I know that it might be disruptive to explode the xml files into many smaller ones, but I think it have a nice side effect for maintenance: it decouples definitions for different features that today all stick together. For some people, but that's a subjective opinion, it could improve code readability/maintainability.