### PR TITLE
Activate selective stale probot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,8 @@
+onlyLabels: ['Status: Waiting feedback']
+daysUntilStale: 14
+daysUntilClose: 7
+staleLabel: 'Stale'
+markComment: >
+  This issue is still waiting on feedback. Please provide the information requested above to allow us to continue working on this ticket.
+
+  This issue will be closed after 7 days. You can still provide us with the necessary information to continue working on this issue, and we will reopen the ticket for you. Thanks!


### PR DESCRIPTION
I'm strongly opposed to adding bot which automatically closes issues without human involvement, but here it's configured to require certain label first, so it's involvement will be here only in cases we manually mark as such.

Idea here is to post warning in issues labelled as "Status: Waiting feedback"
if there is no activity after 14 days and after no further activity within 7 days happen, closes it.