### PR TITLE
Allow DBAL 3.0 and ignore ORM tests on php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,10 @@ jobs:
 
     # Test against PHP 8
     - php: nightly
+      env: SYMFONY_DEPRECATIONS_HELPER=weak
       before_install:
         - composer config platform.php 7.4.99
+        - composer remove --dev doctrine/orm --no-update
       install:
         - travis_retry composer update -n --prefer-dist
 

--- a/Tests/Command/ImportMappingDoctrineCommandTest.php
+++ b/Tests/Command/ImportMappingDoctrineCommandTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -19,6 +20,15 @@ class ImportMappingDoctrineCommandTest extends TestCase
 
     /** @var CommandTester|null */
     private $commandTester;
+
+    public static function setUpBeforeClass()
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
 
     protected function setup()
     {

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -23,6 +24,15 @@ use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 
 class ContainerTest extends TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
     /**
      * https://github.com/doctrine/orm/pull/7953 needed, otherwise ORM classes we define services for trigger deprecations
      *

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DataCollector;
 
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -16,6 +17,10 @@ class DoctrineDataCollectorTest extends TestCase
 
     public function testCollectEntities()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $manager   = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
         $config    = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
         $factory   = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory')

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -195,6 +196,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testLoadSimpleSingleConnection()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_service_simple_single_entity_manager');
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
@@ -230,6 +235,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      */
     public function testLoadSimpleSingleConnectionWithoutDbName()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_service_simple_single_entity_manager_without_dbname');
 
         /** @var Definition $definition */
@@ -265,6 +274,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testLoadSingleConnection()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_service_single_entity_manager');
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
@@ -301,6 +314,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testLoadMultipleConnections()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_service_multiple_entity_managers');
 
         $definition = $container->getDefinition('doctrine.dbal.conn1_connection');
@@ -381,6 +398,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testEntityManagerMetadataCacheDriverConfiguration()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_service_multiple_entity_managers');
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_metadata_cache'));
@@ -395,6 +416,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      */
     public function testEntityManagerMemcacheMetadataCacheDriverConfiguration()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_service_simple_single_entity_manager_memcache');
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
@@ -418,6 +443,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      */
     public function testEntityManagerRedisMetadataCacheDriverConfigurationWithDatabaseKey()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_service_simple_single_entity_manager_redis');
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
@@ -436,6 +465,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testDependencyInjectionImportsOverrideDefaults()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_imports');
 
         $cacheDefinition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
@@ -447,6 +480,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testSingleEntityManagerMultipleMappingBundleDefinitions()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_single_em_bundle_mappings', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
@@ -485,6 +522,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testMultipleEntityManagersMappingBundleDefinitions()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_multiple_em_bundle_mappings', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
         $this->assertEquals(['em1' => 'doctrine.orm.em1_entity_manager', 'em2' => 'doctrine.orm.em2_entity_manager'], $container->getParameter('doctrine.entity_managers'), 'Set of the existing EntityManagers names is incorrect.');
@@ -527,6 +568,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testSingleEntityManagerDefaultTableOptions()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_single_em_default_table_options', ['YamlBundle', 'AnnotationsBundle', 'XmlBundle']);
 
         $param = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
@@ -557,6 +602,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testSetCustomFunctions()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_functions');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
@@ -567,6 +616,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testSetNamingStrategy()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_namingstrategy');
 
         $def1 = $container->getDefinition('doctrine.orm.em1_configuration');
@@ -578,6 +631,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testSetQuoteStrategy()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_quotestrategy');
 
         $def1 = $container->getDefinition('doctrine.orm.em1_configuration');
@@ -589,6 +646,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testSecondLevelCache()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_second_level_cache');
 
         $this->assertTrue($container->has('doctrine.orm.default_configuration'));
@@ -647,6 +708,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testSingleEMSetCustomFunctions()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_single_em_dql_functions');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
@@ -655,6 +720,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testAddCustomHydrationMode()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_hydration_mode');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
@@ -663,6 +732,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testAddFilter()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_filters');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
@@ -683,6 +756,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testResolveTargetEntity()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_resolve_target_entity');
 
         $definition = $container->getDefinition('doctrine.orm.listeners.resolve_target_entity');
@@ -693,6 +770,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testAttachEntityListeners()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_attach_entity_listener');
 
         $definition  = $container->getDefinition('doctrine.orm.default_listeners.attach_entity_listeners');
@@ -921,6 +1002,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testEntityListenerResolver()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_entity_listener_resolver', ['YamlBundle'], new EntityListenerPass());
 
         $definition = $container->getDefinition('doctrine.orm.em1_configuration');
@@ -938,6 +1023,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testAttachEntityListenerTag()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
@@ -970,6 +1059,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testAttachEntityListenersTwoConnections()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer(['YamlBundle']);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
@@ -990,6 +1083,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testAttachLazyEntityListener()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
@@ -1017,6 +1114,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testAttachLazyEntityListenerForCustomResolver()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
@@ -1039,6 +1140,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      */
     public function testLazyEntityListenerResolverWithoutCorrectInterface()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
@@ -1051,6 +1156,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testPrivateLazyEntityListener()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
@@ -1069,6 +1178,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      */
     public function testAbstractLazyEntityListener()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer([]);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
@@ -1081,6 +1194,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testRepositoryFactory()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->loadContainer('orm_repository_factory');
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -30,6 +30,10 @@ class DoctrineExtensionTest extends TestCase
      */
     public function testAutowiringAlias()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
         $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
@@ -56,6 +60,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testPublicServicesAndAliases()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
         $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
@@ -107,6 +115,10 @@ class DoctrineExtensionTest extends TestCase
      */
     public function testOrmRequiresDbal()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $extension = new DoctrineExtension();
 
         $extension->load([['orm' => ['auto_mapping' => true]]], $this->getContainer());
@@ -152,6 +164,10 @@ class DoctrineExtensionTest extends TestCase
      */
     public function testAutomapping(array $entityManagers)
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $extension = new DoctrineExtension();
 
         $container = $this->getContainer([
@@ -245,6 +261,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testDependencyInjectionConfigurationDefaults()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
         $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
@@ -373,6 +393,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testAutoGenerateProxyClasses()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
@@ -397,6 +421,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testSingleEntityManagerWithDefaultConfiguration()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
@@ -417,6 +445,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testSingleEntityManagerWithDefaultSecondLevelCacheConfiguration()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
@@ -442,6 +474,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testSingleEntityManagerWithCustomSecondLevelCacheConfiguration()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
@@ -473,6 +509,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testBundleEntityAliases()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
@@ -492,6 +532,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testOverwriteEntityAliases()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
@@ -511,6 +555,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testYamlBundleMappingDetection()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer('YamlBundle');
         $extension = new DoctrineExtension();
 
@@ -529,6 +577,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testXmlBundleMappingDetection()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer('XmlBundle');
         $extension = new DoctrineExtension();
 
@@ -556,6 +608,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testAnnotationsBundleMappingDetection()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer('AnnotationsBundle');
         $extension = new DoctrineExtension();
 
@@ -583,6 +639,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testOrmMergeConfigs()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer(['XmlBundle', 'AnnotationsBundle']);
         $extension = new DoctrineExtension();
 
@@ -640,6 +700,10 @@ class DoctrineExtensionTest extends TestCase
 
     public function testAnnotationsBundleMappingDetectionWithVendorNamespace()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer('AnnotationsBundle', 'Vendor');
         $extension = new DoctrineExtension();
 
@@ -700,6 +764,10 @@ class DoctrineExtensionTest extends TestCase
      */
     public function testDeprecatedCacheConfiguration(string $expectedAliasName, string $expectedAliasTarget, string $cacheName, $cacheConfig) : void
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
@@ -765,6 +833,10 @@ class DoctrineExtensionTest extends TestCase
      */
     public function testCacheConfiguration(string $expectedAliasName, string $expectedAliasTarget, string $cacheName, $cacheConfig) : void
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 

--- a/Tests/Mapping/ContainerEntityListenerResolverTest.php
+++ b/Tests/Mapping/ContainerEntityListenerResolverTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Mapping;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Psr\Container\ContainerInterface;
@@ -14,6 +15,15 @@ class ContainerEntityListenerResolverTest extends TestCase
 
     /** @var ContainerInterface|PHPUnit_Framework_MockObject_MockObject */
     private $container;
+
+    public static function setUpBeforeClass()
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
 
     protected function setUp()
     {

--- a/Tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/Tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -5,10 +5,20 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\Mapping;
 use Doctrine\Bundle\DoctrineBundle\Mapping\ClassMetadataCollection;
 use Doctrine\Bundle\DoctrineBundle\Mapping\DisconnectedMetadataFactory;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCase;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 class DisconnectedMetadataFactoryTest extends TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Can't find base path for "Doctrine\Bundle\DoctrineBundle\Tests\Mapping\DisconnectedMetadataFactoryTest

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -132,6 +132,10 @@ class RegistryTest extends TestCase
 
     public function testReset()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $noProxyManager = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
         $noProxyManager->expects($this->once())
             ->method('clear');
@@ -164,6 +168,10 @@ class RegistryTest extends TestCase
 
     public function testIdentityMapsStayConsistentAfterReset()
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $kernel = new TestKernel();
         $kernel->boot();
 

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -15,6 +15,15 @@ use stdClass;
 
 class ContainerRepositoryFactoryTest extends TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
     public function testGetRepositoryReturnsService()
     {
         $em        = $this->createEntityManager(['Foo\CoolEntity' => 'my_repo']);

--- a/Tests/Repository/ServiceEntityRepositoryTest.php
+++ b/Tests/Repository/ServiceEntityRepositoryTest.php
@@ -3,11 +3,21 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 
 class ServiceEntityRepositoryTest extends TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
     /**
      * @expectedException \LogicException
      * @expectedExceptionMessage Could not find the entity manager for class "Doctrine\Bundle\DoctrineBundle\Tests\Repository\TestEntity". Check your Doctrine configuration to make sure it is configured to load this entity’s metadata.

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomClassRepoEntity;
@@ -20,6 +21,15 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class ServiceRepositoryTest extends TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
     /**
      * https://github.com/doctrine/orm/pull/7953 needed, otherwise ORM classes we define services for trigger deprecations
      *

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "doctrine/dbal": "^2.5.12",
+        "doctrine/dbal": "^2.5.12|^3.0",
         "doctrine/doctrine-cache-bundle": "~1.2",
         "doctrine/persistence": "^1.3.3",
         "jdorn/sql-formatter": "^1.2.16",


### PR DESCRIPTION
On order to run at least a few tests on php 8, this PR…

* Allows DBAL 3.0 to be installed because DBAL 2 will trigger fatal errors on php 8.
* Uninstalls ORM on the php 8 build because there currently is no ORM version that allows DBAL 3.
* Skips all tests that require ORM if it's not there.
* Ignores deprecation warnings because PHPUnit will trigger lots of them. We need to upgrade PHPUnit to fix this.