### PR TITLE
Add missing method

### DIFF
--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
@@ -124,6 +125,11 @@ class FakeDriver implements Driver
     public function getDatabase(Connection $conn) : string
     {
         return 'fake_db';
+    }
+
+    public function getExceptionConverter() : ExceptionConverter
+    {
+        throw new Exception('not implemented');
     }
 }
 


### PR DESCRIPTION
In doctrine/dbal 3, [the Driver interface contains an extra method](github.com/doctrine/dbal/blob/7a5da364badc91edac7022d6e1249c73fd917be3/src/Driver.php#L47)

Note that this still does not fix the PHP 8 build, and reveals a lot more issues. I think upgrading to PHPUnit 9.3 will help.