### PR TITLE
Fix #1230 - Console commands do not respect driverOptions when master/slave configuration is used

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -261,7 +261,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if (! empty($options['slaves'])) {
             $nonRewrittenKeys = [
                 'driver' => true,
-                'driverOptions' => true,
                 'driverClass' => true,
                 'wrapperClass' => true,
                 'keepSlave' => true,

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -126,6 +126,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'mysql_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
+                'driverOptions' => [],
             ],
             $param['master']
         );


### PR DESCRIPTION
@stof could you please check this, you were the one adding driverOptions to this blacklist, so there is a tiny chance you would know if that was on purpose