### PR TITLE
Updated service definition to support Messenger 5.1

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransportFactory;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use function class_exists;
 use function sprintf;
@@ -842,11 +842,17 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $container->removeDefinition('doctrine.orm.messenger.event_subscriber.doctrine_clear_entity_manager');
         }
 
+        $transportFactoryDefinition = $container->getDefinition('messenger.transport.doctrine.factory');
         if (! class_exists(DoctrineTransportFactory::class)) {
-            return;
+            // If symfony/messenger < 5.1
+            if (class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class)) {
+                $transportFactoryDefinition->setClass(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class);
+            } else {
+                // Dont add the tag
+                return;
+            }
         }
 
-        $transportFactoryDefinition = $container->getDefinition('messenger.transport.doctrine.factory');
         $transportFactoryDefinition->addTag('messenger.transport_factory');
     }
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -24,8 +24,8 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransportFactory;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use function class_exists;
 use function sprintf;
@@ -845,11 +845,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $transportFactoryDefinition = $container->getDefinition('messenger.transport.doctrine.factory');
         if (! class_exists(DoctrineTransportFactory::class)) {
             // If symfony/messenger < 5.1
-            if (class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class)) {
-                $transportFactoryDefinition->setClass(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class);
-            } else {
+            if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class)) {
                 // Dont add the tag
                 return;
+            } else {
+                $transportFactoryDefinition->setClass(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class);
             }
         }
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -845,12 +845,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $transportFactoryDefinition = $container->getDefinition('messenger.transport.doctrine.factory');
         if (! class_exists(DoctrineTransportFactory::class)) {
             // If symfony/messenger < 5.1
-            if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class)) {
+            if (! class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class)) {
                 // Dont add the tag
                 return;
-            } else {
-                $transportFactoryDefinition->setClass(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class);
             }
+
+            $transportFactoryDefinition->setClass(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class);
         }
 
         $transportFactoryDefinition->addTag('messenger.transport_factory');

--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -32,7 +32,7 @@
         The following service isn't tagged as transport factory because the class may not exist.
         The tag is added conditionally in DoctrineExtension.
         -->
-        <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory" public="false">
+        <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransportFactory" public="false">
             <argument type="service" id="doctrine" />
         </service>
 


### PR DESCRIPTION
I have a PR open to Symfony to move the Doctrine transport to a new package. See https://github.com/symfony/symfony/pull/35422

If my Symfony PR is merged, this PR makes sure that DoctrineBundle is compatible with Symfony Messenger 5.1 without any deprecation notices. 

This PR could also be cherry-picked to 1.x branch. 