### PR TITLE
Add type declarations where backwards compatible

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -96,11 +96,9 @@ class ConnectionFactory
      * and the platform version is unknown.
      * For details have a look at DoctrineBundle issue #673.
      *
-     * @return AbstractPlatform
-     *
      * @throws DBALException
      */
-    private function getDatabasePlatform(Connection $connection)
+    private function getDatabasePlatform(Connection $connection) : AbstractPlatform
     {
         try {
             return $connection->getDatabasePlatform();
@@ -119,7 +117,7 @@ class ConnectionFactory
     /**
      * initialize the types
      */
-    private function initializeTypes()
+    private function initializeTypes() : void
     {
         foreach ($this->typesConfig as $typeName => $typeConfig) {
             if (Type::hasType($typeName)) {

--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -74,7 +74,10 @@ class ProfilerController implements ContainerAwareInterface
         ]));
     }
 
-    private function explainSQLitePlatform(Connection $connection, $query)
+    /**
+     * @param mixed[] $query
+     */
+    private function explainSQLitePlatform(Connection $connection, array $query)
     {
         $params = $query['params'];
 

--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -88,7 +88,7 @@ class EntityListenerPass implements CompilerPassInterface
         }
     }
 
-    private function attachToListener(ContainerBuilder $container, $name, string $class, array $attributes)
+    private function attachToListener(ContainerBuilder $container, string $name, string $class, array $attributes) : void
     {
         $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $name);
 

