### PR TITLE
Remove unneeded BC layer

### DIFF
--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -7,7 +7,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\Persistence\ObjectRepository;
-use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
@@ -25,14 +24,8 @@ final class ContainerRepositoryFactory implements RepositoryFactory
     /**
      * @param ContainerInterface $container A service locator containing the repositories
      */
-    public function __construct(ContainerInterface $container = null)
+    public function __construct(ContainerInterface $container)
     {
-        // When DoctrineBundle requires Symfony 3.3+, this can be removed
-        // and the $container argument can become required.
-        if ($container === null) {
-            throw new InvalidArgumentException(sprintf('The first argument of %s::__construct() is required on Symfony 3.3 or higher.', self::class));
-        }
-
         $this->container = $container;
     }
 


### PR DESCRIPTION
Symfony <3.3 compat was dropped in https://github.com/doctrine/DoctrineBundle/commit/fe2d0dc803cc18cd02177251b24bd9ffd2882bfe, this code is not needed anymore.