### PR TITLE
Fix `RunSqlDoctrineCommand` command with latest doctrine/dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/dbal": "^2.5.12",
+        "doctrine/dbal": "^2.5.12,<2.11-dev",
         "doctrine/doctrine-cache-bundle": "~1.2",
         "doctrine/persistence": "^1.3.3",
         "jdorn/sql-formatter": "^1.2.16",


### PR DESCRIPTION
Proposal to fix #1168 

To avoid the issue, I propose to restrict the version that can be retrieved as long as `doctrine/dbal` 2.11 is not released.