### PR TITLE
Deprecate ImportDoctrineCommand

### DIFF
--- a/Command/Proxy/ImportDoctrineCommand.php
+++ b/Command/Proxy/ImportDoctrineCommand.php
@@ -7,8 +7,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+@trigger_error(sprintf('The "%s" (doctrine:database:import) command is deprecated, use a database client instead.', ImportDoctrineCommand::class), E_USER_DEPRECATED);
+
 /**
  * Loads an SQL file and executes it.
+ *
+ * @deprecated Use a database client application instead.
  */
 class ImportDoctrineCommand extends ImportCommand
 {


### PR DESCRIPTION
As base command `Doctrine\DBAL\Tools\Console\Command\ImportCommand` had been deprecated in 2.x and removed 3.x, this command should be deprecated as well.