### PR TITLE
Make method signature compatible with DBAL 2 and 3

### DIFF
--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -111,7 +111,7 @@ class FakeDriver implements Driver
         throw new Exception('not implemented');
     }
 
-    public function getSchemaManager(Connection $conn) : void
+    public function getSchemaManager(Connection $conn, ?AbstractPlatform $platform = null) : void
     {
         throw new Exception('not implemented');
     }


### PR DESCRIPTION
[In DBAL 2][dbal-2], the signature is: `public function getSchemaManager(Connection $conn);`
[In DBAL 3][dbal-3], there is a new argument: `public function getSchemaManager(Connection $conn, AbstractPlatform $platform);`

This should fix the php 8 job which is the only one which seems to be installing DBAL 3.

[dbal-2]: https://github.com/doctrine/dbal/blob/787c1411233f0fd403565bdb9708d664ced70fe1/lib/Doctrine/DBAL/Driver.php#L42
[dbal-3]: https://github.com/doctrine/dbal/blob/7a5da364badc91edac7022d6e1249c73fd917be3/src/Driver.php#L42