### PR TITLE
Address deprecation of Definition::setPrivate()

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -850,7 +850,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $definition = $container->register($serviceId, DoctrineProvider::class);
         $definition->addArgument(new Reference($poolName));
-        $definition->setPrivate(true);
 
         return $serviceId;
     }


### PR DESCRIPTION
~The call might be useless in many versions of Symfony, not sure it's
useless for all of them though. setPrivate is deprecated since 5.2, in
favor of setPublic which is available since 2.0.~



Services are private by default since symfony/dependency-injection 4.0,
which means the deprecated call can safely be dropped.