### PR TITLE
Fix error when resetting manager registry

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -168,7 +168,7 @@ class Registry extends ManagerRegistry implements RegistryInterface, ResetInterf
 
     public function reset() : void
     {
-        foreach ($this->getManagerNames() as $managerName) {
+        foreach (array_keys($this->getManagerNames()) as $managerName) {
             $this->resetManager($managerName);
         }
     }

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -122,4 +122,20 @@ class RegistryTest extends TestCase
 
         $registry->resetManager('default');
     }
+
+    /**
+     * @group legacy
+     */
+    public function testReset()
+    {
+        $em        = new stdClass();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $container->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('doctrine.orm.default_entity_manager'))
+            ->will($this->returnValue($em));
+
+        $registry = new Registry($container, [], ['default' => 'doctrine.orm.default_entity_manager'], 'default', 'default');
+        $registry->reset();
+    }
 }


### PR DESCRIPTION
This fixes errors of the sort "InvalidArgumentException: Doctrine ORM Manager named "doctrine.orm.default_entity_manager" does not exist."