### PR TITLE
Add navigator.clipboard condition

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -270,14 +270,14 @@
 
                                 <div id="formatted-query-{{ i }}-{{ loop.parent.loop.index }}" class="sql-runnable hidden">
                                     {{ query.sql|doctrine_format_sql(highlight = true) }}
-                                    <button class="btn btn-sm" data-clipboard-text="{{ query.sql|doctrine_format_sql(highlight = false)|e('html_attr') }}">Copy</button>
+                                    <button class="btn btn-sm hidden" data-clipboard-text="{{ query.sql|doctrine_format_sql(highlight = false)|e('html_attr') }}">Copy</button>
                                 </div>
 
                                 {% if query.runnable %}
                                     <div id="original-query-{{ i }}-{{ loop.parent.loop.index }}" class="sql-runnable hidden">
                                         {% set runnable_sql = (query.sql ~ ';')|doctrine_replace_query_parameters(query.params) %}
                                         {{ runnable_sql|doctrine_prettify_sql }}
-                                        <button class="btn btn-sm" data-clipboard-text="{{ runnable_sql|e('html_attr') }}">Copy</button>
+                                        <button class="btn btn-sm hidden" data-clipboard-text="{{ runnable_sql|e('html_attr') }}">Copy</button>
                                     </div>
                                 {% endif %}
 
@@ -516,11 +516,14 @@
             }
         {% endif %}
 
-        document.querySelectorAll('[data-clipboard-text]').forEach(function(button) {
-            button.addEventListener('click', function() {
-                navigator.clipboard.writeText(button.getAttribute('data-clipboard-text'));
-            })
-        });
+        if (navigator.clipboard) {
+            document.querySelectorAll('[data-clipboard-text]').forEach(function(button) {
+                Sfjs.removeClass(button, 'hidden');
+                button.addEventListener('click', function() {
+                    navigator.clipboard.writeText(button.getAttribute('data-clipboard-text'));
+                })
+            });
+        }
 
         //]]></script>
 {% endblock %}


### PR DESCRIPTION
Hi. I am getting the following JS error when clicking "Copy" button in Web profiler.

> 250f859?panel=db:2616 Uncaught TypeError: Cannot read property 'writeText' of undefined
    at HTMLButtonElement.<anonymous> (50f859?panel=db:2616)

That happens because the Clipboard API is only avaible for secured (HTTPS) connections. Given HTTP is still widely used escpeially on local dev environments I propose hide the "Copy" buttons when it is not supported.