### PR TITLE
Add void return type declaration to tests

### DIFF
--- a/Tests/BundleTest.php
+++ b/Tests/BundleTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class BundleTest extends TestCase
 {
-    public function testBuildCompilerPasses()
+    public function testBuildCompilerPasses() : void
     {
         $container = new ContainerBuilder();
         $bundle    = new DoctrineBundle();

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -10,14 +10,14 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class CreateDatabaseDoctrineTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown() : void
     {
         @unlink(sys_get_temp_dir() . '/test');
         @unlink(sys_get_temp_dir() . '/shard_1');
         @unlink(sys_get_temp_dir() . '/shard_2');
     }
 
-    public function testExecute()
+    public function testExecute() : void
     {
         $connectionName = 'default';
         $dbName         = 'test';
@@ -41,7 +41,7 @@ class CreateDatabaseDoctrineTest extends TestCase
         $this->assertContains('Created database ' . sys_get_temp_dir() . '/' . $dbName . ' for connection named ' . $connectionName, $commandTester->getDisplay());
     }
 
-    public function testExecuteWithShardOption()
+    public function testExecuteWithShardOption() : void
     {
         $connectionName = 'default';
         $params         = [

--- a/Tests/Command/DropDatabaseDoctrineTest.php
+++ b/Tests/Command/DropDatabaseDoctrineTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class DropDatabaseDoctrineTest extends TestCase
 {
-    public function testExecute()
+    public function testExecute() : void
     {
         $connectionName = 'default';
         $dbName         = 'test';
@@ -42,7 +42,7 @@ class DropDatabaseDoctrineTest extends TestCase
         );
     }
 
-    public function testExecuteWithoutOptionForceWillFailWithAttentionMessage()
+    public function testExecuteWithoutOptionForceWillFailWithAttentionMessage() : void
     {
         $connectionName = 'default';
         $dbName         = 'test';

--- a/Tests/Command/ImportMappingDoctrineCommandTest.php
+++ b/Tests/Command/ImportMappingDoctrineCommandTest.php
@@ -25,7 +25,7 @@ class ImportMappingDoctrineCommandTest extends TestCase
     /** @var CommandTester|null */
     private $commandTester;
 
-    protected function setup()
+    protected function setup() : void
     {
         $this->kernel = new ImportMappingTestingKernel();
         $this->kernel->boot();
@@ -40,7 +40,7 @@ class ImportMappingDoctrineCommandTest extends TestCase
         $this->commandTester = new CommandTester($command);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         $fs = new Filesystem();
         if ($this->kernel !== null) {
@@ -52,7 +52,7 @@ class ImportMappingDoctrineCommandTest extends TestCase
         $this->commandTester = null;
     }
 
-    public function testExecuteXmlWithBundle()
+    public function testExecuteXmlWithBundle() : void
     {
         $this->commandTester->execute(['name' => 'ImportMappingTestFooBundle']);
 
@@ -61,7 +61,7 @@ class ImportMappingDoctrineCommandTest extends TestCase
         $this->assertContains('"Doctrine\Bundle\DoctrineBundle\Tests\Command\Entity\Product"', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
     }
 
-    public function testExecuteAnnotationsWithBundle()
+    public function testExecuteAnnotationsWithBundle() : void
     {
         $this->commandTester->execute([
             'name' => 'ImportMappingTestFooBundle',
@@ -77,12 +77,12 @@ class ImportMappingDoctrineCommandTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /The --path option is required/
      */
-    public function testExecuteThrowsExceptionWithNamespaceAndNoPath()
+    public function testExecuteThrowsExceptionWithNamespaceAndNoPath() : void
     {
         $this->commandTester->execute(['name' => 'Some\Namespace']);
     }
 
-    public function testExecuteXmlWithNamespace()
+    public function testExecuteXmlWithNamespace() : void
     {
         $this->commandTester->execute([
             'name' => 'Some\Namespace\Entity',
@@ -94,7 +94,7 @@ class ImportMappingDoctrineCommandTest extends TestCase
         $this->assertContains('"Some\Namespace\Entity\Product"', file_get_contents($expectedMetadataPath), 'Metadata contains correct namespace');
     }
 
-    public function testExecuteAnnotationsWithNamespace()
+    public function testExecuteAnnotationsWithNamespace() : void
     {
         $this->commandTester->execute([
             'name' => 'Some\Namespace\Entity',
@@ -127,9 +127,9 @@ class ImportMappingTestingKernel extends Kernel
         ];
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader) : void
     {
-        $loader->load(function (ContainerBuilder $container) {
+        $loader->load(function (ContainerBuilder $container) : void {
             $container->loadFromExtension('framework', ['secret' => 'F00']);
 
             $container->loadFromExtension('doctrine', [

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -15,7 +15,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @expectedException \Doctrine\DBAL\DBALException
      */
-    public function testContainer()
+    public function testContainer() : void
     {
         $typesConfig  = [];
         $factory      = new ConnectionFactory($typesConfig);
@@ -38,7 +38,7 @@ class ConnectionFactoryTest extends TestCase
         }
     }
 
-    public function testDefaultCharset()
+    public function testDefaultCharset() : void
     {
         $factory = new ConnectionFactory([]);
         $params  = [
@@ -54,7 +54,7 @@ class ConnectionFactoryTest extends TestCase
         $this->assertSame(1 + $creationCount, FakeConnection::$creationCount);
     }
 
-    public function testDefaultCharsetMySql()
+    public function testDefaultCharsetMySql() : void
     {
         $factory = new ConnectionFactory([]);
         $params  = ['driver' => 'pdo_mysql'];
@@ -106,12 +106,12 @@ class FakeDriver implements Driver
      * @param string|null $password
      * @param mixed[]     $driverOptions
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = []) : void
     {
         throw new Exception('not implemented');
     }
 
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn) : void
     {
         throw new Exception('not implemented');
     }

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -26,7 +26,7 @@ class ContainerTest extends TestCase
      *
      * @group legacy
      */
-    public function testContainer()
+    public function testContainer() : void
     {
         $container = $this->createXmlBundleTestContainer();
 

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -14,7 +14,7 @@ class DoctrineDataCollectorTest extends TestCase
     const FIRST_ENTITY  = 'TestBundle\Test\Entity\Test1';
     const SECOND_ENTITY = 'TestBundle\Test\Entity\Test2';
 
-    public function testCollectEntities()
+    public function testCollectEntities() : void
     {
         $manager   = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
         $config    = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
@@ -49,7 +49,7 @@ class DoctrineDataCollectorTest extends TestCase
         $this->assertCount(2, $entities['default']);
     }
 
-    public function testGetGroupedQueries()
+    public function testGetGroupedQueries() : void
     {
         $logger            = $this->getMockBuilder('Doctrine\DBAL\Logging\DebugStack')->getMock();
         $logger->queries   = [];

--- a/Tests/Dbal/RegexSchemaAssetFilterTest.php
+++ b/Tests/Dbal/RegexSchemaAssetFilterTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class RegexSchemaAssetFilterTest extends TestCase
 {
-    public function testShouldIncludeAsset()
+    public function testShouldIncludeAsset() : void
     {
         $filter = new RegexSchemaAssetFilter('~^(?!t_)~');
 

--- a/Tests/Dbal/SchemaAssetsFilterManagerTest.php
+++ b/Tests/Dbal/SchemaAssetsFilterManagerTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class SchemaAssetsFilterManagerTest extends TestCase
 {
-    public function testInvoke()
+    public function testInvoke() : void
     {
         $filterA = new RegexSchemaAssetFilter('~^(?!t_)~');
         $filterB = new RegexSchemaAssetFilter('~^(?!s_)~');

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -25,7 +25,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 {
     abstract protected function loadFromFile(ContainerBuilder $container, $file);
 
-    public function testDbalLoadFromXmlMultipleConnections()
+    public function testDbalLoadFromXmlMultipleConnections() : void
     {
         $container = $this->loadContainer('dbal_service_multiple_connections');
 
@@ -94,7 +94,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('utf8', $config['charset']);
     }
 
-    public function testDbalLoadFromXmlSingleConnections()
+    public function testDbalLoadFromXmlSingleConnections() : void
     {
         $container = $this->loadContainer('dbal_service_single_connection');
 
@@ -108,7 +108,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('5.6.20', $config['serverVersion']);
     }
 
-    public function testDbalLoadSingleMasterSlaveConnection()
+    public function testDbalLoadSingleMasterSlaveConnection() : void
     {
         $container = $this->loadContainer('dbal_service_single_master_slave_connection');
 
@@ -142,7 +142,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals(['engine' => 'InnoDB'], $param['defaultTableOptions']);
     }
 
-    public function testDbalLoadPoolShardingConnection()
+    public function testDbalLoadPoolShardingConnection() : void
     {
         $container = $this->loadContainer('dbal_service_pool_sharding_connection');
 
@@ -177,7 +177,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals(['engine' => 'InnoDB'], $param['defaultTableOptions']);
     }
 
-    public function testDbalLoadSavepointsForNestedTransactions()
+    public function testDbalLoadSavepointsForNestedTransactions() : void
     {
         $container = $this->loadContainer('dbal_savepoints');
 
@@ -193,7 +193,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertCount(0, $calls);
     }
 
-    public function testLoadSimpleSingleConnection()
+    public function testLoadSimpleSingleConnection() : void
     {
         $container = $this->loadContainer('orm_service_simple_single_entity_manager');
 
@@ -228,7 +228,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     /**
      * The PDO driver doesn't require a database name to be to set when connecting to a database server
      */
-    public function testLoadSimpleSingleConnectionWithoutDbName()
+    public function testLoadSimpleSingleConnectionWithoutDbName() : void
     {
         $container = $this->loadContainer('orm_service_simple_single_entity_manager_without_dbname');
 
@@ -263,7 +263,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testLoadSingleConnection()
+    public function testLoadSingleConnection() : void
     {
         $container = $this->loadContainer('orm_service_single_entity_manager');
 
@@ -299,7 +299,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($configDef, 'setDefaultRepositoryClassName', ['Acme\Doctrine\Repository']);
     }
 
-    public function testLoadMultipleConnections()
+    public function testLoadMultipleConnections() : void
     {
         $container = $this->loadContainer('orm_service_multiple_entity_managers');
 
@@ -359,7 +359,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('cache.doctrine.orm.em1.result', (string) $arguments[0]);
     }
 
-    public function testLoadLogging()
+    public function testLoadLogging() : void
     {
         $container = $this->loadContainer('dbal_logging');
 
@@ -379,7 +379,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', [new Reference('doctrine.dbal.logger.chain.both')]);
     }
 
-    public function testEntityManagerMetadataCacheDriverConfiguration()
+    public function testEntityManagerMetadataCacheDriverConfiguration() : void
     {
         $container = $this->loadContainer('orm_service_multiple_entity_managers');
 
@@ -390,7 +390,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionClass($definition, DoctrineProvider::class);
     }
 
-    public function testDependencyInjectionImportsOverrideDefaults()
+    public function testDependencyInjectionImportsOverrideDefaults() : void
     {
         $container = $this->loadContainer('orm_imports');
 
@@ -401,7 +401,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setAutoGenerateProxyClasses', ['%doctrine.orm.auto_generate_proxy_classes%']);
     }
 
-    public function testSingleEntityManagerMultipleMappingBundleDefinitions()
+    public function testSingleEntityManagerMultipleMappingBundleDefinitions() : void
     {
         $container = $this->loadContainer('orm_single_em_bundle_mappings', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
@@ -439,7 +439,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testMultipleEntityManagersMappingBundleDefinitions()
+    public function testMultipleEntityManagersMappingBundleDefinitions() : void
     {
         $container = $this->loadContainer('orm_multiple_em_bundle_mappings', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
@@ -481,7 +481,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testSingleEntityManagerDefaultTableOptions()
+    public function testSingleEntityManagerDefaultTableOptions() : void
     {
         $container = $this->loadContainer('orm_single_em_default_table_options', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
@@ -500,7 +500,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('InnoDB', $defaults['engine']);
     }
 
-    public function testSetTypes()
+    public function testSetTypes() : void
     {
         $container = $this->loadContainer('dbal_types');
 
@@ -511,7 +511,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('%doctrine.dbal.connection_factory.types%', $container->getDefinition('doctrine.dbal.connection_factory')->getArgument(0));
     }
 
-    public function testSetCustomFunctions()
+    public function testSetCustomFunctions() : void
     {
         $container = $this->loadContainer('orm_functions');
 
@@ -521,7 +521,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomDatetimeFunction', ['test_datetime', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestDatetimeFunction']);
     }
 
-    public function testSetNamingStrategy()
+    public function testSetNamingStrategy() : void
     {
         $container = $this->loadContainer('orm_namingstrategy');
 
@@ -532,7 +532,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($def2, 'setNamingStrategy', [0 => new Reference('doctrine.orm.naming_strategy.underscore')]);
     }
 
-    public function testSetQuoteStrategy()
+    public function testSetQuoteStrategy() : void
     {
         $container = $this->loadContainer('orm_quotestrategy');
 
@@ -543,7 +543,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($def2, 'setQuoteStrategy', [0 => new Reference('doctrine.orm.quote_strategy.ansi')]);
     }
 
-    public function testSecondLevelCache()
+    public function testSecondLevelCache() : void
     {
         $container = $this->loadContainer('orm_second_level_cache');
 
@@ -601,7 +601,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('doctrine.orm.default_second_level_cache.region_cache_driver', $slcFactoryArgs[1]);
     }
 
-    public function testSingleEMSetCustomFunctions()
+    public function testSingleEMSetCustomFunctions() : void
     {
         $container = $this->loadContainer('orm_single_em_dql_functions');
 
@@ -609,7 +609,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomStringFunction', ['test_string', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction']);
     }
 
-    public function testAddCustomHydrationMode()
+    public function testAddCustomHydrationMode() : void
     {
         $container = $this->loadContainer('orm_hydration_mode');
 
@@ -617,7 +617,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomHydrationMode', ['test_hydrator', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator']);
     }
 
-    public function testAddFilter()
+    public function testAddFilter() : void
     {
         $container = $this->loadContainer('orm_filters');
 
@@ -637,7 +637,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertCount(2, $entityManager->getFilters()->getEnabledFilters());
     }
 
-    public function testResolveTargetEntity()
+    public function testResolveTargetEntity() : void
     {
         $container = $this->loadContainer('orm_resolve_target_entity');
 
@@ -647,7 +647,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals(['doctrine.event_subscriber' => [[]]], $definition->getTags());
     }
 
-    public function testAttachEntityListeners()
+    public function testAttachEntityListeners() : void
     {
         $container = $this->loadContainer('orm_attach_entity_listener');
 
@@ -718,7 +718,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testDbalAutoCommit()
+    public function testDbalAutoCommit() : void
     {
         $container = $this->loadContainer('dbal_auto_commit');
 
@@ -726,7 +726,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'setAutoCommit', [false]);
     }
 
-    public function testDbalOracleConnectstring()
+    public function testDbalOracleConnectstring() : void
     {
         $container = $this->loadContainer('dbal_oracle_connectstring');
 
@@ -734,7 +734,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('scott@sales-server:1521/sales.us.example.com', $config['connectstring']);
     }
 
-    public function testDbalOracleInstancename()
+    public function testDbalOracleInstancename() : void
     {
         $container = $this->loadContainer('dbal_oracle_instancename');
 
@@ -742,7 +742,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('mySuperInstance', $config['instancename']);
     }
 
-    public function testDbalSchemaFilterNewConfig()
+    public function testDbalSchemaFilterNewConfig() : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -796,7 +796,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     /**
      * @dataProvider dataWellKnownSchemaFilterServices
      */
-    public function testWellKnownSchemaFilterDefaultTables(string $fileName, string $tableName)
+    public function testWellKnownSchemaFilterDefaultTables(string $fileName, string $tableName) : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -834,7 +834,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     /**
      * @dataProvider dataWellKnownSchemaOverriddenTablesFilterServices
      */
-    public function testWellKnownSchemaFilterOverriddenTables(string $fileName, string $tableName)
+    public function testWellKnownSchemaFilterOverriddenTables(string $fileName, string $tableName) : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -851,7 +851,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertFalse($filter($tableName));
     }
 
-    public function testEntityListenerResolver()
+    public function testEntityListenerResolver() : void
     {
         $container = $this->loadContainer('orm_entity_listener_resolver', ['YamlBundle'], new EntityListenerPass());
 
@@ -868,7 +868,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($listener, 'register', [new Reference('entity_listener2')]);
     }
 
-    public function testAttachEntityListenerTag()
+    public function testAttachEntityListenerTag() : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -900,7 +900,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($attachListener, 'addEntityListener', ['My/Entity2', 'EntityListener2', 'preFlush', 'preFlushHandler']);
     }
 
-    public function testAttachEntityListenersTwoConnections()
+    public function testAttachEntityListenersTwoConnections() : void
     {
         $container = $this->getContainer(['YamlBundle']);
         $loader    = new DoctrineExtension();
@@ -920,7 +920,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($foobarEventManager, 'addEventListener', [['loadClassMetadata'], new Reference('doctrine.orm.em2_listeners.attach_entity_listeners')]);
     }
 
-    public function testAttachLazyEntityListener()
+    public function testAttachLazyEntityListener() : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -947,7 +947,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($resolver2, 'registerService', ['EntityListener2', 'entity_listener2']);
     }
 
-    public function testAttachLazyEntityListenerForCustomResolver()
+    public function testAttachLazyEntityListenerForCustomResolver() : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -969,7 +969,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage EntityListenerServiceResolver
      */
-    public function testLazyEntityListenerResolverWithoutCorrectInterface()
+    public function testLazyEntityListenerResolverWithoutCorrectInterface() : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -981,7 +981,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->compileContainer($container);
     }
 
-    public function testPrivateLazyEntityListener()
+    public function testPrivateLazyEntityListener() : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -999,7 +999,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /The service ".*" must not be abstract as this entity listener is lazy-loaded/
      */
-    public function testAbstractLazyEntityListener()
+    public function testAbstractLazyEntityListener() : void
     {
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
@@ -1011,7 +1011,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->compileContainer($container);
     }
 
-    public function testRepositoryFactory()
+    public function testRepositoryFactory() : void
     {
         $container = $this->loadContainer('orm_repository_factory');
 
@@ -1068,17 +1068,17 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      *
      * @param string $expectedClass
      */
-    private function assertDICDefinitionClass(Definition $definition, $expectedClass)
+    private function assertDICDefinitionClass(Definition $definition, $expectedClass) : void
     {
         $this->assertEquals($expectedClass, $definition->getClass(), 'Expected Class of the DIC Container Service Definition is wrong.');
     }
 
-    private function assertDICConstructorArguments(Definition $definition, $args)
+    private function assertDICConstructorArguments(Definition $definition, $args) : void
     {
         $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '" . $definition->getClass() . "' don't match.");
     }
 
-    private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null)
+    private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null) : void
     {
         $calls = $definition->getMethodCalls();
         if (! isset($calls[$pos][0])) {
@@ -1102,7 +1102,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * @param string $methodName
      * @param array  $params
      */
-    private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null)
+    private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null) : void
     {
         $calls  = $definition->getMethodCalls();
         $called = false;
@@ -1127,7 +1127,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->fail("Method '" . $methodName . "' is expected to be called once, definition does not contain a call though.");
     }
 
-    private function assertDICDefinitionMethodCallCount(Definition $definition, $methodName, array $params = [], $nbCalls = 1)
+    private function assertDICDefinitionMethodCallCount(Definition $definition, $methodName, array $params = [], $nbCalls = 1) : void
     {
         $calls  = $definition->getMethodCalls();
         $called = 0;
@@ -1155,7 +1155,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * @param string $methodName
      * @param array  $params
      */
-    private function assertDICDefinitionNoMethodCall(Definition $definition, $methodName, array $params = null)
+    private function assertDICDefinitionNoMethodCall(Definition $definition, $methodName, array $params = null) : void
     {
         $calls = $definition->getMethodCalls();
         foreach ($calls as $call) {
@@ -1171,7 +1171,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         }
     }
 
-    private function compileContainer(ContainerBuilder $container)
+    private function compileContainer(ContainerBuilder $container) : void
     {
         $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveChildDefinitionsPass()]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -21,7 +21,7 @@ class ConfigurationTest extends TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testGetConfigTreeBuilderDoNotUseDoctrineCommon()
+    public function testGetConfigTreeBuilderDoNotUseDoctrineCommon() : void
     {
         $configuration = new Configuration(true);
         $configuration->getConfigTreeBuilder();

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -26,7 +26,7 @@ class DoctrineExtensionTest extends TestCase
      *
      * @group legacy
      */
-    public function testAutowiringAlias()
+    public function testAutowiringAlias() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -49,7 +49,7 @@ class DoctrineExtensionTest extends TestCase
         }
     }
 
-    public function testPublicServicesAndAliases()
+    public function testPublicServicesAndAliases() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -62,7 +62,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertTrue($container->getAlias('database_connection')->isPublic());
     }
 
-    public function testDbalGenerateDefaultConnectionConfiguration()
+    public function testDbalGenerateDefaultConnectionConfiguration() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -82,7 +82,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals([], $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0)['driverOptions']);
     }
 
-    public function testDbalOverrideDefaultConnection()
+    public function testDbalOverrideDefaultConnection() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -100,7 +100,7 @@ class DoctrineExtensionTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage Configuring the ORM layer requires to configure the DBAL layer as well.
      */
-    public function testOrmRequiresDbal()
+    public function testOrmRequiresDbal() : void
     {
         $extension = new DoctrineExtension();
 
@@ -145,7 +145,7 @@ class DoctrineExtensionTest extends TestCase
     /**
      * @dataProvider getAutomappingConfigurations
      */
-    public function testAutomapping(array $entityManagers)
+    public function testAutomapping(array $entityManagers) : void
     {
         $extension = new DoctrineExtension();
 
@@ -194,7 +194,7 @@ class DoctrineExtensionTest extends TestCase
         );
     }
 
-    public function testDbalLoad()
+    public function testDbalLoad() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -212,7 +212,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('root', $config['user']);
     }
 
-    public function testDbalWrapperClass()
+    public function testDbalWrapperClass() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -238,7 +238,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('doctrine.dbal.second_connection')->getClass());
     }
 
-    public function testDependencyInjectionConfigurationDefaults()
+    public function testDependencyInjectionConfigurationDefaults() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -345,7 +345,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertSame(ArrayAdapter::class, $container->getDefinition((string) $arguments[0])->getClass());
     }
 
-    public function testUseSavePointsAddMethodCallToAddSavepointsToTheConnection()
+    public function testUseSavePointsAddMethodCallToAddSavepointsToTheConnection() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -365,7 +365,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertTrue($calls[0][1][0]);
     }
 
-    public function testAutoGenerateProxyClasses()
+    public function testAutoGenerateProxyClasses() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -389,7 +389,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals(3 /* \Doctrine\Common\Proxy\AbstractProxyFactory::AUTOGENERATE_EVAL */, $container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
     }
 
-    public function testSingleEntityManagerWithDefaultConfiguration()
+    public function testSingleEntityManagerWithDefaultConfiguration() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -409,7 +409,7 @@ class DoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testSingleEntityManagerWithDefaultSecondLevelCacheConfiguration()
+    public function testSingleEntityManagerWithDefaultSecondLevelCacheConfiguration() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -434,7 +434,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('%doctrine.orm.second_level_cache.default_cache_factory.class%', $slcDefinition->getClass());
     }
 
-    public function testSingleEntityManagerWithCustomSecondLevelCacheConfiguration()
+    public function testSingleEntityManagerWithCustomSecondLevelCacheConfiguration() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -465,7 +465,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('YamlBundle\Cache\MyCacheFactory', $slcDefinition->getClass());
     }
 
-    public function testBundleEntityAliases()
+    public function testBundleEntityAliases() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -484,7 +484,7 @@ class DoctrineExtensionTest extends TestCase
         );
     }
 
-    public function testOverwriteEntityAliases()
+    public function testOverwriteEntityAliases() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -503,7 +503,7 @@ class DoctrineExtensionTest extends TestCase
         );
     }
 
-    public function testYamlBundleMappingDetection()
+    public function testYamlBundleMappingDetection() : void
     {
         $container = $this->getContainer('YamlBundle');
         $extension = new DoctrineExtension();
@@ -521,7 +521,7 @@ class DoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testXmlBundleMappingDetection()
+    public function testXmlBundleMappingDetection() : void
     {
         $container = $this->getContainer('XmlBundle');
         $extension = new DoctrineExtension();
@@ -548,7 +548,7 @@ class DoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testAnnotationsBundleMappingDetection()
+    public function testAnnotationsBundleMappingDetection() : void
     {
         $container = $this->getContainer('AnnotationsBundle');
         $extension = new DoctrineExtension();
@@ -575,7 +575,7 @@ class DoctrineExtensionTest extends TestCase
         ]);
     }
 
-    public function testOrmMergeConfigs()
+    public function testOrmMergeConfigs() : void
     {
         $container = $this->getContainer(['XmlBundle', 'AnnotationsBundle']);
         $extension = new DoctrineExtension();
@@ -632,7 +632,7 @@ class DoctrineExtensionTest extends TestCase
         }
     }
 
-    public function testAnnotationsBundleMappingDetectionWithVendorNamespace()
+    public function testAnnotationsBundleMappingDetectionWithVendorNamespace() : void
     {
         $container = $this->getContainer('AnnotationsBundle', 'Vendor');
         $extension = new DoctrineExtension();
@@ -657,7 +657,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('Fixtures\Bundles\Vendor\AnnotationsBundle\Entity', $calls[0][1][1]);
     }
 
-    public function testMessengerIntegration()
+    public function testMessengerIntegration() : void
     {
         if (! interface_exists(MessageBusInterface::class)) {
             $this->markTestSkipped('Symfony Messenger component is not installed');
@@ -786,7 +786,7 @@ class DoctrineExtensionTest extends TestCase
         ];
     }
 
-    public function testShardManager()
+    public function testShardManager() : void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -838,12 +838,12 @@ class DoctrineExtensionTest extends TestCase
         return $container;
     }
 
-    private function assertDICConstructorArguments(Definition $definition, array $args)
+    private function assertDICConstructorArguments(Definition $definition, array $args) : void
     {
         $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '" . $definition->getClass() . "' don't match.");
     }
 
-    private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null)
+    private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null) : void
     {
         $calls = $definition->getMethodCalls();
         if (! isset($calls[$pos][0])) {
@@ -865,7 +865,7 @@ class DoctrineExtensionTest extends TestCase
      * @param string     $methodName
      * @param array|null $params
      */
-    private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null)
+    private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null) : void
     {
         $calls  = $definition->getMethodCalls();
         $called = false;
@@ -890,7 +890,7 @@ class DoctrineExtensionTest extends TestCase
         $this->fail("Method '" . $methodName . "' is expected to be called once, definition does not contain a call though.");
     }
 
-    private function compileContainer(ContainerBuilder $container)
+    private function compileContainer(ContainerBuilder $container) : void
     {
         $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveChildDefinitionsPass()]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);

--- a/Tests/DependencyInjection/Fixtures/CustomEntityListenerServiceResolver.php
+++ b/Tests/DependencyInjection/Fixtures/CustomEntityListenerServiceResolver.php
@@ -17,7 +17,7 @@ class CustomEntityListenerServiceResolver implements EntityListenerServiceResolv
     /**
      * {@inheritdoc}
      */
-    public function clear($className = null)
+    public function clear($className = null) : void
     {
         $this->resolver->clear($className);
     }
@@ -33,7 +33,7 @@ class CustomEntityListenerServiceResolver implements EntityListenerServiceResolv
     /**
      * {@inheritdoc}
      */
-    public function register($object)
+    public function register($object) : void
     {
         $this->resolver->register($object);
     }
@@ -41,7 +41,7 @@ class CustomEntityListenerServiceResolver implements EntityListenerServiceResolv
     /**
      * {@inheritdoc}
      */
-    public function registerService($className, $serviceId)
+    public function registerService($className, $serviceId) : void
     {
         $this->resolver->registerService($className, $serviceId);
     }

--- a/Tests/DependencyInjection/TestFilter.php
+++ b/Tests/DependencyInjection/TestFilter.php
@@ -10,7 +10,7 @@ class TestFilter extends SQLFilter
     /**
      * Gets the SQL query part to add to a query.
      */
-    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
+    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias) : void
     {
     }
 }

--- a/Tests/DependencyInjection/XMLSchemaTest.php
+++ b/Tests/DependencyInjection/XMLSchemaTest.php
@@ -26,7 +26,7 @@ class XMLSchemaTest extends TestCase
     /**
      * @dataProvider dataValidateSchemaFiles
      */
-    public function testValidateSchema($file)
+    public function testValidateSchema($file) : void
     {
         $found = false;
         $dom   = new DOMDocument('1.0', 'UTF-8');

--- a/Tests/DependencyInjection/XmlDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/XmlDoctrineExtensionTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function loadFromFile(ContainerBuilder $container, $file) : void
     {
         $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/xml'));
         $loadXml->load($file . '.xml');

--- a/Tests/DependencyInjection/YamlDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/YamlDoctrineExtensionTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class YamlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function loadFromFile(ContainerBuilder $container, $file) : void
     {
         $loadYaml = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/yml'));
         $loadYaml->load($file . '.yml');

--- a/Tests/Mapping/ContainerEntityListenerResolverTest.php
+++ b/Tests/Mapping/ContainerEntityListenerResolverTest.php
@@ -15,7 +15,7 @@ class ContainerEntityListenerResolverTest extends TestCase
     /** @var ContainerInterface|PHPUnit_Framework_MockObject_MockObject */
     private $container;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -23,7 +23,7 @@ class ContainerEntityListenerResolverTest extends TestCase
         $this->resolver  = new ContainerEntityListenerResolver($this->container);
     }
 
-    public function testResolveClass()
+    public function testResolveClass() : void
     {
         $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
         $object    = $this->resolver->resolve($className);
@@ -32,7 +32,7 @@ class ContainerEntityListenerResolverTest extends TestCase
         $this->assertSame($object, $this->resolver->resolve($className));
     }
 
-    public function testRegisterClassAndResolve()
+    public function testRegisterClassAndResolve() : void
     {
         $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
         $object    = new $className();
@@ -42,7 +42,7 @@ class ContainerEntityListenerResolverTest extends TestCase
         $this->assertSame($object, $this->resolver->resolve($className));
     }
 
-    public function testRegisterServiceAndResolve()
+    public function testRegisterServiceAndResolve() : void
     {
         $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
         $serviceId = 'app.entity_listener';
@@ -68,7 +68,7 @@ class ContainerEntityListenerResolverTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage There is no service named
      */
-    public function testRegisterMissingServiceAndResolve()
+    public function testRegisterMissingServiceAndResolve() : void
     {
         $className = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
         $serviceId = 'app.entity_listener';
@@ -83,7 +83,7 @@ class ContainerEntityListenerResolverTest extends TestCase
         $this->resolver->resolve($className);
     }
 
-    public function testClearOne()
+    public function testClearOne() : void
     {
         $className1 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
         $className2 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener2';
@@ -106,7 +106,7 @@ class ContainerEntityListenerResolverTest extends TestCase
         $this->assertSame($obj2, $this->resolver->resolve($className2));
     }
 
-    public function testClearAll()
+    public function testClearAll() : void
     {
         $className1 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener1';
         $className2 = '\Doctrine\Bundle\DoctrineBundle\Tests\Mapping\EntityListener2';
@@ -133,7 +133,7 @@ class ContainerEntityListenerResolverTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage An object was expected, but got "string".
      */
-    public function testRegisterStringException()
+    public function testRegisterStringException() : void
     {
         $this->resolver->register('CompanyContractListener');
     }

--- a/Tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/Tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -13,7 +13,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Can't find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest
      */
-    public function testCannotFindNamespaceAndPathForMetadata()
+    public function testCannotFindNamespaceAndPathForMetadata() : void
     {
         $class      = new ClassMetadataInfo(self::class);
         $collection = new ClassMetadataCollection([$class]);
@@ -24,7 +24,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
         $factory->findNamespaceAndPathForMetadata($collection);
     }
 
-    public function testFindNamespaceAndPathForMetadata()
+    public function testFindNamespaceAndPathForMetadata() : void
     {
         $class      = new ClassMetadataInfo('\Vendor\Package\Class');
         $collection = new ClassMetadataCollection([$class]);

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -32,7 +32,7 @@ class ProfilerTest extends BaseTestCase
     /** @var DoctrineDataCollector */
     private $collector;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->logger = new DebugStack();
         $registry     = $this->getMockBuilder(ManagerRegistry::class)->getMock();
@@ -63,7 +63,7 @@ class ProfilerTest extends BaseTestCase
         $this->twig->addRuntimeLoader($loader);
     }
 
-    public function testRender()
+    public function testRender() : void
     {
         $this->logger->queries = [
             [

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -10,7 +10,7 @@ use stdClass;
 
 class RegistryTest extends TestCase
 {
-    public function testGetDefaultConnectionName()
+    public function testGetDefaultConnectionName() : void
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry  = new Registry($container, [], [], 'default', 'default');
@@ -18,7 +18,7 @@ class RegistryTest extends TestCase
         $this->assertEquals('default', $registry->getDefaultConnectionName());
     }
 
-    public function testGetDefaultEntityManagerName()
+    public function testGetDefaultEntityManagerName() : void
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry  = new Registry($container, [], [], 'default', 'default');
@@ -26,7 +26,7 @@ class RegistryTest extends TestCase
         $this->assertEquals('default', $registry->getDefaultManagerName());
     }
 
-    public function testGetDefaultConnection()
+    public function testGetDefaultConnection() : void
     {
         $conn      = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
@@ -40,7 +40,7 @@ class RegistryTest extends TestCase
         $this->assertSame($conn, $registry->getConnection());
     }
 
-    public function testGetConnection()
+    public function testGetConnection() : void
     {
         $conn      = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
@@ -58,7 +58,7 @@ class RegistryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Doctrine ORM Connection named "default" does not exist.
      */
-    public function testGetUnknownConnection()
+    public function testGetUnknownConnection() : void
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry  = new Registry($container, [], [], 'default', 'default');
@@ -66,7 +66,7 @@ class RegistryTest extends TestCase
         $registry->getConnection('default');
     }
 
-    public function testGetConnectionNames()
+    public function testGetConnectionNames() : void
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry  = new Registry($container, ['default' => 'doctrine.dbal.default_connection'], [], 'default', 'default');
@@ -74,7 +74,7 @@ class RegistryTest extends TestCase
         $this->assertEquals(['default' => 'doctrine.dbal.default_connection'], $registry->getConnectionNames());
     }
 
-    public function testGetDefaultEntityManager()
+    public function testGetDefaultEntityManager() : void
     {
         $em        = new stdClass();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
@@ -88,7 +88,7 @@ class RegistryTest extends TestCase
         $this->assertSame($em, $registry->getManager());
     }
 
-    public function testGetEntityManager()
+    public function testGetEntityManager() : void
     {
         $em        = new stdClass();
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
@@ -106,7 +106,7 @@ class RegistryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Doctrine ORM Manager named "default" does not exist.
      */
-    public function testGetUnknownEntityManager()
+    public function testGetUnknownEntityManager() : void
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry  = new Registry($container, [], [], 'default', 'default');
@@ -118,7 +118,7 @@ class RegistryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Doctrine ORM Manager named "default" does not exist.
      */
-    public function testResetUnknownEntityManager()
+    public function testResetUnknownEntityManager() : void
     {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $registry  = new Registry($container, [], [], 'default', 'default');
@@ -126,7 +126,7 @@ class RegistryTest extends TestCase
         $registry->resetManager('default');
     }
 
-    public function testReset()
+    public function testReset() : void
     {
         $noProxyManager = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
         $noProxyManager->expects($this->once())

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -15,7 +15,7 @@ use stdClass;
 
 class ContainerRepositoryFactoryTest extends TestCase
 {
-    public function testGetRepositoryReturnsService()
+    public function testGetRepositoryReturnsService() : void
     {
         $em        = $this->createEntityManager(['Foo\CoolEntity' => 'my_repo']);
         $repo      = new StubRepository();
@@ -25,7 +25,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $this->assertSame($repo, $factory->getRepository($em, 'Foo\CoolEntity'));
     }
 
-    public function testGetRepositoryReturnsEntityRepository()
+    public function testGetRepositoryReturnsEntityRepository() : void
     {
         $container = $this->createContainer([]);
         $em        = $this->createEntityManager(['Foo\BoringEntity' => null]);
@@ -37,7 +37,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $this->assertSame($actualRepo, $factory->getRepository($em, 'Foo\BoringEntity'));
     }
 
-    public function testCustomRepositoryIsReturned()
+    public function testCustomRepositoryIsReturned() : void
     {
         $container = $this->createContainer([]);
         $em        = $this->createEntityManager([
@@ -55,7 +55,7 @@ class ContainerRepositoryFactoryTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The service "my_repo" must implement ObjectRepository (or extend a base class, like ServiceEntityRepository).
      */
-    public function testServiceRepositoriesMustExtendObjectRepository()
+    public function testServiceRepositoriesMustExtendObjectRepository() : void
     {
         $repo = new stdClass();
 
@@ -67,7 +67,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $factory->getRepository($em, 'Foo\CoolEntity');
     }
 
-    public function testServiceRepositoriesCanNotExtendsEntityRepository()
+    public function testServiceRepositoriesCanNotExtendsEntityRepository() : void
     {
         $repo = $this->getMockBuilder(ObjectRepository::class)->getMock();
 
@@ -85,7 +85,7 @@ class ContainerRepositoryFactoryTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The "Doctrine\Bundle\DoctrineBundle\Tests\Repository\StubServiceRepository" entity repository implements "Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface", but its service could not be found. Make sure the service exists and is tagged with "doctrine.repository_service".
      */
-    public function testRepositoryMatchesServiceInterfaceButServiceNotFound()
+    public function testRepositoryMatchesServiceInterfaceButServiceNotFound() : void
     {
         $container = $this->createContainer([]);
 
@@ -101,7 +101,7 @@ class ContainerRepositoryFactoryTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The "Foo\CoolEntity" entity has a repositoryClass set to "not_a_real_class", but this is not a valid class. Check your class naming. If this is meant to be a service id, make sure this service exists and is tagged with "doctrine.repository_service".
      */
-    public function testCustomRepositoryIsNotAValidClass()
+    public function testCustomRepositoryIsNotAValidClass() : void
     {
         $container = $this->createContainer([]);
 

--- a/Tests/Repository/ServiceEntityRepositoryTest.php
+++ b/Tests/Repository/ServiceEntityRepositoryTest.php
@@ -12,7 +12,7 @@ class ServiceEntityRepositoryTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage Could not find the entity manager for class "Doctrine\Bundle\DoctrineBundle\Tests\Repository\TestEntity". Check your Doctrine configuration to make sure it is configured to load this entity’s metadata.
      */
-    public function testConstructorThrowsExceptionWhenNoManagerFound()
+    public function testConstructorThrowsExceptionWhenNoManagerFound() : void
     {
         $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
         new ServiceEntityRepository($registry, TestEntity::class);

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -25,7 +25,7 @@ class ServiceRepositoryTest extends TestCase
      *
      * @group legacy
      */
-    public function testRepositoryServiceWiring()
+    public function testRepositoryServiceWiring() : void
     {
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.name' => 'app',

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -83,7 +83,7 @@ class TestCase extends BaseTestCase
 
 class TestCaseAllPublicCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container) : void
     {
         foreach ($container->getDefinitions() as $id => $definition) {
             if (strpos($id, 'doctrine') === false) {

--- a/Tests/Twig/DoctrineExtensionTest.php
+++ b/Tests/Twig/DoctrineExtensionTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class DoctrineExtensionTest extends TestCase
 {
-    public function testReplaceQueryParametersWithPostgresCasting()
+    public function testReplaceQueryParametersWithPostgresCasting() : void
     {
         $extension  = new DoctrineExtension();
         $query      = 'a=? OR (1)::string OR b=?';
@@ -17,7 +17,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('a=1 OR (1)::string OR b=2', $result);
     }
 
-    public function testReplaceQueryParametersWithStartingIndexAtOne()
+    public function testReplaceQueryParametersWithStartingIndexAtOne() : void
     {
         $extension  = new DoctrineExtension();
         $query      = 'a=? OR b=?';
@@ -30,7 +30,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('a=1 OR b=2', $result);
     }
 
-    public function testReplaceQueryParameters()
+    public function testReplaceQueryParameters() : void
     {
         $extension  = new DoctrineExtension();
         $query      = 'a=? OR b=?';
@@ -43,7 +43,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('a=1 OR b=2', $result);
     }
 
-    public function testReplaceQueryParametersWithNamedIndex()
+    public function testReplaceQueryParametersWithNamedIndex() : void
     {
         $extension  = new DoctrineExtension();
         $query      = 'a=:a OR b=:b';
@@ -56,34 +56,34 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('a=1 OR b=2', $result);
     }
 
-    public function testEscapeBinaryParameter()
+    public function testEscapeBinaryParameter() : void
     {
         $binaryString = pack('H*', '9d40b8c1417f42d099af4782ec4b20b6');
         $this->assertEquals('0x9D40B8C1417F42D099AF4782EC4B20B6', DoctrineExtension::escapeFunction($binaryString));
     }
 
-    public function testEscapeStringParameter()
+    public function testEscapeStringParameter() : void
     {
         $this->assertEquals("'test string'", DoctrineExtension::escapeFunction('test string'));
     }
 
-    public function testEscapeArrayParameter()
+    public function testEscapeArrayParameter() : void
     {
         $this->assertEquals("1, NULL, 'test', foo", DoctrineExtension::escapeFunction([1, null, 'test', new DummyClass('foo')]));
     }
 
-    public function testEscapeObjectParameter()
+    public function testEscapeObjectParameter() : void
     {
         $object = new DummyClass('bar');
         $this->assertEquals('bar', DoctrineExtension::escapeFunction($object));
     }
 
-    public function testEscapeNullParameter()
+    public function testEscapeNullParameter() : void
     {
         $this->assertEquals('NULL', DoctrineExtension::escapeFunction(null));
     }
 
-    public function testEscapeBooleanParameter()
+    public function testEscapeBooleanParameter() : void
     {
         $this->assertEquals('1', DoctrineExtension::escapeFunction(true));
     }


### PR DESCRIPTION
As a side effect, this makes the code a bit more forward-compatible with
recent versions of PHPUnit, that have that return type declaration on
setUp().