### PR TITLE
Allow non-scalar DBAL options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -160,7 +160,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('keep_slave')->end()
                 ->arrayNode('options')
                     ->useAttributeAsKey('key')
-                    ->prototype('scalar')->end()
+                    ->prototype('variable')->end()
                 ->end()
                 ->arrayNode('mapping_types')
                     ->useAttributeAsKey('name')

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -94,11 +94,11 @@
     </xsd:complexType>
 
     <xsd:complexType name="option">
-        <xsd:simpleContent>
-            <xsd:extension base="xsd:string">
+        <xsd:complexContent>
+            <xsd:extension base="xsd:anyType">
                 <xsd:attribute name="key" type="xsd:string" use="required" />
             </xsd:extension>
-        </xsd:simpleContent>
+        </xsd:complexContent>
     </xsd:complexType>
 
     <xsd:complexType name="connection">

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -45,6 +45,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('sqlite_s3cr3t', $config['password']);
         $this->assertSame('/tmp/db.sqlite', $config['path']);
         $this->assertTrue($config['memory']);
+        $this->assertArrayHasKey('userDefinedFunctions', $config['driverOptions']);
 
         // doctrine.dbal.oci8_connection
         $config = $container->getDefinition('doctrine.dbal.oci_connection')->getArgument(0);

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -45,7 +45,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('sqlite_s3cr3t', $config['password']);
         $this->assertSame('/tmp/db.sqlite', $config['path']);
         $this->assertTrue($config['memory']);
-        $this->assertArrayHasKey('userDefinedFunctions', $config['driverOptions']);
+        $this->assertSame(['asin' => ['callback' => 'asin', 'numArgs' => 1]], $config['driverOptions']['userDefinedFunctions']);
+        $this->assertSame('foo', $config['driverOptions']['arbitraryValue']);
 
         // doctrine.dbal.oci8_connection
         $config = $container->getDefinition('doctrine.dbal.oci_connection')->getArgument(0);

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -21,7 +21,9 @@
                 user="sqlite_user"
                 password="sqlite_s3cr3t"
                 path="/tmp/db.sqlite"
-                memory="true" />
+                memory="true">
+                <option key="userDefinedFunctions" />
+            </connection>
             <connection
                 name="oci"
                 driver="oci8"

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -22,7 +22,13 @@
                 password="sqlite_s3cr3t"
                 path="/tmp/db.sqlite"
                 memory="true">
-                <option key="userDefinedFunctions" />
+                <option key="userDefinedFunctions">
+                    <asin>
+                        <callback>asin</callback>
+                        <numArgs>1</numArgs>
+                    </asin>
+                </option>
+                <option key="arbitraryValue">foo</option>
             </connection>
             <connection
                 name="oci"

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -14,6 +14,8 @@ doctrine:
                 password: sqlite_s3cr3t
                 path: /tmp/db.sqlite
                 memory: true
+                options:
+                    userDefinedFunctions: []
             oci:
                 driver: oci8
                 dbname: oracle_db

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -15,7 +15,11 @@ doctrine:
                 path: /tmp/db.sqlite
                 memory: true
                 options:
-                    userDefinedFunctions: []
+                    userDefinedFunctions:
+                        asin:
+                            callback: 'asin'
+                            numArgs: 1
+                    arbitraryValue: foo
             oci:
                 driver: oci8
                 dbname: oracle_db


### PR DESCRIPTION
DBAL actually accepts mixed[], not string[] as we force. This causes problems with some options, such as `userDefinedFunctions`.

Fixes #365