### PR TITLE
Filter out well-known Symfony tables from DBAL schema migrations

### DIFF
--- a/Dbal/BlacklistSchemaAssetFilter.php
+++ b/Dbal/BlacklistSchemaAssetFilter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Dbal;
+
+use Doctrine\DBAL\Schema\AbstractAsset;
+use function in_array;
+
+class BlacklistSchemaAssetFilter
+{
+    /** @var string[] */
+    private $blacklist;
+
+    /**
+     * @param string[] $blacklist
+     */
+    public function __construct(array $blacklist)
+    {
+        $this->blacklist = $blacklist;
+    }
+
+    public function __invoke($assetName) : bool
+    {
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        return ! in_array($assetName, $this->blacklist, true);
+    }
+}

--- a/DependencyInjection/Compiler/WellKnownSchemaFilterPass.php
+++ b/DependencyInjection/Compiler/WellKnownSchemaFilterPass.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Doctrine\DBAL\Configuration;
+use Symfony\Component\Cache\Adapter\PdoAdapter;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+use Symfony\Component\Lock\Store\PdoStore;
+use Symfony\Component\Messenger\Transport\Doctrine\Connection;
+
+/**
+ * Blacklist tables used by well-known Symfony classes.
+ */
+class WellKnownSchemaFilterPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (! method_exists(Configuration::class, 'setSchemaAssetsFilter')) {
+            // only supported when using doctrine/dbal 2.9 or higher
+            return;
+        }
+
+        $blacklist = [];
+
+        foreach ($container->getDefinitions() as $definition) {
+            if ($definition->isAbstract() || $definition->isSynthetic()) {
+                continue;
+            }
+
+            switch ($definition->getClass()) {
+                case PdoAdapter::class:
+                    $blacklist[] = $definition->getArguments()[3]['db_table'] ?? 'cache_items';
+                    break;
+
+                case PdoSessionHandler::class:
+                    $blacklist[] = $definition->getArguments()[1]['db_table'] ?? 'lock_keys';
+                    break;
+
+                case PdoStore::class:
+                    $blacklist[] = $definition->getArguments()[1]['db_table'] ?? 'sessions';
+                    break;
+
+                case Connection::class:
+                    $blacklist[] = $definition->getArguments()[0]['table_name'] ?? 'messenger_messages';
+                    break;
+            }
+        }
+
+        if (! $blacklist) {
+            return;
+        }
+
+        $definition = $container->getDefinition('doctrine.dbal.well_known_schema_asset_filter');
+        $definition->replaceArgument(0, $blacklist);
+
+        foreach (array_keys($container->getParameter('doctrine.connections')) as $name) {
+            $definition->addTag('doctrine.dbal.schema_filter', ['connection' => $name]);
+        }
+    }
+}

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\WellKnownSchemaFilterPass;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Proxy\Autoloader;
@@ -37,6 +38,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new DoctrineValidationPass('orm'));
         $container->addCompilerPass(new EntityListenerPass());
         $container->addCompilerPass(new ServiceRepositoryCompilerPass());
+        $container->addCompilerPass(new WellKnownSchemaFilterPass());
         $container->addCompilerPass(new DbalSchemaFilterPass());
     }
 

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -75,6 +75,10 @@
             <!-- schema assets filters -->
         </service>
 
+        <service id="doctrine.dbal.well_known_schema_asset_filter" class="Doctrine\Bundle\DoctrineBundle\Dbal\BlacklistSchemaAssetFilter" public="false">
+            <argument type="collection" />
+        </service>
+
         <!-- commands -->
         <service id="doctrine.database_create_command" class="Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand">
             <argument type="service" id="doctrine" />

