### PR TITLE
Fix desynchronized entity managers after kernel reset

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Container\ContainerInterface;
@@ -182,7 +183,9 @@ class Registry extends ManagerRegistry implements RegistryInterface, ResetInterf
 
         $manager = $this->container->get($serviceId);
 
-        if (! $manager instanceof LazyLoadingInterface) {
+        assert($manager instanceof EntityManagerInterface);
+
+        if (! $manager instanceof LazyLoadingInterface || $manager->isOpen()) {
             $manager->clear();
 
             return;

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
@@ -2,8 +2,13 @@
 
 namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 
 class TestCustomClassRepoRepository extends EntityRepository
 {
+    public function getEntityManager() : EntityManager
+    {
+        return parent::getEntityManager();
+    }
 }

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class TestKernel extends Kernel
+{
+    /** @var string|null */
+    private $projectDir;
+
+    public function __construct()
+    {
+        parent::__construct('test', true);
+    }
+
+    public function registerBundles() : iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(static function (ContainerBuilder $container) {
+            // @todo Setting the kernel.name parameter can be removed once the dependency on DoctrineCacheBundle has been dropped
+            $container->setParameter('kernel.name', 'foo');
+            $container->loadFromExtension('framework', ['secret' => 'F00']);
+
+            $container->loadFromExtension('doctrine', [
+                'dbal' => ['driver' => 'pdo_sqlite'],
+                'orm' => [
+                    'mappings' => [
+                        'RepositoryServiceBundle' => [
+                            'type' => 'annotation',
+                            'dir' => __DIR__ . '/Bundles/RepositoryServiceBundle/Entity',
+                            'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Entity',
+                        ],
+                    ],
+                ],
+            ]);
+
+            // Register a NullLogger to avoid getting the stderr default logger of FrameworkBundle
+            $container->register('logger', NullLogger::class);
+        });
+    }
+
+    public function getProjectDir() : string
+    {
+        if ($this->projectDir === null) {
+            $this->projectDir = sys_get_temp_dir() . '/sf_kernel_' . md5(mt_rand());
+        }
+
+        return $this->projectDir;
+    }
+
+    public function getRootDir() : string
+    {
+        return $this->getProjectDir();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "phpunit/phpunit": "^7.5",
         "symfony/phpunit-bridge": "^4.2",
         "symfony/property-info": "^3.4.30|^4.3.3",
+        "symfony/proxy-manager-bridge": "^3.4|^4|^5",
         "symfony/twig-bridge": "^3.4|^4.1",
         "symfony/validator": "^3.4.30|^4.3.3",
         "symfony/web-profiler-bundle": "^3.4.30|^4.3.3",


### PR DESCRIPTION
Fixes #1114

We can't reset because of this https://github.com/symfony/symfony/issues/35216 + performance issues, so let's just do clear() so it works for long running processes (same thing php-pm does for years).