### PR TITLE
Allow passing a custom connection factory for DBAL

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -124,6 +124,7 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('slave')
             ->fixXmlConfig('shard')
             ->fixXmlConfig('default_table_option')
+            ->fixXmlConfig('factory_argument')
             ->children()
                 ->scalarNode('driver')->defaultValue('pdo_mysql')->end()
                 ->scalarNode('platform_service')->end()
@@ -157,6 +158,10 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('default_table_options')
                     ->info("This option is used by the schema-tool and affects generated SQL. Possible keys include 'charset','collate', and 'engine'.")
                     ->useAttributeAsKey('name')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->scalarNode('factory')->end()
+                ->arrayNode('factory_arguments')
                     ->prototype('scalar')->end()
                 ->end()
             ->end();

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -117,7 +117,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function loadDbalConnection($name, array $connection, ContainerBuilder $container)
     {
-        $configuration = $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name), new ChildDefinition('doctrine.dbal.connection.configuration'));
+        $configuration       = $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name), new ChildDefinition('doctrine.dbal.connection.configuration'));
         $connectionServiceId = sprintf('doctrine.dbal.%s_connection', $name);
 
         if (isset($connection['factory'])) {
@@ -132,7 +132,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             return;
         }
 
-        $logger        = null;
+        $logger = null;
         if ($connection['logging']) {
             $logger = new Reference('doctrine.dbal.logger');
         }

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -40,6 +40,7 @@
         <xsd:attribute name="profiling-collect-schema-errors" type="xsd:string" default="true" />
         <xsd:attribute name="server-version" type="xsd:string" />
         <xsd:attribute name="use-savepoints" type="xsd:boolean" />
+        <xsd:attribute name="factory" type="xsd:string" />
         <xsd:attributeGroup ref="driver-config" />
     </xsd:attributeGroup>
 
@@ -80,6 +81,7 @@
             <xsd:element name="slave" type="slave" />
             <xsd:element name="shard" type="shard" />
             <xsd:element name="default-table-option" type="named_scalar" />
+            <xsd:element name="factory-argument" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
     </xsd:group>
 

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1030,17 +1030,17 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'setRepositoryFactory', ['repository_factory']);
     }
 
-    public function testConnectionFactoryWithParameters(): void
+    public function testConnectionFactoryWithParameters() : void
     {
         $container = $this->getContainer([]);
         $container->registerExtension(new DoctrineExtension());
         $this->loadFromFile($container, 'dbal_connection_factory');
 
-        $mockConnection = $this->createMock(Connection::class);
-        $actualDatabaseId = null;
+        $mockConnection      = $this->createMock(Connection::class);
+        $actualDatabaseId    = null;
         $actualDatabaseIndex = null;
-        $container->set('my_connection_factory', function(string $databaseId, int $databaseIndex) use (&$actualDatabaseId, &$actualDatabaseIndex, $mockConnection) {
-            $actualDatabaseId = $databaseId;
+        $container->set('my_connection_factory', static function (string $databaseId, int $databaseIndex) use (&$actualDatabaseId, &$actualDatabaseIndex, $mockConnection) {
+            $actualDatabaseId    = $databaseId;
             $actualDatabaseIndex = $databaseIndex;
 
             return $mockConnection;

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_connection_factory.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_connection_factory.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal factory="my_connection_factory">
+            <factory-argument>my_database_id</factory-argument>
+            <factory-argument>21</factory-argument>
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_connection_factory.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_connection_factory.yml
@@ -1,0 +1,6 @@
+doctrine:
+  dbal:
+    factory: my_connection_factory
+    factory_arguments:
+      - my_database_id
+      - 21


### PR DESCRIPTION
This resolves #1178. My goal is to allow resolving connection string and other connection parameters at runtime.
Happy to discuss different approaches, if this is not the right solution.