### PR TITLE
Fix doctrine deprecations

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -2,11 +2,11 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\EntityGenerator;
+use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -2,11 +2,11 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
+use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Command/Proxy/DelegateCommand.php
+++ b/Command/Proxy/DelegateCommand.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
-use Doctrine\ORM\Version;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,14 +27,6 @@ abstract class DelegateCommand extends Command
     protected function getMinimalVersion()
     {
         return '2.3.0-DEV';
-    }
-
-    /**
-     * @return bool
-     */
-    private function isVersionCompatible()
-    {
-        return version_compare(Version::VERSION, $this->getMinimalVersion()) >= 0;
     }
 
     /**

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\DataCollector;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Cache\Logging\CacheLoggerChain;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
@@ -10,6 +9,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Tools\SchemaValidator;
+use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector as BaseCollector;
 use Symfony\Component\HttpFoundation\Request;

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -7,8 +7,8 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositor
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
 use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\CacheProviderLoader;
 use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\SymfonyBridgeAdapter;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
-use Doctrine\ORM\Version;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 use LogicException;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
@@ -93,8 +93,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $loader->load('dbal.xml');
 
         if (method_exists(Alias::class, 'setDeprecated')) {
-            $container->getAlias('Symfony\Bridge\Doctrine\RegistryInterface')->setDeprecated(true, 'The "%alias_id%" service alias is deprecated, use `Doctrine\Common\Persistence\ManagerRegistry` instead.');
-            $container->getAlias('Doctrine\Bundle\DoctrineBundle\Registry')->setDeprecated(true, 'The "%alias_id%" service alias is deprecated, use `Doctrine\Common\Persistence\ManagerRegistry` instead.');
+            $container->getAlias('Symfony\Bridge\Doctrine\RegistryInterface')->setDeprecated(true, 'The "%alias_id%" service alias is deprecated, use `Doctrine\Persistence\ManagerRegistry` instead.');
+            $container->getAlias('Doctrine\Bundle\DoctrineBundle\Registry')->setDeprecated(true, 'The "%alias_id%" service alias is deprecated, use `Doctrine\Persistence\ManagerRegistry` instead.');
+            $container->getAlias('Doctrine\Common\Persistence\ManagerRegistry')->setDeprecated(true, 'The "%alias_id%" service alias is deprecated, use `Doctrine\Persistence\ManagerRegistry` instead.');
         }
 
         if (empty($config['default_connection'])) {
@@ -346,7 +347,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function ormLoad(array $config, ContainerBuilder $container)
     {
-        if (! class_exists(Version::class)) {
+        if (! class_exists(UnitOfWork::class)) {
             throw new LogicException('To configure the ORM layer, you must first install the doctrine/orm package.');
         }
 

--- a/Mapping/DisconnectedMetadataFactory.php
+++ b/Mapping/DisconnectedMetadataFactory.php
@@ -2,10 +2,10 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
+use Doctrine\Persistence\ManagerRegistry;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -3,10 +3,10 @@
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\RepositoryFactory;
+use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use RuntimeException;

--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
 
 /**

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -64,6 +64,7 @@
             <argument>%doctrine.default_connection%</argument>
             <argument>%doctrine.default_entity_manager%</argument>
         </service>
+        <service id="Doctrine\Persistence\ManagerRegistry" alias="doctrine" public="false" />
         <service id="Doctrine\Common\Persistence\ManagerRegistry" alias="doctrine" public="false" />
         <service id="Symfony\Bridge\Doctrine\RegistryInterface" alias="doctrine" public="false" />
         <service id="Doctrine\Bundle\DoctrineBundle\Registry" alias="doctrine" public="false" />

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -94,7 +94,7 @@ class CreateDatabaseDoctrineTest extends TestCase
     private function getMockContainer($connectionName, $params = null)
     {
         // Mock the container and everything you'll need here
-        $mockDoctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
+        $mockDoctrine = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')
             ->getMock();
 
         $mockDoctrine->expects($this->any())

--- a/Tests/Command/DropDatabaseDoctrineTest.php
+++ b/Tests/Command/DropDatabaseDoctrineTest.php
@@ -83,7 +83,7 @@ class DropDatabaseDoctrineTest extends TestCase
     private function getMockContainer($connectionName, $params = null)
     {
         // Mock the container and everything you'll need here
-        $mockDoctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
+        $mockDoctrine = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')
             ->getMock();
 
         $mockDoctrine->expects($this->any())

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -10,22 +10,10 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Version;
 use Exception;
 
 class ConnectionFactoryTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (class_exists(Version::class)) {
-            return;
-        }
-
-        $this->markTestSkipped('Doctrine ORM is not available.');
-    }
-
     /**
      * @expectedException \Doctrine\DBAL\DBALException
      */

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -4,15 +4,14 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventManager;
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\DBAL\Configuration as DBALConfiguration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Version;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Bridge\Doctrine\Logger\DbalLogger;
@@ -24,17 +23,11 @@ use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 
 class ContainerTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (class_exists(Version::class)) {
-            return;
-        }
-
-        $this->markTestSkipped('Doctrine ORM is not available.');
-    }
-
+    /**
+     * https://github.com/doctrine/orm/pull/7953 needed, otherwise ORM classes we define services for trigger deprecations
+     *
+     * @group legacy
+     */
     public function testContainer()
     {
         $container = $this->createXmlBundleTestContainer();

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -107,7 +107,7 @@ class DoctrineDataCollectorTest extends TestCase
      */
     private function createCollector(array $managers)
     {
-        $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
         $registry
             ->expects($this->any())
             ->method('getConnectionNames')

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoRepository.php
@@ -3,7 +3,7 @@
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomServiceRepoEntity;
 
 class TestCustomServiceRepoRepository extends ServiceEntityRepository

--- a/Tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/Tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -6,21 +6,9 @@ use Doctrine\Bundle\DoctrineBundle\Mapping\ClassMetadataCollection;
 use Doctrine\Bundle\DoctrineBundle\Mapping\DisconnectedMetadataFactory;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCase;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\ORM\Version;
 
 class DisconnectedMetadataFactoryTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (class_exists(Version::class)) {
-            return;
-        }
-
-        $this->markTestSkipped('Doctrine ORM is not available.');
-    }
-
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Can't find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest
@@ -30,7 +18,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
         $class      = new ClassMetadataInfo(self::class);
         $collection = new ClassMetadataCollection([$class]);
 
-        $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
         $factory  = new DisconnectedMetadataFactory($registry);
 
         $factory->findNamespaceAndPathForMetadata($collection);
@@ -41,7 +29,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
         $class      = new ClassMetadataInfo('\Vendor\Package\Class');
         $collection = new ClassMetadataCollection([$class]);
 
-        $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
         $factory  = new DisconnectedMetadataFactory($registry);
 
         $factory->findNamespaceAndPathForMetadata($collection, '/path/to/code');

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -4,8 +4,8 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Bridge\Twig\Extension\CodeExtension;
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -4,11 +4,11 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ContainerRepositoryFactory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use stdClass;
@@ -18,7 +18,7 @@ class ContainerRepositoryFactoryTest extends TestCase
     public function testGetRepositoryReturnsService()
     {
         $em        = $this->createEntityManager(['Foo\CoolEntity' => 'my_repo']);
-        $repo      = new StubRepository($em, new ClassMetadata(''));
+        $repo      = new StubRepository();
         $container = $this->createContainer(['my_repo' => $repo]);
 
         $factory = new ContainerRepositoryFactory($container);
@@ -153,10 +153,48 @@ class ContainerRepositoryFactoryTest extends TestCase
     }
 }
 
