### PR TITLE
fix symfony/config deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -699,16 +699,16 @@ class Configuration implements ConfigurationInterface
      * introduced at the same time. By checking if getDefinition() exists,
      * we can determine the correct param count to use when calling setDeprecated.
      */
-    private function getCommentedParamDeprecationMsg(): array
+    private function getCommentedParamDeprecationMsg() : array
     {
         if (method_exists(BaseNode::class, 'getDefinition')) {
             return [
                 'doctrine/doctrine-bundle',
                 '2.0',
-                'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.'
+                'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.',
             ];
         }
 
-        return [];
+        return [null];
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -695,15 +695,15 @@ class Configuration implements ConfigurationInterface
      * Returns the correct deprecation param's as an array for setDeprecated.
      *
      * Symfony/Config v5.1 introduces a deprecation notice when calling
-     * setDeprecation() with less than 3 args and the getDefinition method was
-     * introduced at the same time. By checking if getDefinition() exists,
+     * setDeprecation() with less than 3 args and the getDeprecation method was
+     * introduced at the same time. By checking if getDeprecation() exists,
      * we can determine the correct param count to use when calling setDeprecated.
      */
     private function getCommentedParamDeprecationMsg() : array
     {
-        $msg = 'The doctrine-bundle type commenting features removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.';
+        $msg = 'The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.';
 
-        if (method_exists(BaseNode::class, 'getDefinition')) {
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
             return [
                 'doctrine/doctrine-bundle',
                 '2.0',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -92,10 +92,10 @@ class Configuration implements ConfigurationInterface
                             ->children()
                                 ->scalarNode('class')->isRequired()->end()
                                 ->booleanNode('commented')->setDeprecated(
-                                        'doctrine/DoctrineBundle',
-                                        '2.0',
-                                        'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.'
-                                    )->end()
+                                    'doctrine/DoctrineBundle',
+                                    '2.0',
+                                    'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.'
+                                )->end()
                             ->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -91,7 +91,11 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->children()
                                 ->scalarNode('class')->isRequired()->end()
-                                ->booleanNode('commented')->setDeprecated()->end()
+                                ->booleanNode('commented')->setDeprecated(
+                                        'doctrine/DoctrineBundle',
+                                        '2.0',
+                                        'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.'
+                                    )->end()
                             ->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -701,16 +701,16 @@ class Configuration implements ConfigurationInterface
      */
     private function getCommentedParamDeprecationMsg() : array
     {
-        $msg = 'The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.';
+        $message = 'The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.';
 
         if (method_exists(BaseNode::class, 'getDeprecation')) {
             return [
                 'doctrine/doctrine-bundle',
                 '2.0',
-                $msg,
+                $message,
             ];
         }
 
-        return [$msg];
+        return [$message];
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -701,14 +701,16 @@ class Configuration implements ConfigurationInterface
      */
     private function getCommentedParamDeprecationMsg() : array
     {
+        $msg = 'The doctrine-bundle type commenting features removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.';
+
         if (method_exists(BaseNode::class, 'getDefinition')) {
             return [
                 'doctrine/doctrine-bundle',
                 '2.0',
-                'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.',
+                $msg,
             ];
         }
 
-        return [null];
+        return [$msg];
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -92,7 +92,7 @@ class Configuration implements ConfigurationInterface
                             ->children()
                                 ->scalarNode('class')->isRequired()->end()
                                 ->booleanNode('commented')->setDeprecated(
-                                    'doctrine/DoctrineBundle',
+                                    'doctrine/doctrine-bundle',
                                     '2.0',
                                     'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.'
                                 )->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
 use Doctrine\ORM\EntityManager;
 use ReflectionClass;
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -91,11 +92,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->children()
                                 ->scalarNode('class')->isRequired()->end()
-                                ->booleanNode('commented')->setDeprecated(
-                                    'doctrine/doctrine-bundle',
-                                    '2.0',
-                                    'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.'
-                                )->end()
+                                ->booleanNode('commented')->setDeprecated(...$this->getCommentedParamDeprecationMsg())->end()
                             ->end()
                         ->end()
                     ->end()
@@ -692,5 +689,26 @@ class Configuration implements ConfigurationInterface
             'names' => $namesArray,
             'values' => $valuesArray,
         ];
+    }
+
+    /**
+     * Returns the correct deprecation param's as an array for setDeprecated.
+     *
+     * Symfony/Config v5.1 introduces a deprecation notice when calling
+     * setDeprecation() with less than 3 args and the getDefinition method was
+     * introduced at the same time. By checking if getDefinition() exists,
+     * we can determine the correct param count to use when calling setDeprecated.
+     */
+    private function getCommentedParamDeprecationMsg(): array
+    {
+        if (method_exists(BaseNode::class, 'getDefinition')) {
+            return [
+                'doctrine/doctrine-bundle',
+                '2.0',
+                'Type commenting features removed; the corresponding config parameter was deprecated and will be dropped in 3.0.'
+            ];
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
Starting in Symfony/Config 5.1, calling `NodeDefinition::setDeprecated()` with no arguments is deprecated. See https://github.com/symfony/symfony/pull/35871 

This addresses the deprecation by providing the soon to be required parameters.