### PR TITLE
Remove deprecated functionality from DoctrineCommand

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\EntityGenerator;
 use LogicException;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Base class for Doctrine console commands to extend from.
@@ -18,58 +17,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class DoctrineCommand extends Command
 {
-    /** @var ManagerRegistry|null */
+    /** @var ManagerRegistry */
     private $doctrine;
 
-    /** @var ContainerInterface|null */
-    private $container;
-
-    public function __construct(ManagerRegistry $doctrine = null)
+    public function __construct(ManagerRegistry $doctrine)
     {
         parent::__construct();
 
-        if ($doctrine === null) {
-            @trigger_error(sprintf(
-                'The "%s" constructor expects a "%s" instance as first argument, not passing it will throw a \TypeError in DoctrineBundle 2.0.',
-                static::class,
-                ManagerRegistry::class
-            ), E_USER_DEPRECATED);
-        }
-
         $this->doctrine = $doctrine;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated and will be removed in DoctrineBundle 2.0.', __METHOD__), E_USER_DEPRECATED);
-
-        $this->container = $container;
-    }
-
-    /**
-     * @deprecated
-     *
-     * @return ContainerInterface
-     *
-     * @throws LogicException
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated and will be removed in DoctrineBundle 2.0.', __METHOD__), E_USER_DEPRECATED);
-
-        if ($this->container === null) {
-            $application = $this->getApplication();
-            if ($application === null) {
-                throw new LogicException('The container cannot be retrieved as the application instance is not yet set.');
-            }
-
-            $this->container = $application->getKernel()->getContainer();
-        }
-
-        return $this->container;
     }
 
     /**
@@ -130,6 +85,6 @@ abstract class DoctrineCommand extends Command
      */
     protected function getDoctrine()
     {
-        return $this->doctrine ?: $this->doctrine = $this->getContainer()->get('doctrine');
+        return $this->doctrine;
     }
 }

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -93,6 +93,8 @@
         </service>
 
         <service id="doctrine.generate_entities_command" class="Doctrine\Bundle\DoctrineBundle\Command\GenerateEntitiesDoctrineCommand">
+            <argument type="service" id="doctrine" />
+
             <tag name="console.command" command="doctrine:generate:entities" />
         </service>
 


### PR DESCRIPTION
Since the master branch is 2.0 now, this code can be removed, right? 😃 