--- a/Tests/DependencyInjection/Fixtures/config/xml/well_known_schema_filter_default_tables.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/well_known_schema_filter_default_tables.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="connection1">
+            <connection name="connection1" schema-filter="~^(?!t_)~" />
+            <connection name="connection2" />
+            <connection name="connection3" />
+        </dbal>
+    </config>
+
+    <srv:services>
+        <srv:service id="well_known_filter" alias="doctrine.dbal.well_known_schema_asset_filter" public="true" />
+        <srv:service id="symfony.cache" class="Symfony\Component\Cache\Adapter\PdoAdapter" />
+        <srv:service id="symfony.session" class="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler" />
+        <srv:service id="symfony.lock" class="Symfony\Component\Lock\Store\PdoStore" />
+        <srv:service id="symfony.messenger" class="Symfony\Component\Messenger\Transport\Doctrine\Connection" />
+    </srv:services>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/well_known_schema_filter_overridden_tables.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/well_known_schema_filter_overridden_tables.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="connection1">
+            <connection name="connection1" schema-filter="~^(?!t_)~" />
+            <connection name="connection2" />
+            <connection name="connection3" />
+        </dbal>
+    </config>
+
+    <srv:services>
+        <srv:service id="well_known_filter" alias="doctrine.dbal.well_known_schema_asset_filter" public="true" />
+        <srv:service id="symfony.cache" class="Symfony\Component\Cache\Adapter\PdoAdapter">
+            <srv:argument />
+            <srv:argument />
+            <srv:argument />
+            <srv:argument type="collection">
+                <srv:argument key="db_table">app_cache</srv:argument>
+            </srv:argument>
+        </srv:service>
+        <srv:service id="symfony.session" class="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler">
+            <srv:argument />
+            <srv:argument type="collection">
+                <srv:argument key="db_table">app_session</srv:argument>
+            </srv:argument>
+        </srv:service>
+        <srv:service id="symfony.lock" class="Symfony\Component\Lock\Store\PdoStore">
+            <srv:argument />
+            <srv:argument type="collection">
+                <srv:argument key="db_table">app_locks</srv:argument>
+            </srv:argument>
+        </srv:service>
+        <srv:service id="symfony.messenger" class="Symfony\Component\Messenger\Transport\Doctrine\Connection">
+            <srv:argument type="collection">
+                <srv:argument key="table_name">app_messages</srv:argument>
+            </srv:argument>
+        </srv:service>
+    </srv:services>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/well_known_schema_filter_default_tables.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/well_known_schema_filter_default_tables.yml
@@ -1,0 +1,25 @@
+doctrine:
+    dbal:
+        default_connection: connection1
+        connections:
+            connection1:
+                schema_filter: ~^(?!t_)~
+            connection2: []
+            connection3: []
+
+services:
+    well_known_filter:
+        alias: 'doctrine.dbal.well_known_schema_asset_filter'
+        public: true
+
+    symfony.cache:
+        class: 'Symfony\Component\Cache\Adapter\PdoAdapter'
+
+    symfony.session:
+        class: 'Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler'
+
+    symfony.lock:
+        class: 'Symfony\Component\Lock\Store\PdoStore'
+
+    symfony.messenger:
+        class: 'Symfony\Component\Messenger\Transport\Doctrine\Connection'

--- a/Tests/DependencyInjection/Fixtures/config/yml/well_known_schema_filter_overridden_tables.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/well_known_schema_filter_overridden_tables.yml
@@ -1,0 +1,38 @@
+doctrine:
+    dbal:
+        default_connection: connection1
+        connections:
+            connection1:
+                schema_filter: ~^(?!t_)~
+            connection2: []
+            connection3: []
+
+services:
+    well_known_filter:
+        alias: 'doctrine.dbal.well_known_schema_asset_filter'
+        public: true
+
+    symfony.cache:
+        class: 'Symfony\Component\Cache\Adapter\PdoAdapter'
+        arguments:
+            - ~
+            - ~
+            - ~
+            - db_table: app_cache
+
+    symfony.session:
+        class: 'Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler'
+        arguments:
+            - ~
+            - db_table: app_session
+
+    symfony.lock:
+        class: 'Symfony\Component\Lock\Store\PdoStore'
+        arguments:
+            - ~
+            - db_table: app_locks
+
+    symfony.messenger:
+        class: 'Symfony\Component\Messenger\Transport\Doctrine\Connection'
+        arguments:
+            - table_name: app_messages


### PR DESCRIPTION
This prevents constantly generating `DROP TABLE sessions`, etc. when generating migrations.

Closes #987