### PR TITLE
Add new service alias for manager registry

### DIFF
--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -14,7 +14,7 @@ use LogicException;
  *
  * class YourEntityRepository extends ServiceEntityRepository
  * {
- *     public function __construct(RegistryInterface $registry)
+ *     public function __construct(Registry $registry)
  *     {
  *         parent::__construct($registry, YourEntity::class);
  *     }

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -66,6 +66,7 @@
         </service>
         <service id="Doctrine\Common\Persistence\ManagerRegistry" alias="doctrine" public="false" />
         <service id="Symfony\Bridge\Doctrine\RegistryInterface" alias="doctrine" public="false" />
+        <service id="Doctrine\Bundle\DoctrineBundle\Registry" alias="doctrine" public="false" />
 
         <service id="doctrine.twig.doctrine_extension" class="Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension" public="false">
             <tag name="twig.extension" />

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
@@ -2,13 +2,13 @@
 
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
+use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomServiceRepoEntity;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class TestCustomServiceRepoRepository extends ServiceEntityRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(Registry $registry)
     {
         parent::__construct($registry, TestCustomServiceRepoEntity::class);
     }


### PR DESCRIPTION
This adds a new alias as a replacement for the deprecated `RegistryInterface` from the Doctrine Bridge.