### PR TITLE
Autowire entity managers by argument type and name

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -11,6 +11,7 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Tools\Console\ConnectionProvider;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\UnitOfWork;
 use LogicException;
@@ -544,14 +545,20 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $entityManager['connection'] = $this->defaultConnection;
         }
 
+        $entityManagerId = sprintf('doctrine.orm.%s_entity_manager', $entityManager['name']);
+
         $container
-            ->setDefinition(sprintf('doctrine.orm.%s_entity_manager', $entityManager['name']), new ChildDefinition('doctrine.orm.entity_manager.abstract'))
+            ->setDefinition($entityManagerId, new ChildDefinition('doctrine.orm.entity_manager.abstract'))
             ->setPublic(true)
             ->setArguments([
                 new Reference(sprintf('doctrine.dbal.%s_connection', $entityManager['connection'])),
                 new Reference(sprintf('doctrine.orm.%s_configuration', $entityManager['name'])),
             ])
             ->setConfigurator([new Reference($managerConfiguratorName), 'configure']);
+
+        $container
+            ->registerAliasForArgument($entityManagerId, EntityManagerInterface::class, sprintf('%sEntityManager', $entityManager['name']))
+            ->setPublic(false);
 
         $container->setAlias(
             sprintf('doctrine.orm.%s_entity_manager.event_manager', $entityManager['name']),

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -887,6 +887,21 @@ You can easily define `doctrine filters`_ in your configuration file:
 
 .. _`reference-dbal-configuration`:
 
+Autowiring multiple Entity Managers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can autowire different entity managers by type-hinting your service arguments with
+the following syntax: ``Doctrine\ORM\EntityManagerInterface $<entity manager>EntityManager``.
+For example, to inject a ``purchase_logs`` entity manager use this:
+
+.. code-block:: diff
+
+    -     public function __construct(EntityManagerInterface $entityManager)
+    +     public function __construct(EntityManagerInterface $purchaseLogsEntityManager)
+        {
+            $this->entityManager = $purchaseLogsEntityManager;
+        }
+
 Doctrine DBAL Configuration
 ---------------------------
 

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -52,7 +52,49 @@ class DoctrineExtensionTest extends TestCase
 
             $alias = $container->getAlias($id);
             $this->assertEquals($target, (string) $alias, sprintf('The autowiring for `%s` should use `%s`.', $id, $target));
-            $this->assertFalse($alias->isPublic(), sprintf('The autowiring alias for `%s` should be private.', $id, $target));
+            $this->assertFalse($alias->isPublic(), sprintf('The autowiring alias for `%s` should be private.', $id));
+        }
+    }
+
+    public function testEntityManagerAutowiringAlias()
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->getContainer([
+            'YamlBundle',
+            'XmlBundle',
+        ]);
+        $extension = new DoctrineExtension();
+
+        $config = BundleConfigurationBuilder::createBuilder()
+            ->addBaseConnection()
+            ->addEntityManager([
+                'entity_managers' => [
+                    'default' => [
+                        'mappings' => ['YamlBundle' => []],
+                    ],
+                    'purchase_logs' => [
+                        'mappings' => ['XmlBundle' => []],
+                    ],
+                ],
+            ])
+            ->build();
+
+        $extension->load([$config], $container);
+
+        $expectedAliases = [
+            EntityManagerInterface::class . ' $defaultEntityManager' => 'doctrine.orm.default_entity_manager',
+            EntityManagerInterface::class . ' $purchaseLogsEntityManager' => 'doctrine.orm.purchase_logs_entity_manager',
+        ];
+
+        foreach ($expectedAliases as $id => $target) {
+            $this->assertTrue($container->hasAlias($id), sprintf('The container should have a `%s` alias for autowiring support.', $id));
+
+            $alias = $container->getAlias($id);
+            $this->assertEquals($target, (string) $alias, sprintf('The autowiring for `%s` should use `%s`.', $id, $target));
+            $this->assertFalse($alias->isPublic(), sprintf('The autowiring alias for `%s` should be private.', $id));
         }
     }
 


### PR DESCRIPTION
This will allow autowiring entity managers by argument type and name which is useful when you have multiple entity managers:

```yaml
orm:
    entity_managers:
        my_name:
            mappings:
                MyBundle: []
```

```php
use Doctrine\ORM\EntityManagerInterface;

class Foo
{
    public function __construct(EntityManagerInterface $myNameEntityManager) {}
}
```