### PR TITLE
Add minimal compatibility with changes in DBAL 2.11 RunSqlCommand

### DIFF
--- a/Command/Proxy/RunSqlDoctrineCommand.php
+++ b/Command/Proxy/RunSqlDoctrineCommand.php
@@ -21,7 +21,6 @@ class RunSqlDoctrineCommand extends RunSqlCommand
 
         $this
             ->setName('doctrine:query:sql')
-            ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'The connection to use for this command')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command executes the given SQL query and
 outputs the results:
@@ -29,6 +28,12 @@ outputs the results:
 <info>php %command.full_name% "SELECT * FROM users"</info>
 EOT
         );
+
+        if ($this->getDefinition()->hasOption('connection')) {
+            return;
+        }
+
+        $this->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'The connection to use for this command');
     }
 
     /**


### PR DESCRIPTION
Fixes #1168 .
Supersedes #1169 .

Proper fix would be more involved, relying on interfaces in DBAL to not change, which we cannot assume won't happen at this point. Full, proper fix needs to be done once DBAL 2.11 API is stable. Such fix will probably involve deprecating our current command class as well, since DBAL one has everything our command added on top in past.