### PR TITLE
Adding support for DoctrineClearEntityManagerWorkerSubscriber

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Version;
 use LogicException;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
@@ -877,6 +878,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('messenger.xml');
+
+        if (! class_exists(DoctrineClearEntityManagerWorkerSubscriber::class)) {
+            $container->removeDefinition('doctrine.orm.messenger.event_subscriber.doctrine_clear_entity_manager');
+        }
 
         if (! class_exists(DoctrineTransportFactory::class)) {
             return;

--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -14,14 +14,6 @@
 
         <!--
         The following service isn't prefixed by the "doctrine.orm" namespace in order for end-users to just use
-        the "doctrine_clear_entity_manager" shortcut in message buses middleware config
-        -->
-        <service id="messenger.middleware.doctrine_clear_entity_manager" class="Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerMiddleware" abstract="true" public="false">
-            <argument type="service" id="doctrine" />
-        </service>
-
-        <!--
-        The following service isn't prefixed by the "doctrine.orm" namespace in order for end-users to just use
         the "doctrine_ping_connection" shortcut in message buses middleware config
         -->
         <service id="messenger.middleware.doctrine_ping_connection" class="Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware" abstract="true" public="false">
@@ -41,6 +33,11 @@
         The tag is added conditionally in DoctrineExtension.
         -->
         <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory" public="false">
+            <argument type="service" id="doctrine" />
+        </service>
+
+        <service id="doctrine.orm.messenger.event_subscriber.doctrine_clear_entity_manager" class="Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber" public="false">
+            <tag name="kernel.event_subscriber" />
             <argument type="service" id="doctrine" />
         </service>
     </services>

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
@@ -668,12 +669,17 @@ class DoctrineExtensionTest extends TestCase
 
         $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_transaction'));
         $this->assertCount(1, $middlewarePrototype->getArguments());
-        $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_clear_entity_manager'));
-        $this->assertCount(1, $middlewarePrototype->getArguments());
         $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_ping_connection'));
         $this->assertCount(1, $middlewarePrototype->getArguments());
         $this->assertNotNull($middlewarePrototype = $container->getDefinition('messenger.middleware.doctrine_close_connection'));
         $this->assertCount(1, $middlewarePrototype->getArguments());
+
+        if (class_exists(DoctrineClearEntityManagerWorkerSubscriber::class)) {
+            $this->assertNotNull($subscriber = $container->getDefinition('doctrine.orm.messenger.event_subscriber.doctrine_clear_entity_manager'));
+            $this->assertCount(1, $subscriber->getArguments());
+        } else {
+            $this->assertFalse($container->hasDefinition('doctrine.orm.messenger.event_subscriber.doctrine_clear_entity_manager'));
+        }
     }
 
     /**


### PR DESCRIPTION
Hi!

This wires symfony/symfony#34156 as a service. That PR also removes `DoctrineClearEntityManagerMiddleware`, which was never released in DoctrineBundle, so we can safely remove it without any BC worries.

The idea (validated if/when #34156 is merged) is that we should run `$entityManager->clear()` between *each* message that a worker (`messenger:consume`) handles. I have not made this configurable - I would rather someone approach us with a valid case for disabling this before doing that. If there *is* a valid case for wanting this disabled, I don't know what it is - so this would help us learn about such a case.

Thanks!