### PR TITLE
Preload Autoloader class when the ORM is used

### DIFF
--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
@@ -10,7 +10,7 @@ doctrine:
                 memory: true
 
     orm:
-        default_entity_manager: dm2
+        default_entity_manager: default
         proxy_namespace: Proxies
         auto_generate_proxy_classes: true
         entity_managers:


### PR DESCRIPTION
The `Autoloader` class is always used on bundle boot when the ORM is used.