### PR TITLE
Default to real-utf8 when no charset is provided

### DIFF
--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -49,6 +49,26 @@ class ConnectionFactoryTest extends TestCase
             FakeDriver::$exception = null;
         }
     }
+
+    public function testDefaultCharset()
+    {
+        $factory = new ConnectionFactory([]);
+        $params  = ['driverClass' => FakeDriver::class];
+
+        $connection = $factory->createConnection($params);
+
+        $this->assertSame('utf8', $connection->getParams()['charset']);
+    }
+
+    public function testDefaultCharsetMySql()
+    {
+        $factory = new ConnectionFactory([]);
+        $params  = ['driver' => 'pdo_mysql'];
+
+        $connection = $factory->createConnection($params);
+
+        $this->assertSame('utf8mb4', $connection->getParams()['charset']);
+    }
 }
 
 /**

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -9,6 +9,8 @@ PHP and Symfony version support
    Symfony 3.4 LTS and 4.1 or newer.
  * Support for Twig 1.34 and below as well as 2.4 and below (for 2.x) releases
    was dropped.
+ * When no charset parameter is defined, it now defaults to `utf8mb4` on the
+   MySQL platform and to `utf8` on all other platforms.
 
 Commands
 --------


### PR DESCRIPTION
This is a back port of #1070 since that was inadvertently merged to master only.