### PR TITLE
Update comment on the schema_filter key

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -96,8 +96,9 @@ Configuration Reference
                         platform_service:     ~
                         auto_commit:          ~
 
-                        # If set to "/^sf2_/" all tables not prefixed with "sf2_" will be ignored by the schema
-                        # tool. This is for custom tables which should not be altered automatically.
+                        # If set to "/^sf2_/" all tables, and any named objects such as sequences
+                        # not prefixed with "sf2_" will be ignored by the schema tool.
+                        # This is for custom tables which should not be altered automatically.
                         schema_filter:        ~
 
                         # When true, queries are logged to a "doctrine" monolog channel


### PR DESCRIPTION
See https://github.com/doctrine/dbal/issues/3986

The `schema_filter` key does not filter only tables.