### PR TITLE
Only trigger deprecation when command is executed

### DIFF
--- a/Command/Proxy/ImportDoctrineCommand.php
+++ b/Command/Proxy/ImportDoctrineCommand.php
@@ -7,8 +7,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-@trigger_error(sprintf('The "%s" (doctrine:database:import) command is deprecated, use a database client instead.', ImportDoctrineCommand::class), E_USER_DEPRECATED);
-
 /**
  * Loads an SQL file and executes it.
  *
@@ -33,6 +31,8 @@ class ImportDoctrineCommand extends ImportCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error(sprintf('The "%s" (doctrine:database:import) command is deprecated, use a database client instead.', ImportDoctrineCommand::class), E_USER_DEPRECATED);
+
         DoctrineCommandHelper::setApplicationConnection($this->getApplication(), $input->getOption('connection'));
 
         return parent::execute($input, $output);


### PR DESCRIPTION
The bundle always registers this command. This means that this deprecation is always triggered on every `bin/console` call and the user has no way to fix this deprecation.

This PR proposes to move the deprecation to the `execute()` method - such that it is only triggered when using the command. Moving it in the constructor/`configure()` method does not work, as that is called when using `bin/console` or `bin/console list`.