### PR TITLE
Add PhpArrayAdapter to cache metadata

### DIFF
--- a/CacheWarmer/DoctrineMetadataCacheWarmer.php
+++ b/CacheWarmer/DoctrineMetadataCacheWarmer.php
@@ -22,10 +22,8 @@ class DoctrineMetadataCacheWarmer extends AbstractPhpFileCacheWarmer
 
     /**
      * @param string $cacheDir
-     *
-     * @return bool false if there is nothing to warm-up
      */
-    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter)
+    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter): bool
     {
         $metadataFactory = new ClassMetadataFactory();
         $metadataFactory->setEntityManager($this->entityManager);

--- a/CacheWarmer/DoctrineMetadataCacheWarmer.php
+++ b/CacheWarmer/DoctrineMetadataCacheWarmer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\CacheWarmer;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\AbstractPhpFileCacheWarmer;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\DoctrineProvider;
+
+class DoctrineMetadataCacheWarmer extends AbstractPhpFileCacheWarmer
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager, string $phpArrayFile)
+    {
+        $this->entityManager = $entityManager;
+
+        parent::__construct($phpArrayFile);
+    }
+
+    /**
+     * @param string $cacheDir
+     *
+     * @return bool false if there is nothing to warm-up
+     */
+    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter)
+    {
+        $metadataFactory = new ClassMetadataFactory();
+        $metadataFactory->setEntityManager($this->entityManager);
+        $metadataFactory->setCacheDriver(new DoctrineProvider($arrayAdapter));
+        $metadataFactory->getAllMetadata();
+
+        return true;
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -688,6 +688,13 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('pool')->end()
             ->end();
 
+        if ($name === 'metadata_cache_driver') {
+            $node->setDeprecated(...$this->getDeprecationMsg(
+                'The "metadata_cache_driver" configuration key is deprecated. PHP Array cache is now automatically registered when %kernel.debug% is false.',
+                '2.2'
+            ));
+        }
+
         return $node;
     }
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -818,10 +818,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $this->loadCacheDriver('result_cache', $entityManager['name'], $entityManager['result_cache_driver'], $container);
         $this->loadCacheDriver('query_cache', $entityManager['name'], $entityManager['query_cache_driver'], $container);
 
