### PR TITLE
[WAIT] Added support for EntityMessageCollector

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -382,12 +382,38 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/orm/Proxies')->end()
                         ->scalarNode('proxy_namespace')->defaultValue('Proxies')->end()
                     ->end()
+                    ->fixXmlConfig('messenger_message_collector')
+                    ->append($this->getOrmMessengerCollectorNode())
                     ->fixXmlConfig('entity_manager')
                     ->append($this->getOrmEntityManagersNode())
                     ->fixXmlConfig('resolve_target_entity', 'resolve_target_entities')
                     ->append($this->getOrmTargetEntityResolverNode())
                 ->end()
             ->end();
+    }
+
+    /**
+     * @return NodeDefinition
+     */
+    private function getOrmMessengerCollectorNode()
+    {
+        $treeBuilder = new TreeBuilder('messenger_message_collector');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $node = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $node = $treeBuilder->root('messenger_message_collector');
+        }
+
+        $node
+            ->canBeEnabled()
+            ->children()
+                ->scalarNode('connection')->defaultNull()->end()
+                ->scalarNode('message_bus')->defaultValue('message_bus')->end()
+            ->end();
+
+        return $node;
     }
 
     /**

--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -43,5 +43,12 @@
         <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory" public="false">
             <argument type="service" id="doctrine" />
         </service>
+
+        <!--
+        The following service isn't tagged as the class may not exist.
+        The tag is added conditionally in DoctrineExtension.
+        -->
+        <service id="messenger.event_subscriber.entity_message_collector" class="Symfony\Bridge\Doctrine\Messenger\EventSubscriber\EntityMessageCollector" abstract="true" public="false">
+        </service>
     </services>
 </container>


### PR DESCRIPTION
This feature will allow you to register `EntityMessageCollector` as an event listener. This class will be merged into Symfony 4.4.

https://github.com/symfony/symfony/pull/28850
