### PR TITLE
Propagate template from EntityRepository

### DIFF
--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -19,6 +19,9 @@ use LogicException;
  *         parent::__construct($registry, YourEntity::class);
  *     }
  * }
+ *
+ * @template T
+ * @template-extends EntityRepository<T>
  */
 class ServiceEntityRepository extends EntityRepository implements ServiceEntityRepositoryInterface
 {

--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -27,6 +27,8 @@ class ServiceEntityRepository extends EntityRepository implements ServiceEntityR
 {
     /**
      * @param string $entityClass The class name of the entity this repository manages
+     *
+     * @psalm-param class-string<T> $entityClass
      */
     public function __construct(ManagerRegistry $registry, string $entityClass)
     {


### PR DESCRIPTION
Hi @greg0ire, seems like there is no psalm on this project
I could try to add it during some of my free time.

This PR avoid to a `TooManyTemplateParams` error from psalm and allow to benefit from the `ObjectRepository<T>` interface.