### PR TITLE
Remove aliases for common interfaces

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -64,7 +64,6 @@
             <argument>%doctrine.default_connection%</argument>
             <argument>%doctrine.default_entity_manager%</argument>
         </service>
-        <service id="Symfony\Bridge\Doctrine\RegistryInterface" alias="doctrine" public="false" />
         <service id="Doctrine\Bundle\DoctrineBundle\Registry" alias="doctrine" public="false" />
 
         <service id="doctrine.twig.doctrine_extension" class="Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension" public="false">

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -64,7 +64,6 @@
             <argument>%doctrine.default_connection%</argument>
             <argument>%doctrine.default_entity_manager%</argument>
         </service>
-        <service id="Doctrine\Common\Persistence\ManagerRegistry" alias="doctrine" public="false" />
         <service id="Symfony\Bridge\Doctrine\RegistryInterface" alias="doctrine" public="false" />
         <service id="Doctrine\Bundle\DoctrineBundle\Registry" alias="doctrine" public="false" />
 

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -75,7 +75,6 @@
     </parameters>
 
     <services>
-        <service id="Doctrine\Common\Persistence\ObjectManager" alias="doctrine.orm.entity_manager" public="false" />
         <service id="Doctrine\ORM\EntityManagerInterface" alias="doctrine.orm.entity_manager" public="false" />
 
         <!--- Internal Annotation Metadata Reader Service alias, use annotation_reader service -->

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
@@ -35,8 +33,6 @@ class DoctrineExtensionTest extends TestCase
         $expectedAliases = [
             DriverConnection::class => 'database_connection',
             Connection::class => 'database_connection',
-            ManagerRegistry::class => 'doctrine',
-            ObjectManager::class => 'doctrine.orm.entity_manager',
             EntityManagerInterface::class => 'doctrine.orm.entity_manager',
         ];
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -41,6 +41,17 @@ Registry
  * `Registry` no longer implements `Symfony\Bridge\Doctrine\RegistryInterface`.
  * Removed all deprecated entity manager specific methods from the registry.
 
+Service aliases
+---------------
+
+ * The `Doctrine\Common\Persistence\ManagerRegistry` and
+   `Symfony\Bridge\Doctrine\RegistryInterface` interfaces are no longer aliased
+   to the `doctrine` service, use `Doctrine\Bundle\DoctrineBundle\Registry`
+   instead.
+ * The `Doctrine\Common\Persistence\ObjectManager` interface is no longer
+   aliased to the `doctrine.orm.entity_manager` service, use
+   `Doctrine\ORM\EntityManagerInterface` instead.
+
 Types
 -----
 


### PR DESCRIPTION
Fixes #870. This is a repeat of #740, which was reverted in #805. For 2.0.0, we can do this again.