--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -11,7 +11,7 @@ final class ServiceRepositoryCompilerPass implements CompilerPassInterface
 {
     const REPOSITORY_SERVICE_TAG = 'doctrine.repository_service';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container) : void
     {
         // when ORM is not enabled
         if (! $container->hasDefinition('doctrine.orm.container_repository_factory')) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -49,7 +49,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Add DBAL section to configuration tree
      */
-    private function addDbalSection(ArrayNodeDefinition $node)
+    private function addDbalSection(ArrayNodeDefinition $node) : void
     {
         $node
             ->children()
@@ -103,10 +103,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Return the dbal connections node
-     *
-     * @return ArrayNodeDefinition
      */
-    private function getDbalConnectionsNode()
+    private function getDbalConnectionsNode() : ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('connections');
         $node        = $treeBuilder->getRootNode();
@@ -185,7 +183,7 @@ class Configuration implements ConfigurationInterface
      *
      * These keys are available for slave configurations too.
      */
-    private function configureDbalDriverNode(ArrayNodeDefinition $node)
+    private function configureDbalDriverNode(ArrayNodeDefinition $node) : void
     {
         $node
             ->children()
@@ -295,7 +293,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Add the ORM section to configuration tree
      */
-    private function addOrmSection(ArrayNodeDefinition $node)
+    private function addOrmSection(ArrayNodeDefinition $node) : void
     {
         $node
             ->children()
@@ -377,10 +375,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Return ORM target entity resolver node
-     *
-     * @return NodeDefinition
      */
-    private function getOrmTargetEntityResolverNode()
+    private function getOrmTargetEntityResolverNode() : NodeDefinition
     {
         $treeBuilder = new TreeBuilder('resolve_target_entities');
         $node        = $treeBuilder->getRootNode();
@@ -396,10 +392,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Return ORM entity listener node
-     *
-     * @return NodeDefinition
      */
-    private function getOrmEntityListenersNode()
+    private function getOrmEntityListenersNode() : NodeDefinition
     {
         $treeBuilder = new TreeBuilder('entity_listeners');
         $node        = $treeBuilder->getRootNode();
@@ -482,10 +476,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Return ORM entity manager node
-     *
-     * @return ArrayNodeDefinition
      */
-    private function getOrmEntityManagersNode()
+    private function getOrmEntityManagersNode() : ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('entity_managers');
         $node        = $treeBuilder->getRootNode();
@@ -644,12 +636,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Return a ORM cache driver node for an given entity manager
-     *
-     * @param string $name
-     *
-     * @return ArrayNodeDefinition
      */
-    private function getOrmCacheDriverNode($name)
+    private function getOrmCacheDriverNode(string $name) : ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder($name);
         $node        = $treeBuilder->getRootNode();
@@ -673,10 +661,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Find proxy auto generate modes for their names and int values
-     *
-     * @return array
      */
-    private function getAutoGenerateModes()
+    private function getAutoGenerateModes() : array
     {
         $constPrefix = 'AUTOGENERATE_';
         $prefixLen   = strlen($constPrefix);

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -760,10 +760,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
     /**
      * Loads a property info extractor for each defined entity manager.
-     *
-     * @param string $entityManagerName
      */
-    private function loadPropertyInfoExtractor($entityManagerName, ContainerBuilder $container)
+    private function loadPropertyInfoExtractor(string $entityManagerName, ContainerBuilder $container) : void
     {
         $propertyExtractorDefinition = $container->register(sprintf('doctrine.orm.%s_entity_manager.property_info_extractor', $entityManagerName), DoctrineExtractor::class);
         $argumentId                  = sprintf('doctrine.orm.%s_entity_manager', $entityManagerName);

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -13,12 +13,12 @@ class ManagerConfigurator
     /** @var string[] */
     private $enabledFilters = [];
 
-    /** @var string[] */
+    /** @var array<string,array<string,string>> */
     private $filtersParameters = [];
 
     /**
-     * @param string[] $enabledFilters
-     * @param string[] $filtersParameters
+     * @param string[]                           $enabledFilters
+     * @param array<string,array<string,string>> $filtersParameters
      */
     public function __construct(array $enabledFilters, array $filtersParameters)
     {
@@ -37,7 +37,7 @@ class ManagerConfigurator
     /**
      * Enables filters for a given entity manager
      */
-    private function enableFilters(EntityManagerInterface $entityManager)
+    private function enableFilters(EntityManagerInterface $entityManager) : void
     {
         if (empty($this->enabledFilters)) {
             return;
@@ -56,11 +56,8 @@ class ManagerConfigurator
 
     /**
      * Sets default parameters for a given filter
-     *
-     * @param string    $name   Filter name
-     * @param SQLFilter $filter Filter object
      */
-    private function setFilterParameters($name, SQLFilter $filter)
+    private function setFilterParameters(string $name, SQLFilter $filter) : void
     {
         if (empty($this->filtersParameters[$name])) {
             return;

--- a/Mapping/DisconnectedMetadataFactory.php
+++ b/Mapping/DisconnectedMetadataFactory.php
@@ -126,15 +126,9 @@ class DisconnectedMetadataFactory
     /**
      * Get a base path for a class
      *
-     * @param string $name      class name
-     * @param string $namespace class namespace
-     * @param string $path      class path
-     *
-     * @return string
-     *
      * @throws RuntimeException When base path not found.
      */
-    private function getBasePathForClass($name, $namespace, $path)
+    private function getBasePathForClass(string $name, string $namespace, string $path) : string
     {
         $namespace   = str_replace('\\', '/', $namespace);
         $search      = str_replace('\\', '/', $path);
@@ -147,12 +141,7 @@ class DisconnectedMetadataFactory
         return $destination;
     }
 
-    /**
-     * @param string $namespace
-     *
-     * @return ClassMetadataCollection
-     */
-    private function getMetadataForNamespace($namespace)
+    private function getMetadataForNamespace(string $namespace) : ClassMetadataCollection
     {
         $metadata = [];
         foreach ($this->getAllMetadata() as $m) {
@@ -166,12 +155,7 @@ class DisconnectedMetadataFactory
         return new ClassMetadataCollection($metadata);
     }
 
-    /**
-     * @param string $entity
-     *
-     * @return ClassMetadataCollection
-     */
-    private function getMetadataForClass($entity)
+    private function getMetadataForClass(string $entity) : ClassMetadataCollection
     {
         foreach ($this->registry->getManagers() as $em) {
             $cmf = new DisconnectedClassMetadataFactory();
@@ -188,7 +172,7 @@ class DisconnectedMetadataFactory
     /**
      * @return ClassMetadata[]
      */
-    private function getAllMetadata()
+    private function getAllMetadata() : array
     {
         $metadata = [];
         foreach ($this->registry->getManagers() as $em) {

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -39,7 +39,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
     /**
      * {@inheritdoc}
      */
-    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    public function getRepository(EntityManagerInterface $entityManager, $entityName) : ObjectRepository
     {
         $metadata            = $entityManager->getClassMetadata($entityName);
         $repositoryServiceId = $metadata->customRepositoryClassName;
@@ -72,8 +72,10 @@ final class ContainerRepositoryFactory implements RepositoryFactory
         return $this->getOrCreateRepository($entityManager, $metadata);
     }
 
-    private function getOrCreateRepository(EntityManagerInterface $entityManager, ClassMetadata $metadata)
-    {
+    private function getOrCreateRepository(
+        EntityManagerInterface $entityManager,
+        ClassMetadata $metadata
+    ) : ObjectRepository {
         $repositoryHash = $metadata->getName() . spl_object_hash($entityManager);
         if (isset($this->managedRepositories[$repositoryHash])) {
             return $this->managedRepositories[$repositoryHash];

--- a/Tests/Builder/BundleConfigurationBuilder.php
+++ b/Tests/Builder/BundleConfigurationBuilder.php
@@ -21,7 +21,7 @@ class BundleConfigurationBuilder
         return $builder;
     }
 
-    public function addBaseConnection()
+    public function addBaseConnection() : self
     {
         $this->addConnection([
             'connections' => [
@@ -32,7 +32,7 @@ class BundleConfigurationBuilder
         return $this;
     }
 
-    public function addBaseEntityManager()
+    public function addBaseEntityManager() : self
     {
         $this->addEntityManager([
             'default_entity_manager' => 'default',
@@ -48,7 +48,7 @@ class BundleConfigurationBuilder
         return $this;
     }
 
-    public function addBaseSecondLevelCache()
+    public function addBaseSecondLevelCache() : self
     {
         $this->addSecondLevelCache([
             'region_cache_driver' => ['type' => 'pool', 'pool' => 'my_pool'],
@@ -60,28 +60,28 @@ class BundleConfigurationBuilder
         return $this;
     }
 
-    public function addConnection($config)
+    public function addConnection($config) : self
     {
         $this->configuration['dbal'] = $config;
 
         return $this;
     }
 
-    public function addEntityManager($config)
+    public function addEntityManager($config) : self
     {
         $this->configuration['orm'] = $config;
 
         return $this;
     }
 
-    public function addSecondLevelCache($config, $manager = 'default')
+    public function addSecondLevelCache($config, $manager = 'default') : self
     {
         $this->configuration['orm']['entity_managers'][$manager]['second_level_cache'] = $config;
 
         return $this;
     }
 
-    public function build()
+    public function build() : array
     {
         return $this->configuration;
     }

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -3,8 +3,8 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -86,12 +86,9 @@ class CreateDatabaseDoctrineTest extends TestCase
     }
 
     /**
-     * @param string       $connectionName Connection name
-     * @param mixed[]|null $params         Connection parameters
-     *
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @param mixed[]|null $params Connection parameters
      */
-    private function getMockContainer($connectionName, $params = null)
+    private function getMockContainer(string $connectionName, array $params = null) : MockObject
     {
         // Mock the container and everything you'll need here
         $mockDoctrine = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')

--- a/Tests/Command/DropDatabaseDoctrineTest.php
+++ b/Tests/Command/DropDatabaseDoctrineTest.php
@@ -3,8 +3,8 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -75,12 +75,9 @@ class DropDatabaseDoctrineTest extends TestCase
     }
 
     /**
-     * @param string     $connectionName Connection name
-     * @param array|null $params         Connection parameters
-     *
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @param array|null $params Connection parameters
      */
-    private function getMockContainer($connectionName, $params = null)
+    private function getMockContainer(string $connectionName, array $params = null) : MockObject
     {
         // Mock the container and everything you'll need here
         $mockDoctrine = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -89,7 +89,7 @@ class FakeDriver implements Driver
      *
      * @link https://github.com/doctrine/DoctrineBundle/issues/673
      */
-    public function getDatabasePlatform()
+    public function getDatabasePlatform() : AbstractPlatform
     {
         if (self::$exception !== null) {
             throw self::$exception;
@@ -116,12 +116,12 @@ class FakeDriver implements Driver
         throw new Exception('not implemented');
     }
 
-    public function getName()
+    public function getName() : string
     {
         return 'FakeDriver';
     }
 
-    public function getDatabase(Connection $conn)
+    public function getDatabase(Connection $conn) : string
     {
         return 'fake_db';
     }

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -86,12 +86,7 @@ class DoctrineDataCollectorTest extends TestCase
         $this->assertSame(1, $groupedQueries['default'][1]['count']);
     }
 
-    /**
-     * @param string $entityFQCN
-     *
-     * @return ClassMetadataInfo
-     */
-    private function createEntityMetadata($entityFQCN)
+    private function createEntityMetadata(string $entityFQCN) : ClassMetadataInfo
     {
         $metadata            = new ClassMetadataInfo($entityFQCN);
         $metadata->name      = $entityFQCN;
@@ -100,12 +95,7 @@ class DoctrineDataCollectorTest extends TestCase
         return $metadata;
     }
 
-    /**
-     * @param array $managers
-     *
-     * @return DoctrineDataCollector
-     */
-    private function createCollector(array $managers)
+    private function createCollector(array $managers) : DoctrineDataCollector
     {
         $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
         $registry

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 abstract class AbstractDoctrineExtensionTest extends TestCase
 {
-    abstract protected function loadFromFile(ContainerBuilder $container, $file);
+    abstract protected function loadFromFile(ContainerBuilder $container, string $file) : void;
 
     public function testDbalLoadFromXmlMultipleConnections() : void
     {
@@ -1019,8 +1019,11 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'setRepositoryFactory', ['repository_factory']);
     }
 
-    private function loadContainer($fixture, array $bundles = ['YamlBundle'], CompilerPassInterface $compilerPass = null)
-    {
+    private function loadContainer(
+        string $fixture,
+        array $bundles = ['YamlBundle'],
+        CompilerPassInterface $compilerPass = null
+    ) : ContainerBuilder {
         $container = $this->getContainer($bundles);
         $container->registerExtension(new DoctrineExtension());
 
@@ -1035,7 +1038,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         return $container;
     }
 
-    private function getContainer(array $bundles)
+    private function getContainer(array $bundles) : ContainerBuilder
     {
         $map = [];
         foreach ($bundles as $bundle) {
@@ -1065,21 +1068,23 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * Assertion on the Class of a DIC Service Definition.
-     *
-     * @param string $expectedClass
      */
-    private function assertDICDefinitionClass(Definition $definition, $expectedClass) : void
+    private function assertDICDefinitionClass(Definition $definition, string $expectedClass) : void
     {
         $this->assertEquals($expectedClass, $definition->getClass(), 'Expected Class of the DIC Container Service Definition is wrong.');
     }
 
-    private function assertDICConstructorArguments(Definition $definition, $args) : void
+    private function assertDICConstructorArguments(Definition $definition, array $args) : void
     {
         $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '" . $definition->getClass() . "' don't match.");
     }
 
-    private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null) : void
-    {
+    private function assertDICDefinitionMethodCallAt(
+        int $pos,
+        Definition $definition,
+        string $methodName,
+        array $params = null
+    ) : void {
         $calls = $definition->getMethodCalls();
         if (! isset($calls[$pos][0])) {
             $this->fail(sprintf('Method call at position %s not found!', $pos));
@@ -1098,12 +1103,12 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * Assertion for the DI Container, check if the given definition contains a method call with the given parameters.
-     *
-     * @param string $methodName
-     * @param array  $params
      */
-    private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null) : void
-    {
+    private function assertDICDefinitionMethodCallOnce(
+        Definition $definition,
+        string $methodName,
+        array $params = null
+    ) : void {
         $calls  = $definition->getMethodCalls();
         $called = false;
         foreach ($calls as $call) {
@@ -1127,8 +1132,12 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->fail("Method '" . $methodName . "' is expected to be called once, definition does not contain a call though.");
     }
 
-    private function assertDICDefinitionMethodCallCount(Definition $definition, $methodName, array $params = [], $nbCalls = 1) : void
-    {
+    private function assertDICDefinitionMethodCallCount(
+        Definition $definition,
+        string $methodName,
+        array $params = [],
+        int $nbCalls = 1
+    ) : void {
         $calls  = $definition->getMethodCalls();
         $called = 0;
         foreach ($calls as $call) {
@@ -1151,12 +1160,12 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * Assertion for the DI Container, check if the given definition does not contain a method call with the given parameters.
-     *
-     * @param string $methodName
-     * @param array  $params
      */
-    private function assertDICDefinitionNoMethodCall(Definition $definition, $methodName, array $params = null) : void
-    {
+    private function assertDICDefinitionNoMethodCall(
+        Definition $definition,
+        string $methodName,
+        array $params = null
+    ) : void {
         $calls = $definition->getMethodCalls();
         foreach ($calls as $call) {
             if ($call[0] !== $methodName) {

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -107,7 +107,7 @@ class DoctrineExtensionTest extends TestCase
         $extension->load([['orm' => ['auto_mapping' => true]]], $this->getContainer());
     }
 
-    public function getAutomappingConfigurations()
+    public function getAutomappingConfigurations() : array
     {
         return [
             [
@@ -810,7 +810,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition('doctrine.dbal.bar_shard_manager'));
     }
 
-    private function getContainer($bundles = 'YamlBundle', $vendor = null)
+    private function getContainer($bundles = 'YamlBundle', $vendor = null) : ContainerBuilder
     {
         $bundles = (array) $bundles;
 
@@ -843,7 +843,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '" . $definition->getClass() . "' don't match.");
     }
 
-    private function assertDICDefinitionMethodCallAt($pos, Definition $definition, $methodName, array $params = null) : void
+    private function assertDICDefinitionMethodCallAt(int $pos, Definition $definition, string $methodName, array $params = null) : void
     {
         $calls = $definition->getMethodCalls();
         if (! isset($calls[$pos][0])) {
@@ -861,11 +861,8 @@ class DoctrineExtensionTest extends TestCase
 
     /**
      * Assertion for the DI Container, check if the given definition contains a method call with the given parameters.
-     *
-     * @param string     $methodName
-     * @param array|null $params
      */
-    private function assertDICDefinitionMethodCallOnce(Definition $definition, $methodName, array $params = null) : void
+    private function assertDICDefinitionMethodCallOnce(Definition $definition, string $methodName, array $params = null) : void
     {
         $calls  = $definition->getMethodCalls();
         $called = false;

--- a/Tests/DependencyInjection/TestDatetimeFunction.php
+++ b/Tests/DependencyInjection/TestDatetimeFunction.php
@@ -8,13 +8,13 @@ use Doctrine\ORM\Query\SqlWalker;
 
 class TestDatetimeFunction extends FunctionNode
 {
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker) : string
     {
         return '';
     }
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser) : void
     {
-        return '';
+        return;
     }
 }

--- a/Tests/DependencyInjection/TestNumericFunction.php
+++ b/Tests/DependencyInjection/TestNumericFunction.php
@@ -8,13 +8,13 @@ use Doctrine\ORM\Query\SqlWalker;
 
 class TestNumericFunction extends FunctionNode
 {
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker) : string
     {
         return '';
     }
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser) : void
     {
-        return '';
+        return;
     }
 }

--- a/Tests/DependencyInjection/TestStringFunction.php
+++ b/Tests/DependencyInjection/TestStringFunction.php
@@ -8,13 +8,13 @@ use Doctrine\ORM\Query\SqlWalker;
 
 class TestStringFunction extends FunctionNode
 {
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker) : string
     {
         return '';
     }
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser) : void
     {
-        return '';
+        return;
     }
 }

--- a/Tests/DependencyInjection/TestType.php
+++ b/Tests/DependencyInjection/TestType.php
@@ -7,12 +7,12 @@ use Doctrine\DBAL\Types\Type;
 
 class TestType extends Type
 {
-    public function getName()
+    public function getName() : string
     {
         return 'test';
     }
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform) : string
     {
         return '';
     }

--- a/Tests/DependencyInjection/XmlDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/XmlDoctrineExtensionTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file) : void
+    protected function loadFromFile(ContainerBuilder $container, string $file) : void
     {
         $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/xml'));
         $loadXml->load($file . '.xml');

--- a/Tests/DependencyInjection/YamlDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/YamlDoctrineExtensionTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class YamlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file) : void
+    protected function loadFromFile(ContainerBuilder $container, string $file) : void
     {
         $loadYaml = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/yml'));
         $loadYaml->load($file . '.yml');

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use stdClass;
@@ -111,7 +112,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $factory->getRepository($em, 'Foo\CoolEntity');
     }
 
-    private function createContainer(array $services)
+    private function createContainer(array $services) : MockObject
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $container->expects($this->any())
@@ -128,7 +129,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         return $container;
     }
 
-    private function createEntityManager(array $entityRepositoryClasses)
+    private function createEntityManager(array $entityRepositoryClasses) : MockObject
     {
         $classMetadatas = [];
         foreach ($entityRepositoryClasses as $entityClass => $entityRepositoryClass) {

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class TestCase extends BaseTestCase
 {
-    public function createXmlBundleTestContainer()
+    public function createXmlBundleTestContainer() : ContainerBuilder
     {
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.name' => 'app',

--- a/Tests/Twig/DoctrineExtensionTest.php
+++ b/Tests/Twig/DoctrineExtensionTest.php
@@ -94,12 +94,12 @@ class DummyClass
     /** @var string */
     protected $str;
 
-    public function __construct($str)
+    public function __construct(string $str)
     {
         $this->str = $str;
     }
 
-    public function __toString()
+    public function __toString() : string
     {
         return $this->str;
     }

--- a/Twig/DoctrineExtension.php
+++ b/Twig/DoctrineExtension.php
@@ -27,13 +27,8 @@ class DoctrineExtension extends AbstractExtension
 
     /**
      * Get the possible combinations of elements from the given array
-     *
-     * @param array $elements
-     * @param int   $combinationsLevel
-     *
-     * @return array
      */
-    private function getPossibleCombinations(array $elements, $combinationsLevel)
+    private function getPossibleCombinations(array $elements, int $combinationsLevel) : array
     {
         $baseCount = count($elements);
         $result    = [];


### PR DESCRIPTION
That means:

- methods in final classes
- final methods (none of those found)
- private methods
- methods in Tests (that excludes `setUp()`, `tearDown()` and `test*`, which
  are handled with an automated tool in #1121 )