### PR TITLE
Fix master-slaves deprecation from dbal 2.11

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -57,6 +57,11 @@ EOT
             $params = $params['master'];
         }
 
+        // Since doctrine/dbal 2.11 master has been replaced by primary
+        if (isset($params['primary'])) {
+            $params = $params['primary'];
+        }
+
         // Cannot inject `shard` option in parent::getDoctrineConnection
         // cause it will try to connect to a non-existing database
         if (isset($params['shards'])) {

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -66,6 +66,11 @@ EOT
             $params = $params['master'];
         }
 
+        // Since doctrine/dbal 2.11 master has been replaced by primary
+        if (isset($params['primary'])) {
+            $params = $params['primary'];
+        }
+
         if (isset($params['shards'])) {
             $shards = $params['shards'];
             // Default select global


### PR DESCRIPTION
Since dbal 2.11 MasterSlaveConnection is deprecated and the `doctrine:database:create` and` doctrine:database:drop` commands no longer work with the "slaves" option. https://github.com/doctrine/dbal/pull/4054

Issue : #1214 