### PR TITLE
Fix render controller when explaining a query

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -112,7 +112,7 @@
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
     {% if 'explain' == page %}
-        {{ render(controller('DoctrineBundle:Profiler:explain', {
+        {{ render(controller('Doctrine\\Bundle\\DoctrineBundle\\Controller\\ProfilerController::explainAction', {
             token: token,
             panel: 'db',
             connectionName: request.query.get('connection'),


### PR DESCRIPTION
When trying to explain a query in the profiler, I had an exception `An exception has been thrown during the rendering of a template ("The controller for URI "/_fragment" is not callable. Controller "DoctrineBundle:Profiler:explain" does neither exist as service nor as class").`

Using the controller method FQCN did solve the problem