### PR TITLE
Add support for new MessengerTransportDoctrineSchemaSubscriber

### DIFF
--- a/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
+++ b/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Cache\Adapter\PdoAdapter;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Injects PdoAdapter into its schema subscriber.
+ *
+ * Must be run later after ResolveChildDefinitionsPass.
+ */
+class CacheSchemaSubscriberPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $subscriberId = 'doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber';
+
+        if (! $container->hasDefinition($subscriberId)) {
+            return;
+        }
+
+        $cacheAdaptersReferences = [];
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if ($definition->isAbstract() || $definition->isSynthetic()) {
+                continue;
+            }
+
+            if ($definition->getClass() !== PdoAdapter::class) {
+                continue;
+            }
+
+            $cacheAdaptersReferences[] = new Reference($id);
+        }
+
+        $container->getDefinition($subscriberId)
+            ->replaceArgument(0, $cacheAdaptersReferences);
+    }
+}

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -12,6 +12,8 @@ use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaSubscriber;
+use Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
@@ -337,6 +339,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (class_exists(AbstractType::class)) {
             $container->getDefinition('form.type.entity')->addTag('kernel.reset', ['method' => 'reset']);
+        }
+
+        // available in Symfony 5.1 and higher
+        if (! class_exists(PdoCacheAdapterDoctrineSchemaSubscriber::class)) {
+            $container->removeDefinition('doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber');
         }
 
         $entityManagers = [];
@@ -840,6 +847,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (! class_exists(DoctrineClearEntityManagerWorkerSubscriber::class)) {
             $container->removeDefinition('doctrine.orm.messenger.event_subscriber.doctrine_clear_entity_manager');
+        }
+
+        // available in Symfony 5.1 and higher
+        if (! class_exists(MessengerTransportDoctrineSchemaSubscriber::class)) {
+            $container->removeDefinition('doctrine.orm.messenger.doctrine_schema_subscriber');
         }
 
         $transportFactoryDefinition = $container->getDefinition('messenger.transport.doctrine.factory');

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubscriberPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
@@ -40,6 +41,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new ServiceRepositoryCompilerPass());
         $container->addCompilerPass(new WellKnownSchemaFilterPass());
         $container->addCompilerPass(new DbalSchemaFilterPass());
+        $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_OPTIMIZE, -10);
     }
 
     /**

--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -40,5 +40,10 @@
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="doctrine" />
         </service>
+
+        <service id="doctrine.orm.messenger.doctrine_schema_subscriber" class="Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaSubscriber">
+            <argument type="tagged" tag="messenger.receiver" />
+            <tag name="doctrine.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -133,6 +133,10 @@
 
         <!-- listeners -->
         <service id="doctrine.orm.listeners.resolve_target_entity" class="%doctrine.orm.listeners.resolve_target_entity.class%" public="false" />
+        <service id="doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber" class="Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber">
+            <argument type="collection" /> <!-- PdoAdapter instances -->
+            <tag name="doctrine.event_subscriber" />
+        </service>
 
         <!-- naming strategy -->
         <service id="doctrine.orm.naming_strategy.default" class="%doctrine.orm.naming_strategy.default.class%" public="false" />

--- a/Tests/CacheSchemaSubscriberTest.php
+++ b/Tests/CacheSchemaSubscriberTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubscriberPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CacheSchemaSubscriberTest extends TestCase
+{
+    public function testSchemaSubscriberWiring() : void
+    {
+        if (! class_exists(PdoCacheAdapterDoctrineSchemaSubscriber::class)) {
+            $this->markTestSkipped('This test requires Symfony 5.1 or higher');
+        }
+
+        $container = new ContainerBuilder(new ParameterBag([
+            'kernel.name' => 'app',
+            'kernel.debug' => false,
+            'kernel.bundles' => [],
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => 'test',
+            'kernel.root_dir' => __DIR__ . '/../../../../', // src dir
+            'kernel.project_dir' => __DIR__ . '/../../../../', // src dir
+            'kernel.bundles_metadata' => [],
+            'kernel.charset' => 'UTF-8',
+            'kernel.container_class' => ContainerBuilder::class,
+            'kernel.secret' => 'test',
+            'env(base64:default::SYMFONY_DECRYPTION_SECRET)' => 'foo',
+        ]));
+
+        $extension = new FrameworkExtension();
+        $container->registerExtension($extension);
+        $extension->load([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_adapter' => ['adapter' => 'cache.adapter.pdo'],
+                    ],
+                ],
+            ],
+        ], $container);
+
+        $extension = new DoctrineExtension();
+        $container->registerExtension($extension);
+        $extension->load([
+            [
+                'dbal' => [],
+                'orm' => [],
+            ],
+        ], $container);
+
+        $container->setAlias('test_subscriber_alias', new Alias('doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber', true));
+        // prevent my_cache_apapter from inlining
+        $container->register('uses_my_cache_adapter', 'stdClass')
+            ->addArgument(new Reference('my_cache_adapter'))
+            ->setPublic(true);
+        $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_OPTIMIZE, -10);
+        $container->compile();
+
+        // check that PdoAdapter service is injected as an argument
+        $definition = $container->findDefinition('test_subscriber_alias');
+        $this->assertEquals([new Reference('my_cache_adapter')], $definition->getArgument(0));
+    }
+}


### PR DESCRIPTION
For https://github.com/symfony/symfony/pull/36655

This adds service integration for 2 new schema subscribers. They allow `doctrine:schema:update` to automatically see tables needed by Messenger & cache.

I've tested this in a real project and it works beautifully: the table show up only when activated (i.e. when using a `doctrine` transport in messenger or configuring a real cache pool that uses the `pdo` adapter.