### PR TITLE
#1235 Resolve DBAL 2.11 master/slave deprecations

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -7,6 +7,8 @@ use Doctrine\Bundle\DoctrineBundle\Dbal\RegexSchemaAssetFilter;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
+use Doctrine\DBAL\Connections\MasterSlaveConnection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Tools\Console\ConnectionProvider;
 use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\UnitOfWork;
@@ -239,7 +241,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'options' => 'driverOptions',
                 'driver_class' => 'driverClass',
                 'wrapper_class' => 'wrapperClass',
-                'keep_slave' => 'keepSlave',
+                'keep_slave' => class_exists(PrimaryReadReplicaConnection::class) ? 'keepReplica' : 'keepSlave',
+                'keep_replica' => 'keepReplica',
+                'replicas' => 'replica',
                 'shard_choser' => 'shardChoser',
                 'shard_manager_class' => 'shardManagerClass',
                 'server_version' => 'serverVersion',
@@ -254,21 +258,24 @@ class DoctrineExtension extends AbstractDoctrineExtension
             unset($options[$old]);
         }
 
-        if (! empty($options['slaves']) && ! empty($options['shards'])) {
+        if (! empty($options['slaves']) && ! empty($options['replica']) && ! empty($options['shards'])) {
             throw new InvalidArgumentException('Sharding and master-slave connection cannot be used together');
         }
 
-        if (! empty($options['slaves'])) {
+        if (! empty($options['slaves']) || ! empty($options['replica'])) {
             $nonRewrittenKeys = [
                 'driver' => true,
                 'driverOptions' => true,
                 'driverClass' => true,
                 'wrapperClass' => true,
                 'keepSlave' => true,
+                'keepReplica' => true,
                 'shardChoser' => true,
                 'platform' => true,
                 'slaves' => true,
                 'master' => true,
+                'primary' => true,
+                'replica' => true,
                 'shards' => true,
                 'serverVersion' => true,
                 'defaultTableOptions' => true,
@@ -283,16 +290,18 @@ class DoctrineExtension extends AbstractDoctrineExtension
                     continue;
                 }
 
-                $options['master'][$key] = $value;
+                $options[class_exists(PrimaryReadReplicaConnection::class) ? 'primary' : 'master'][$key] = $value;
                 unset($options[$key]);
             }
 
             if (empty($options['wrapperClass'])) {
-                // Change the wrapper class only if the user does not already forced using a custom one.
-                $options['wrapperClass'] = 'Doctrine\\DBAL\\Connections\\MasterSlaveConnection';
+                // Change the wrapper class only if user did not configure custom one.
+                $options['wrapperClass'] = class_exists(PrimaryReadReplicaConnection::class) ?
+                    PrimaryReadReplicaConnection::class : // dbal >= 2.11
+                    MasterSlaveConnection::class; // dbal < 2.11
             }
         } else {
-            unset($options['slaves']);
+            unset($options['slaves'], $options['replica']);
         }
 
         if (! empty($options['shards'])) {
@@ -302,9 +311,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'driverClass' => true,
                 'wrapperClass' => true,
                 'keepSlave' => true,
+                'keepReplica' => true,
                 'shardChoser' => true,
                 'platform' => true,
                 'slaves' => true,
+                'replica' => true,
                 'global' => true,
                 'shards' => true,
                 'serverVersion' => true,

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -29,6 +29,7 @@
         <xsd:attribute name="driver-class" type="xsd:string" />
         <xsd:attribute name="wrapper-class" type="xsd:string" />
         <xsd:attribute name="keep-slave" type="xsd:string" />
+        <xsd:attribute name="keep-replica" type="xsd:string" />
         <xsd:attribute name="platform-service" type="xsd:string" />
         <xsd:attribute name="shard-choser" type="xsd:string" />
         <xsd:attribute name="shard-choser-service" type="xsd:string" />
@@ -77,7 +78,8 @@
         <xsd:choice>
             <xsd:element name="option" type="option" />
             <xsd:element name="mapping-type" type="named_scalar" />
-            <xsd:element name="slave" type="slave" />
+            <xsd:element name="slave" type="replica" />
+            <xsd:element name="replica" type="replica" />
             <xsd:element name="shard" type="shard" />
             <xsd:element name="default-table-option" type="named_scalar" />
         </xsd:choice>
@@ -109,7 +111,7 @@
         <xsd:attributeGroup ref="connection-config" />
     </xsd:complexType>
 
-    <xsd:complexType name="slave">
+    <xsd:complexType name="replica">
         <xsd:attribute name="name" type="xsd:string" use="required" />
         <xsd:attributeGroup ref="driver-config" />
     </xsd:complexType>

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -116,7 +116,7 @@ Configuration Reference
                         wrapper_class:        ~
                         shard_choser:         ~
                         shard_choser_service: ~
-                        keep_slave:           ~
+                        keep_replica:           ~
 
                         # An array of options
                         options:
@@ -135,9 +135,9 @@ Configuration Reference
                             # collate:      utf8_unicode_ci
                             # engine:       InnoDB
 
-                        slaves:
-                            # A collection of named slave connections (e.g. slave1, slave2)
-                            slave1:
+                        replicas:
+                            # A collection of named replica connections (e.g. replica1, replica2)
+                            replica1:
                                 dbname:               ~
                                 host:                 localhost
                                 port:                 ~
@@ -474,7 +474,7 @@ Configuration Reference
                         wrapper-class=""
                         shard-choser=""
                         shard-choser-service=""
-                        keep-slave=""
+                        keep-replica=""
                     >
 
                         <!-- example -->
@@ -504,8 +504,8 @@ Configuration Reference
                         <!-- sslcrl: The name of a file containing the SSL certificate revocation list (CRL) -->
                         <!-- pooled: True to use a pooled server with the oci8/pdo_oracle driver -->
                         <!-- MultipleActiveResultSets: Configuring MultipleActiveResultSets for the pdo_sqlsrv driver -->
-                        <doctrine:slave
-                            name="slave1"
+                        <doctrine:replica
+                            name="replica1"
                             dbname=""
                             host="localhost"
                             port="null"

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_master_slave_connection.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_master_slave_connection.xml
@@ -7,8 +7,8 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal dbname="mysql_db" user="mysql_user" password="mysql_s3cr3t" unix-socket="/path/to/mysqld.sock" keep-slave="true">
-            <slave name="slave1" dbname="slave_db" user="slave_user" password="slave_s3cr3t" unix-socket="/path/to/mysqld_slave.sock" />
+        <dbal dbname="mysql_db" user="mysql_user" password="mysql_s3cr3t" unix-socket="/path/to/mysqld.sock" keep-replica="true">
+            <replica name="replica1" dbname="replica_db" user="replica_user" password="replica_s3cr3t" unix-socket="/path/to/mysqld_replica.sock" />
             <default-table-option name="engine">InnoDB</default-table-option>
         </dbal>
     </config>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_master_slave_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_master_slave_connection.yml
@@ -4,12 +4,12 @@ doctrine:
         user: mysql_user
         password: mysql_s3cr3t
         unix_socket: /path/to/mysqld.sock
-        keep_slave: true
+        keep_replica: true
         default_table_options:
             engine: InnoDB
-        slaves:
-            slave1:
-                user: slave_user
-                dbname: slave_db
-                password: slave_s3cr3t
-                unix_socket: /path/to/mysqld_slave.sock
+        replicas:
+            replica1:
+                user: replica_user
+                dbname: replica_db
+                password: replica_s3cr3t
+                unix_socket: /path/to/mysqld_replica.sock

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -5,3 +5,11 @@ Commands
 --------
 
  * `doctrine:query:sql` command has been deprecated. Use `dbal:run-sql` command instead.
+ 
+Configuration
+--------
+ * Following the [changes in DBAL 2.11](https://github.com/doctrine/dbal/pull/4054), we deprecated following configuration keys:
+    * `doctrine.dbal.slaves`. Use `doctrine.dbal.replicas`
+    * `doctrine.dbal.keep_slave`. Use `doctrine.dbal.keep_replica`
+    
+    Similarly, if you use XML configuration, please replace `<slave>` with `<replica>`.


### PR DESCRIPTION
One problem of this is is that I could not follow DBALs slaves -> replica exactly. Users have `replicas` in YAML instead. This appears to be a limitation of symfony config component, see https://github.com/symfony/symfony/pull/14053#issuecomment-86105385.