### PR TITLE
Bugfix: drop database command was not working with shard argument.

### DIFF
--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -74,7 +74,7 @@ EOT
                 foreach ($shards as $shard) {
                     if ($shard['id'] === (int) $input->getOption('shard')) {
                         // Select sharded database
-                        $params = $shard;
+                        $params = array_merge($params, $shard);
                         unset($params['id']);
                         break;
                     }


### PR DESCRIPTION
The driver param is stored in global params, so the drop database for shards was throwing an exception.