### PR TITLE
Fix resetting of managers on kernel reset

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -168,7 +168,7 @@ class Registry extends ManagerRegistry implements RegistryInterface, ResetInterf
 
     public function reset() : void
     {
-        foreach ($this->getManagerNames() as $managerName) {
+        foreach ($this->getManagerNames() as $managerName => $serviceId) {
             $this->resetManager($managerName);
         }
     }

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -122,4 +122,30 @@ class RegistryTest extends TestCase
 
         $registry->resetManager('default');
     }
+
+    public function testReset()
+    {
+        $conn      = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $em        = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+
+        $container->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('doctrine.orm.default_entity_manager'))
+            ->will($this->returnValue($em));
+
+        $registry  = new Registry(
+            $container,
+            [
+                'default' => $conn,
+            ],
+            [
+                'default' => 'doctrine.orm.default_entity_manager',
+            ],
+            'default',
+            'default'
+        );
+
+        $registry->reset();
+    }
 }


### PR DESCRIPTION
Not sure about this change but `bin/console debug:container --parameter doctrine.entity_managers`

does return in my case:

```php
    'default' => 'doctrine.orm.default_entity_manager',
```

and if the value instead of key is used it will end up in a 

> Doctrine ORM Manager named "doctrine.orm.default_entity_manager'" does not exist.

Exception