### PR TITLE
Fix DI configuration to allow cache_provider key in cache_driver of type provider

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -670,6 +670,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('type')->defaultNull()->end()
                 ->scalarNode('id')->end()
                 ->scalarNode('pool')->end()
+                ->scalarNode('cache_provider')->end()
             ->end();
 
         return $node;


### PR DESCRIPTION
Hey,

I'm trying to update to version `^2.0` and the installation is failing, because I'm using a cache providers.

My _simplified_ `doctrine_cache` configuration looks like this:
```yaml
doctrine_cache:
    providers:
        data: ...
```

In the version `^1.0` I have `orm` configuration:
```yaml
...
    second_level_cache:
        region_cache_driver:
            cache_provider: data
        regions:
            # this region is here because of the bug https://github.com/doctrine/DoctrineBundle/issues/81
            special_region:
                cache_driver:
                    cache_provider: data
...
```

I figured that it should be like this in version `^2.0`
```yaml
...
    second_level_cache:
        region_cache_driver:
            type: provider
            cache_provider: data
        regions:
            special_region:
                cache_driver:
                    type: provider
                    cache_provider: data
...
```

**BUT** this doesn't work, since `cache_provider` key is not allowed in `cache_driver` configuration, but it is also required in the https://github.com/doctrine/DoctrineBundle/blob/master/DependencyInjection/DoctrineExtension.php#L736-L738 .

So I've added the `scalar_node` for `cache_provider` to fix the situation, I hope it is correct.

I guess for now it could be bypassed by following:
```yaml
cache_driver:
    type: service
    id: doctrine_cache.providers.data
```
