### PR TITLE
Run all tests on PHP 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,11 +37,6 @@ jobs:
             php-version: "7.1"
             symfony-deprecations-helper: "weak"
 
-          # Test against latest Symfony 4.3 stable
-          - symfony-require: "4.3.*"
-            php-version: "7.3"
-            deps: "normal"
-
           # Test against latest Symfony 4.4 dev
           - symfony-require: "4.4.*"
             php-version: "7.3"
@@ -90,18 +85,9 @@ jobs:
       - name: "Globally install symfony/flex"
         run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex"
 
-      # to be removed when our dependencies support PHP 8
-      - name: "Pretend this is PHP 7.4"
-        run: "composer config platform.php 7.4.99"
-        if: "${{ matrix.php-version == '8.0' }}"
-
       - name: "Require symfony/messenger"
         run: "composer require --dev symfony/messenger --no-update"
         if: "${{ startsWith(matrix.symfony-require, '4.') }}"
-
-      - name: "Remove doctrine/orm"
-        run: "composer remove --dev doctrine/orm --no-update"
-        if: "${{ matrix.php-version == '8.0' }}"
 
       - name: "Install stable dependencies with composer"
         run: "composer update --no-interaction --prefer-dist --prefer-stable"

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^8.0",
         "doctrine/orm": "^2.6",
-        "ocramius/proxy-manager": "^2.1",
+        "friendsofphp/proxy-manager-lts": "^1.0",
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.3",
         "symfony/phpunit-bridge": "^4.2",
         "symfony/property-info": "^4.3.3|^5.0",


### PR DESCRIPTION
This PR replaces the ocramius/proxy-manager dev dependency with friendsofphp/proxy-manager-lts, which provides support for a wider range of PHP versions. With ORM 2.8 supporting PHP 8 as well, we should now be able to run all tests on PHP 8.