### PR TITLE
Update Entity Listener Docs to New Service Style

### DIFF
--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -31,8 +31,7 @@ Full example:
     .. code-block:: yaml
 
         services:
-            user_listener:
-                class: \UserListener
+            UserListener:
                 tags:
                     # Minimal configuration below
                     - { name: doctrine.orm.entity_listener }
@@ -46,7 +45,7 @@ Full example:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <services>
-                <service id="user_listener" class="UserListener">
+                <service id="UserListener">
                     <!-- entity_manager attribute is optional -->
                     <tag name="doctrine.orm.entity_listener" entity_manager="custom" />
                 </service>
@@ -62,8 +61,7 @@ definition:
     .. code-block:: yaml
 
         services:
-            user_listener:
-                class: \UserListener
+            UserListener:
                 tags:
                     -
                         name: doctrine.orm.entity_listener
@@ -81,7 +79,7 @@ definition:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <services>
-                <service id="user_listener" class="UserListener">
+                <service id="UserListener">
                     <!-- entity_manager attribute is optional -->
                     <!-- method attribute is optional -->
                     <tag
@@ -116,8 +114,7 @@ are only instantiated when they are actually used.
     .. code-block:: yaml
 
         services:
-            lazy_user_listener:
-                class: \UserListener
+            UserListener:
                 tags:
                     - { name: doctrine.orm.entity_listener, lazy: true }
                     
@@ -129,7 +126,7 @@ are only instantiated when they are actually used.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <services>
-                <service id="lazy_user_listener" class="UserListener">
+                <service id="UserListener">
                     <tag name="doctrine.orm.entity_listener" event="preUpdate" entity="App\Entity\User" lazy="true" />            
                 </service>
             </services>

--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -18,7 +18,7 @@ Full example:
 
     /**
      * @ORM\Entity
-     * @ORM\EntityListeners({"UserListener"})
+     * @ORM\EntityListeners({"App\UserListener"})
      */
     class User
     {
@@ -31,7 +31,7 @@ Full example:
     .. code-block:: yaml
 
         services:
-            UserListener:
+            App\UserListener:
                 tags:
                     # Minimal configuration below
                     - { name: doctrine.orm.entity_listener }
@@ -45,7 +45,7 @@ Full example:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <services>
-                <service id="UserListener">
+                <service id="App\UserListener">
                     <!-- entity_manager attribute is optional -->
                     <tag name="doctrine.orm.entity_listener" entity_manager="custom" />
                 </service>
@@ -61,7 +61,7 @@ definition:
     .. code-block:: yaml
 
         services:
-            UserListener:
+            App\UserListener:
                 tags:
                     -
                         name: doctrine.orm.entity_listener
@@ -79,7 +79,7 @@ definition:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <services>
-                <service id="UserListener">
+                <service id="App\UserListener">
                     <!-- entity_manager attribute is optional -->
                     <!-- method attribute is optional -->
                     <tag
@@ -114,7 +114,7 @@ are only instantiated when they are actually used.
     .. code-block:: yaml
 
         services:
-            UserListener:
+            App\UserListener:
                 tags:
                     - { name: doctrine.orm.entity_listener, lazy: true }
                     
@@ -126,7 +126,7 @@ are only instantiated when they are actually used.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <services>
-                <service id="UserListener">
+                <service id="App\UserListener">
                     <tag name="doctrine.orm.entity_listener" event="preUpdate" entity="App\Entity\User" lazy="true" />            
                 </service>
             </services>


### PR DESCRIPTION
Switching to Symfony 4's new container style: classes for service names.