### PR TITLE
Load messenger services independently from ORM layer

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -60,6 +60,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (! empty($config['dbal'])) {
             $this->dbalLoad($config['dbal'], $container);
+
+            $this->loadMessengerServices($container);
         }
 
         if (empty($config['orm'])) {
@@ -68,10 +70,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (empty($config['dbal'])) {
             throw new LogicException('Configuring the ORM layer requires to configure the DBAL layer as well.');
-        }
-
-        if (! class_exists(Version::class)) {
-            throw new LogicException('To configure the ORM layer, you must first install the doctrine/orm package.');
         }
 
         $this->ormLoad($config['orm'], $container);
@@ -341,6 +339,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function ormLoad(array $config, ContainerBuilder $container)
     {
+        if (! class_exists(Version::class)) {
+            throw new LogicException('To configure the ORM layer, you must first install the doctrine/orm package.');
+        }
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('orm.xml');
 
@@ -399,8 +401,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $container->registerForAutoconfiguration(ServiceEntityRepositoryInterface::class)
             ->addTag(ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
-
-        $this->loadMessengerServices($container);
     }
 
     /**

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -663,12 +663,6 @@ class DoctrineExtensionTest extends TestCase
 
         $config = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager([
-                'default_entity_manager' => 'default',
-                'entity_managers' => [
-                    'default' => [],
-                ],
-            ])
             ->build();
         $extension->load([$config], $container);
 


### PR DESCRIPTION
Based on #1010, but targeting 1.12.x with this PR. Credit goes to @unixslayer who did the original implementation.

I updated the integration test to ensure the configuration doesn't need the `orm` node to add the messenger integration.