### PR TITLE
[Bug] Run CacheSchemaSubscriberPass after CacheCollectorPass

### DIFF
--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -41,7 +41,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new ServiceRepositoryCompilerPass());
         $container->addCompilerPass(new WellKnownSchemaFilterPass());
         $container->addCompilerPass(new DbalSchemaFilterPass());
-        $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_OPTIMIZE, -10);
+        $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
     }
 
     /**

--- a/Tests/CacheSchemaSubscriberTest.php
+++ b/Tests/CacheSchemaSubscriberTest.php
@@ -65,7 +65,7 @@ class CacheSchemaSubscriberTest extends TestCase
         $container->register('uses_my_cache_adapter', 'stdClass')
             ->addArgument(new Reference('my_cache_adapter'))
             ->setPublic(true);
-        $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_OPTIMIZE, -10);
+        $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
         $container->compile();
 
         // check that PdoAdapter service is injected as an argument


### PR DESCRIPTION
The `CacheCollectorPass` of the Cache component decorates the cache adapters with
a `TracingAdapter` which breaks the expectation that the provided Adapter provided to
the `CacheSchemaSubscriber` is a `PdoAdapter` with the `configureSchema` method.

By running the `CacheSchemaSubscriberPass` after the `CacheCollectorPass` only
the actual Adapters (not decorated one) are correctly provided.

Note: This bug only happens when debugging *and* the profiler is enabled.

/cc @weaverryan 