### PR TITLE
Fix compat with Symfony 5 after a recent deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then jq "(.require, .\"require-dev\")|=(with_entries(if .key|test(\"^symfony/\") then .value|=\"${SYMFONY_VERSION}\" else . end))" composer.json|ex -sc 'wq!composer.json' /dev/stdin; fi;
+  - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
 
 install:
-  - travis_retry composer update -n --prefer-dist
+  - travis_retry composer update -n --prefer-dist --prefer-stable
 
 script:
   - ./vendor/bin/phpunit -v
@@ -31,27 +31,22 @@ jobs:
   include:
     # Tests the lowest set of dependencies
     - php: 7.1
-      env: LOWEST SYMFONY_DEPRECATIONS_HELPER=999999
+      env: LOWEST SYMFONY_DEPRECATIONS_HELPER=weak
       install:
         - travis_retry composer update -n --prefer-lowest --prefer-stable --prefer-dist
 
-    # Test against latest Symfony 3.4 stable
-    - php: 7.3
-      env: SYMFONY_VERSION="3.4.*" SYMFONY_DEPRECATIONS_HELPER=999999
-
     # Test against latest Symfony 4.3 stable
     - php: 7.3
-      env: SYMFONY_VERSION="4.3.*"
+      env: SYMFONY_REQUIRE="4.3.*"
       install:
-        - composer require --dev "symfony/messenger:4.3.*" --no-update
-        - travis_retry composer update -n --prefer-dist
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist --prefer-stable
 
     # Test against latest Symfony 4.4 dev
     - php: 7.3
-      env: SYMFONY_VERSION="4.4.*@dev"
+      env: SYMFONY_REQUIRE="4.4.*"
       install:
-        - composer config minimum-stability dev
-        - composer require --dev "symfony/messenger:4.4.*@dev" --no-update
+        - composer require --dev symfony/messenger --no-update
         - travis_retry composer update -n --prefer-dist
 
     # Test dev versions
@@ -59,7 +54,6 @@ jobs:
       if: type = cron
       env: DEV
       install:
-        - composer config minimum-stability dev
         - travis_retry composer update -n --prefer-dist
 
     - stage: Code Quality

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -10,10 +10,10 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Tools\SchemaValidator;
-use Exception;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector as BaseCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class DoctrineDataCollector extends BaseCollector
 {
@@ -36,7 +36,7 @@ class DoctrineDataCollector extends BaseCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, Exception $exception = null)
+    public function collect(Request $request, Response $response, Throwable $exception = null)
     {
         parent::collect($request, $response, $exception);
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,13 +38,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder() : TreeBuilder
     {
         $treeBuilder = new TreeBuilder('doctrine');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('doctrine');
-        }
+        $rootNode    = $treeBuilder->getRootNode();
 
         $this->addDbalSection($rootNode);
         $this->addOrmSection($rootNode);
@@ -115,13 +109,7 @@ class Configuration implements ConfigurationInterface
     private function getDbalConnectionsNode()
     {
         $treeBuilder = new TreeBuilder('connections');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $node = $treeBuilder->root('connections');
-        }
+        $node        = $treeBuilder->getRootNode();
 
         /** @var ArrayNodeDefinition $connectionNode */
         $connectionNode = $node
@@ -395,13 +383,7 @@ class Configuration implements ConfigurationInterface
     private function getOrmTargetEntityResolverNode()
     {
         $treeBuilder = new TreeBuilder('resolve_target_entities');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $node = $treeBuilder->root('resolve_target_entities');
-        }
+        $node        = $treeBuilder->getRootNode();
 
         $node
             ->useAttributeAsKey('interface')
@@ -420,13 +402,7 @@ class Configuration implements ConfigurationInterface
     private function getOrmEntityListenersNode()
     {
         $treeBuilder = new TreeBuilder('entity_listeners');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $node = $treeBuilder->root('entity_listeners');
-        }
+        $node        = $treeBuilder->getRootNode();
 
         $normalizer = static function ($mappings) {
             $entities = [];
@@ -512,13 +488,7 @@ class Configuration implements ConfigurationInterface
     private function getOrmEntityManagersNode()
     {
         $treeBuilder = new TreeBuilder('entity_managers');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $node = $treeBuilder->root('entity_managers');
-        }
+        $node        = $treeBuilder->getRootNode();
 
         $node
             ->requiresAtLeastOneElement()
@@ -682,13 +652,7 @@ class Configuration implements ConfigurationInterface
     private function getOrmCacheDriverNode($name)
     {
         $treeBuilder = new TreeBuilder($name);
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $node = $treeBuilder->root($name);
-        }
+        $node        = $treeBuilder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\DBAL\Configuration as DBALConfiguration;
 use Doctrine\DBAL\Connection;
@@ -20,7 +19,6 @@ use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\Cache\DoctrineProvider;
-use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 
 class ContainerTest extends TestCase
 {
@@ -65,15 +63,8 @@ class ContainerTest extends TestCase
 
         $this->assertFalse($container->has('doctrine.dbal.default_connection.events.mysqlsessioninit'));
 
-        if (! interface_exists(PropertyInitializableExtractorInterface::class)) {
-            $this->assertInstanceOf(ClassMetadataFactory::class, $container->get('doctrine.orm.default_entity_manager.metadata_factory'));
-        }
         $this->assertInstanceOf(DoctrineExtractor::class, $container->get('doctrine.orm.default_entity_manager.property_info_extractor'));
 
-        if (class_exists(DoctrineLoader::class)) {
-            $this->assertInstanceOf(DoctrineLoader::class, $container->get('doctrine.orm.default_entity_manager.validator_loader'));
-        } else {
-            $this->assertFalse($container->has('doctrine.orm.default_entity_manager.validator_loader'));
-        }
+        $this->assertInstanceOf(DoctrineLoader::class, $container->get('doctrine.orm.default_entity_manager.validator_loader'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": ["DBAL", "ORM", "Database", "Persistence"],
     "homepage": "http://www.doctrine-project.org",
     "license": "MIT",
+    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Fabien Potencier",
@@ -26,19 +27,19 @@
     "require": {
         "php": "^7.1",
         "symfony/framework-bundle": "^3.4.30|^4.3.3|^5.0",
-        "symfony/config": "^3.4.30|^4.3.3|^5.0",
+        "symfony/config": "^4.3.3|^5.0",
         "symfony/console": "^3.4.30|^4.3.3|^5.0",
-        "symfony/dependency-injection": "^3.4.30|^4.3.3|^5.0",
+        "symfony/dependency-injection": "^4.3.3|^5.0",
         "doctrine/dbal": "^2.9.0",
         "jdorn/sql-formatter": "^1.2.16",
-        "symfony/doctrine-bridge": "^3.4.30|^4.3.3|^5.0"
+        "symfony/doctrine-bridge": "^4.3.7|^5.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.6",
         "symfony/cache": "^3.4.30|^4.3.3|^5.0",
         "symfony/yaml": "^3.4.30|^4.3.3|^5.0",
         "symfony/validator": "^3.4.30|^4.3.3|^5.0",
-        "symfony/property-info": "^3.4.30|^4.3.3|^5.0",
+        "symfony/property-info": "^4.3.3|^5.0",
         "symfony/phpunit-bridge": "^4.2",
         "symfony/twig-bridge": "^3.4.30|^4.3.3|^5.0",
         "twig/twig": "^1.34|^2.12",


### PR DESCRIPTION
This drops support for Symfony 3.4, but the alternative is ugly, so I think we should do it, for v2 of course.

Follows https://github.com/symfony/symfony/pull/34230 and https://github.com/symfony/symfony/pull/34230