### PR TITLE
Restore autowiring alias for ManagerRegistry

### DIFF
--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -14,7 +14,7 @@ use LogicException;
  *
  * class YourEntityRepository extends ServiceEntityRepository
  * {
- *     public function __construct(Registry $registry)
+ *     public function __construct(ManagerRegistry $registry)
  *     {
  *         parent::__construct($registry, YourEntity::class);
  *     }

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -64,7 +64,7 @@
             <argument>%doctrine.default_connection%</argument>
             <argument>%doctrine.default_entity_manager%</argument>
         </service>
-        <service id="Doctrine\Bundle\DoctrineBundle\Registry" alias="doctrine" public="false" />
+        <service id="Doctrine\Common\Persistence\ManagerRegistry" alias="doctrine" public="false" />
 
         <service id="doctrine.twig.doctrine_extension" class="Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension" public="false">
             <tag name="twig.extension" />

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
@@ -2,13 +2,13 @@
 
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
-use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomServiceRepoEntity;
 
 class TestCustomServiceRepoRepository extends ServiceEntityRepository
 {
-    public function __construct(Registry $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, TestCustomServiceRepoEntity::class);
     }

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -44,9 +44,8 @@ Registry
 Service aliases
 ---------------
 
- * The `Doctrine\Common\Persistence\ManagerRegistry` and
-   `Symfony\Bridge\Doctrine\RegistryInterface` interfaces are no longer aliased
-   to the `doctrine` service, use `Doctrine\Bundle\DoctrineBundle\Registry`
+ * The `Symfony\Bridge\Doctrine\RegistryInterface` interface is no longer aliased
+   to the `doctrine` service, use `Doctrine\Common\Persistence\ManagerRegistry`
    instead.
  * The `Doctrine\Common\Persistence\ObjectManager` interface is no longer
    aliased to the `doctrine.orm.entity_manager` service, use


### PR DESCRIPTION
Promoting autowiring aliases that target classes is encouraging ppl to create tight coupling with the implementation, while IoC is about coding against abstractions.

The fact that the interface is also implemented by the ODM is not an issue to me: this is just the default autowiring alias for the interface. It should serve the majority. There is no issue keeping it.

If we want two aliases, a latter PR could add named autowiring aliases.

Side note: the alias for `Doctrine\ORM\EntityManagerInterface` is encouraging type hinting against a stateful service. But that's for another PR :)