### PR TITLE
Add doctrine project file for website

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -1,0 +1,96 @@
+{
+  "name": "Doctrine Bundle",
+  "shortName": "DoctrineBundle",
+  "slug": "doctrine-bundle",
+  "versions": [
+    {
+      "name": "2.1",
+      "branchName": "master",
+      "slug": "latest",
+      "upcoming": true
+    },
+    {
+      "name": "2.0",
+      "branchName": "2.0.x",
+      "slug": "2.0",
+      "aliases": [
+        "current",
+        "stable"
+      ],
+      "current": true,
+      "maintained": true
+    },
+    {
+      "name": "1.12",
+      "branchName": "1.12.x",
+      "slug": "1.12",
+      "maintained": true
+    },
+    {
+      "name": "1.11",
+      "branchName": "1.11.x",
+      "slug": "1.11",
+      "maintained": false
+    },
+    {
+      "name": "1.10",
+      "branchName": "1.10.x",
+      "slug": "1.10",
+      "maintained": false
+    },
+    {
+      "name": "1.9",
+      "branchName": "1.9.x",
+      "slug": "1.9",
+      "maintained": false
+    },
+    {
+      "name": "1.8",
+      "branchName": "1.8.x",
+      "slug": "1.8",
+      "maintained": false
+    },
+    {
+      "name": "1.7",
+      "branchName": "1.7.x",
+      "slug": "1.7",
+      "maintained": false
+    },
+    {
+      "name": "1.6",
+      "branchName": "1.6.x",
+      "slug": "1.6",
+      "maintained": false
+    },
+    {
+      "name": "1.5",
+      "branchName": "1.5.x",
+      "slug": "1.5",
+      "maintained": false
+    },
+    {
+      "name": "1.4",
+      "branchName": "1.4.x",
+      "slug": "1.4",
+      "maintained": false
+    },
+    {
+      "name": "1.3",
+      "branchName": "1.3.x",
+      "slug": "1.3",
+      "maintained": false
+    },
+    {
+      "name": "1.2",
+      "branchName": "1.2.x",
+      "slug": "1.2",
+      "maintained": false
+    },
+    {
+      "name": "1.1",
+      "branchName": "1.1.x",
+      "slug": "1.1",
+      "maintained": false
+    }
+  ]
+}


### PR DESCRIPTION
DoctrineBundle is missing the project file for the Doctrine website and this PR adds the needed info file `.doctrine-project.json`. It looks like I already had a commit in 2019 but totally forgot about this. :sweat_smile: 

Please check if the branch names and branch infos are correct.