-class StubRepository extends EntityRepository
+/**
+ * Repository implementing non-deprecated interface, as current interface implemented in ORM\EntityRepository
+ * uses deprecated one and Composer autoload triggers deprecations that can't be silenced by @group legacy
+ */
+class NonDeprecatedRepository implements ObjectRepository
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function find($id)
+    {
+        return null;
+    }
+
+    public function findAll() : array
+    {
+        return [];
+    }
+
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null) : array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findOneBy(array $criteria)
+    {
+        return null;
+    }
+
+    public function getClassName() : string
+    {
+        return '';
+    }
+}
+
+class StubRepository extends NonDeprecatedRepository
 {
 }
 
-class StubServiceRepository extends EntityRepository implements ServiceEntityRepositoryInterface
+class StubServiceRepository extends NonDeprecatedRepository implements ServiceEntityRepositoryInterface
 {
 }

--- a/Tests/Repository/ServiceEntityRepositoryTest.php
+++ b/Tests/Repository/ServiceEntityRepositoryTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 
 class ServiceEntityRepositoryTest extends TestCase

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -5,10 +5,8 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\Version;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomClassRepoEntity;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomServiceRepoEntity;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestDefaultRepoEntity;
@@ -22,22 +20,13 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class ServiceRepositoryTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (class_exists(Version::class)) {
-            return;
-        }
-
-        $this->markTestSkipped('Doctrine ORM is not available.');
-    }
-
+    /**
+     * https://github.com/doctrine/orm/pull/7953 needed, otherwise ORM classes we define services for trigger deprecations
+     *
+     * @group legacy
+     */
     public function testRepositoryServiceWiring()
     {
-        // needed for older versions of Doctrine
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
-
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.name' => 'app',
             'kernel.debug' => false,

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -5,7 +5,6 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\ORM\Version;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -16,15 +15,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class TestCase extends BaseTestCase
 {
-    protected function setUp()
-    {
-        if (class_exists(Version::class)) {
-            return;
-        }
-
-        $this->markTestSkipped('Doctrine is not available.');
-    }
-
     public function createXmlBundleTestContainer()
     {
         $container = new ContainerBuilder(new ParameterBag([

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php": "^7.1",
         "doctrine/dbal": "^2.5.12",
         "doctrine/doctrine-cache-bundle": "~1.2",
+        "doctrine/persistence": "^1.3.3",
         "jdorn/sql-formatter": "^1.2.16",
         "symfony/cache": "^3.4.30|^4.3.3",
         "symfony/config": "^3.4.30|^4.3.3",


### PR DESCRIPTION
Rel: https://github.com/doctrine/orm/pull/7953, https://github.com/doctrine/persistence/pull/71

This will make our build after upmerging it clean.

Other than new Persistance deprecations, I have also fixed some extra ones I noticed, such as deprecated `Version` class (we always require ORM in require-dev, so in test cases I just removed its usage, otherwise I used UnitOfWork - EntityManagerInterface triggers deprecation)