-        if (! $container->getParameter('kernel.debug')) {
-            $this->registerMetadataPhpArrayCacheWarmer($entityManager['name'], $container);
-            $this->registerMetadataPhpArrayCache($entityManager['name'], $container);
+        if ($container->getParameter('kernel.debug')) {
+            return;
         }
+
+        $this->registerMetadataPhpArrayCaching($entityManager['name'], $container);
     }
 
     /**
@@ -936,35 +937,24 @@ class DoctrineExtension extends AbstractDoctrineExtension
         return $id;
     }
 
-    private function registerMetadataPhpArrayCacheWarmer(string $entityManagerName, ContainerBuilder $container): void
+    private function registerMetadataPhpArrayCaching(string $entityManagerName, ContainerBuilder $container): void
     {
-        $cacheWarmerDefinition = $container->register(sprintf('doctrine.orm.%s_metadata_cache.php_array_warmer', $entityManagerName), DoctrineMetadataCacheWarmer::class);
-        $cacheWarmerDefinition->setArguments([
-            new Reference(sprintf('doctrine.orm.%s_entity_manager', $entityManagerName)),
-            $this->getPhpArrayFile($entityManagerName),
-        ]);
-        $cacheWarmerDefinition->addTag('kernel.cache_warmer');
-    }
+        $metadataCacheAlias              = $this->getObjectManagerElementName($entityManagerName . '_metadata_cache');
+        $decoratedMetadataCacheServiceId = (string) $container->getAlias($metadataCacheAlias);
+        $phpArrayCacheDecoratorServiceId = $decoratedMetadataCacheServiceId . '.php_array';
+        $phpArrayFile                    = '%kernel.cache_dir%' . sprintf('/doctrine/orm/%s_metadata.php', $entityManagerName);
 
-    private function registerMetadataPhpArrayCache(string $entityManagerName, ContainerBuilder $container): void
-    {
-        $aliasId   = sprintf('doctrine.orm.%s_metadata_cache', $entityManagerName);
-        $serviceId = (string) $container->getAlias($aliasId);
+        $container->register(DoctrineMetadataCacheWarmer::class)
+            ->setArguments([new Reference(sprintf('doctrine.orm.%s_entity_manager', $entityManagerName)), $phpArrayFile])
+            ->addTag('kernel.cache_warmer');
 
-        $phpArrayAdapterDefinition = new Definition(PhpArrayAdapter::class, [
-            $this->getPhpArrayFile($entityManagerName),
-            new Definition(DoctrineAdapter::class, [new Reference($serviceId)]),
-        ]);
-
-        $serviceId .= '.php_array';
-
-        $doctrineCacheDefinition = $container->register($serviceId, DoctrineProvider::class);
-        $doctrineCacheDefinition->addArgument($phpArrayAdapterDefinition);
-        $container->setAlias($aliasId, $serviceId);
-    }
-
-    private function getPhpArrayFile(string $entityManagerName): string
-    {
-        return '%kernel.cache_dir%' . sprintf('/doctrine/orm/%s_metadata.php', $entityManagerName);
+        $container->setAlias($metadataCacheAlias, $phpArrayCacheDecoratorServiceId);
+        $container->register($phpArrayCacheDecoratorServiceId, DoctrineProvider::class)
+            ->addArgument(
+                new Definition(PhpArrayAdapter::class, [
+                    $phpArrayFile,
+                    new Definition(DoctrineAdapter::class, [new Reference($decoratedMetadataCacheServiceId)]),
+                ])
+            );
     }
 }

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -12,6 +12,8 @@ use LogicException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -345,6 +347,18 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('doctrine.orm.default_entity_listener_resolver', (string) $calls[12][1][0]);
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
+        $this->assertEquals(DoctrineProvider::class, $definition->getClass());
+        $arguments = $definition->getArguments();
+        $this->assertInstanceOf(Definition::class, $arguments[0]);
+        $this->assertEquals(PhpArrayAdapter::class, $arguments[0]->getClass());
+        $arguments = $arguments[0]->getArguments();
+        $this->assertSame('%kernel.cache_dir%/doctrine/orm/default_metadata.php', $arguments[0]);
+        $this->assertInstanceOf(Definition::class, $arguments[1]);
+        $this->assertEquals(DoctrineAdapter::class, $arguments[1]->getClass());
+        $arguments = $arguments[1]->getArguments();
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
+        $this->assertEquals('doctrine.orm.cache.provider.cache.doctrine.orm.default.metadata', (string) $arguments[0]);
+        $definition = $container->getDefinition((string) $arguments[0]);
         $this->assertEquals(DoctrineProvider::class, $definition->getClass());
         $arguments = $definition->getArguments();
         $this->assertInstanceOf(Reference::class, $arguments[0]);
@@ -803,7 +817,7 @@ class DoctrineExtensionTest extends TestCase
         return [
             'metadata_cache_default' => [
                 'expectedAliasName' => 'doctrine.orm.default_metadata_cache',
-                'expectedAliasTarget' => 'doctrine.orm.cache.provider.cache.doctrine.orm.default.metadata',
+                'expectedAliasTarget' => 'doctrine.orm.cache.provider.cache.doctrine.orm.default.metadata.php_array',
                 'cacheName' => 'metadata_cache_driver',
                 'cacheConfig' => ['type' => null],
             ],
@@ -822,7 +836,7 @@ class DoctrineExtensionTest extends TestCase
 
             'metadata_cache_pool' => [
                 'expectedAliasName' => 'doctrine.orm.default_metadata_cache',
-                'expectedAliasTarget' => 'doctrine.orm.cache.provider.metadata_cache_pool',
+                'expectedAliasTarget' => 'doctrine.orm.cache.provider.metadata_cache_pool.php_array',
                 'cacheName' => 'metadata_cache_driver',
                 'cacheConfig' => ['type' => 'pool', 'pool' => 'metadata_cache_pool'],
             ],
@@ -841,7 +855,7 @@ class DoctrineExtensionTest extends TestCase
 
             'metadata_cache_service' => [
                 'expectedAliasName' => 'doctrine.orm.default_metadata_cache',
-                'expectedAliasTarget' => 'service_target_metadata',
+                'expectedAliasTarget' => 'service_target_metadata.php_array',
                 'cacheName' => 'metadata_cache_driver',
                 'cacheConfig' => ['type' => 'service', 'id' => 'service_target_metadata'],
             ],

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -766,6 +766,9 @@ class DoctrineExtensionTest extends TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidCacheConfiguration(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {
@@ -812,7 +815,16 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals($expectedAliasTarget, (string) $alias);
     }
 
-    public static function cacheConfigurationProvider(): array
+    /**
+     * @dataProvider legacyCacheConfigurationProvider
+     * @group legacy
+     */
+    public function testLegacyCacheConfiguration(string $expectedAliasName, string $expectedAliasTarget, string $cacheName, array $cacheConfig): void
+    {
+        $this->testCacheConfiguration($expectedAliasName, $expectedAliasTarget, $cacheName, $cacheConfig);
+    }
+
+    public static function legacyCacheConfigurationProvider(): array
     {
         return [
             'metadata_cache_default' => [
@@ -821,6 +833,24 @@ class DoctrineExtensionTest extends TestCase
                 'cacheName' => 'metadata_cache_driver',
                 'cacheConfig' => ['type' => null],
             ],
+            'metadata_cache_pool' => [
+                'expectedAliasName' => 'doctrine.orm.default_metadata_cache',
+                'expectedAliasTarget' => 'doctrine.orm.cache.provider.metadata_cache_pool.php_array',
+                'cacheName' => 'metadata_cache_driver',
+                'cacheConfig' => ['type' => 'pool', 'pool' => 'metadata_cache_pool'],
+            ],
+            'metadata_cache_service' => [
+                'expectedAliasName' => 'doctrine.orm.default_metadata_cache',
+                'expectedAliasTarget' => 'service_target_metadata.php_array',
+                'cacheName' => 'metadata_cache_driver',
+                'cacheConfig' => ['type' => 'service', 'id' => 'service_target_metadata'],
+            ],
+        ];
+    }
+
+    public static function cacheConfigurationProvider(): array
+    {
+        return [
             'query_cache_default' => [
                 'expectedAliasName' => 'doctrine.orm.default_query_cache',
                 'expectedAliasTarget' => 'doctrine.orm.cache.provider.cache.doctrine.orm.default.query',
@@ -833,13 +863,6 @@ class DoctrineExtensionTest extends TestCase
                 'cacheName' => 'result_cache_driver',
                 'cacheConfig' => ['type' => null],
             ],
-
-            'metadata_cache_pool' => [
-                'expectedAliasName' => 'doctrine.orm.default_metadata_cache',
-                'expectedAliasTarget' => 'doctrine.orm.cache.provider.metadata_cache_pool.php_array',
-                'cacheName' => 'metadata_cache_driver',
-                'cacheConfig' => ['type' => 'pool', 'pool' => 'metadata_cache_pool'],
-            ],
             'query_cache_pool' => [
                 'expectedAliasName' => 'doctrine.orm.default_query_cache',
                 'expectedAliasTarget' => 'doctrine.orm.cache.provider.query_cache_pool',
@@ -851,13 +874,6 @@ class DoctrineExtensionTest extends TestCase
                 'expectedAliasTarget' => 'doctrine.orm.cache.provider.result_cache_pool',
                 'cacheName' => 'result_cache_driver',
                 'cacheConfig' => ['type' => 'pool', 'pool' => 'result_cache_pool'],
-            ],
-
-            'metadata_cache_service' => [
-                'expectedAliasName' => 'doctrine.orm.default_metadata_cache',
-                'expectedAliasTarget' => 'service_target_metadata.php_array',
-                'cacheName' => 'metadata_cache_driver',
-                'cacheConfig' => ['type' => 'service', 'id' => 'service_target_metadata'],
             ],
             'query_cache_service' => [
                 'expectedAliasName' => 'doctrine.orm.default_query_cache',

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -13,3 +13,4 @@ Configuration
     * `doctrine.dbal.keep_slave`. Use `doctrine.dbal.keep_replica`
     
     Similarly, if you use XML configuration, please replace `<slave>` with `<replica>`.
+ * The `metadata_cache_driver` configuration key has been deprecated. PHP Array cache is now automatically registered when `%kernel.debug%` is false.


### PR DESCRIPTION
Closes #1186

cc @ostrolucky @dmaicher @nicolas-grekas 

I see two weak places in this implementation:
1. `DoctrineMetadataCacheWarmer` extends `AbstractPhpFileCacheWarmer` which also extended by `ValidatorCacheWarmer`, `SerializerCacheWarmer` and `AnnotationsCacheWarmer` (everywhere `PhpArrayAdapter` used) but it's marked as internal, so BC breaks possible here. I can avoid extending this class but a lot of code will be copy-pasted.
2. Since `PhpArrayAdapter` requires Symfony cache I wrap Doctrine cache with `DoctrineAdapter`. If Doctrine cache is `DoctrineProvider` which wrap a Symfony cache we get a redudant chain of adapters. For example the chain `PhpArrayAdapter -> DoctrineAdapter -> DoctrineProvider -> RedisAdapter` can be simplified by removing `DoctrineAdapter` and `DoctrineProvider`: `PhpArrayAdapter -> RedisAdapter`. I've tried to create a compiler pass which remove this redundancy but get list of entity managers in compiler pass a little bit difficult. And maybe we can implement this simplification in Symfony framework bundle globally for all such cache chains.

What is your opinion about this?