### PR TITLE
Make master connections respect driverOptions

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -53,20 +53,20 @@ EOT
         $ifNotExists = $input->getOption('if-not-exists');
 
         $driverOptions = [];
-        $params = $connection->getParams();
+        $params        = $connection->getParams();
 
         if (isset($params['driverOptions'])) {
-            $driverOptions = $params['driverOptions']
+            $driverOptions = $params['driverOptions'];
         }
 
         if (isset($params['master'])) {
-            $params = $params['master'];
+            $params                  = $params['master'];
             $params['driverOptions'] = $driverOptions;
         }
 
         // Since doctrine/dbal 2.11 master has been replaced by primary
         if (isset($params['primary'])) {
-            $params = $params['primary'];
+            $params                  = $params['primary'];
             $params['driverOptions'] = $driverOptions;
         }
 

--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -52,14 +52,22 @@ EOT
 
         $ifNotExists = $input->getOption('if-not-exists');
 
+        $driverOptions = [];
         $params = $connection->getParams();
+
+        if (isset($params['driverOptions'])) {
+            $driverOptions = $params['driverOptions']
+        }
+
         if (isset($params['master'])) {
             $params = $params['master'];
+            $params['driverOptions'] = $driverOptions;
         }
 
         // Since doctrine/dbal 2.11 master has been replaced by primary
         if (isset($params['primary'])) {
             $params = $params['primary'];
+            $params['driverOptions'] = $driverOptions;
         }
 
         // Cannot inject `shard` option in parent::getDoctrineConnection

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -62,20 +62,20 @@ EOT
         $ifExists = $input->getOption('if-exists');
         
         $driverOptions = [];
-        $params = $connection->getParams();
-        
+        $params        = $connection->getParams();
+
         if (isset($params['driverOptions'])) {
-            $driverOptions = $params['driverOptions']
+            $driverOptions = $params['driverOptions'];
         }
-        
+
         if (isset($params['master'])) {
-            $params = $params['master'];
+            $params                  = $params['master'];
             $params['driverOptions'] = $driverOptions;
         }
 
         // Since doctrine/dbal 2.11 master has been replaced by primary
         if (isset($params['primary'])) {
-            $params = $params['primary'];
+            $params                  = $params['primary'];
             $params['driverOptions'] = $driverOptions;
         }
 

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -60,7 +60,7 @@ EOT
         $connection = $this->getDoctrineConnection($connectionName);
 
         $ifExists = $input->getOption('if-exists');
-        
+
         $driverOptions = [];
         $params        = $connection->getParams();
 

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -60,15 +60,23 @@ EOT
         $connection = $this->getDoctrineConnection($connectionName);
 
         $ifExists = $input->getOption('if-exists');
-
+        
+        $driverOptions = [];
         $params = $connection->getParams();
+        
+        if (isset($params['driverOptions'])) {
+            $driverOptions = $params['driverOptions']
+        }
+        
         if (isset($params['master'])) {
             $params = $params['master'];
+            $params['driverOptions'] = $driverOptions;
         }
 
         // Since doctrine/dbal 2.11 master has been replaced by primary
         if (isset($params['primary'])) {
             $params = $params['primary'];
+            $params['driverOptions'] = $driverOptions;
         }
 
         if (isset($params['shards'])) {

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -261,6 +261,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if (! empty($options['slaves'])) {
             $nonRewrittenKeys = [
                 'driver' => true,
+                'driverOptions' => true,
                 'driverClass' => true,
                 'wrapperClass' => true,
                 'keepSlave' => true,

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -126,7 +126,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'mysql_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
-                'driverOptions' => [],
             ],
             $param['master']
         );


### PR DESCRIPTION
Reverts the changes made in #1240, and applies the passing down of `driverOptions` manually in `CreateDatabaseDoctrineCommand` and `DropDatabaseDoctrineCommand`

Resolves #1252

I haven't written any tests for this - it seems that these commands aren't particularly testable due to the static call to `DriverManager::getConnection`. It's not straightforward to verify the params that are passed to it. I considered refactoring the seemingly common code in both commands into a single parent methods, but there's slight differences between them that makes me wary of breaking something.