### PR TITLE
Fix loop when repositry is injected in Doctrine EventSubscriber

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -412,6 +412,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         $container->registerForAutoconfiguration(ServiceEntityRepositoryInterface::class)
+            ->setLazy(true)
             ->addTag(ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
     }
 


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony/issues/39619 

When a repository is injected in a Doctrine EventSubscriber, the Dependency Graph contain a loop (Repository -> EM -> Connection -> EventSubscriber -> Repository). When ProxyManager is installed, the Symfony "DI Dumper" relies on the lazyness of the EntityManager (declared here https://github.com/doctrine/DoctrineBundle/blob/8654e8c56ca2df71bffc418d6b3bb558e9e0228b/Resources/config/orm.xml#L100) The issue is: the EntityManager is not that lazy, because it calls internal method on __construct. Users ends with an infinite loop = segfault.

This PR makes the repository lazy to prevent infinite loop.

note: This PR does not contains tests. To reproduce the issue, we need to bootstrap an App **with** a dumped-container.