### PR TITLE
Enable `@CustomIdGenerator()` to reference services tagged as "doctrine.id_generator"

### DIFF
--- a/DependencyInjection/Compiler/IdGeneratorPass.php
+++ b/DependencyInjection/Compiler/IdGeneratorPass.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\ClassMetadataFactory;
+use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver;
+use Doctrine\ORM\Mapping\ClassMetadataFactory as ORMClassMetadataFactory;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class IdGeneratorPass implements CompilerPassInterface
+{
+    const ID_GENERATOR_TAG  = 'doctrine.id_generator';
+    const CONFIGURATION_TAG = 'doctrine.orm.configuration';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $generatorIds = array_keys($container->findTaggedServiceIds(self::ID_GENERATOR_TAG));
+
+        // when ORM is not enabled
+        if (! $container->hasDefinition('doctrine.orm.configuration') || ! $generatorIds) {
+            return;
+        }
+
+        $generatorRefs = array_map(static function ($id) {
+            return new Reference($id);
+        }, $generatorIds);
+
+        $ref = ServiceLocatorTagPass::register($container, array_combine($generatorIds, $generatorRefs));
+        $container->setAlias('doctrine.id_generator_locator', new Alias((string) $ref, false));
+
+        foreach ($container->findTaggedServiceIds(self::CONFIGURATION_TAG) as $id => $tags) {
+            $configurationDef   = $container->getDefinition($id);
+            $methodCalls        = $configurationDef->getMethodCalls();
+            $metadataDriverImpl = null;
+
+            foreach ($methodCalls as $i => [$method, $arguments]) {
+                if ($method === 'setMetadataDriverImpl') {
+                    $metadataDriverImpl = (string) $arguments[0];
+                }
+
+                if ($method !== 'setClassMetadataFactoryName') {
+                    continue;
+                }
+
+                if ($arguments[0] !== ORMClassMetadataFactory::class && $arguments[0] !== ClassMetadataFactory::class) {
+                    $class = $container->getReflectionClass($arguments[0]);
+
+                    if ($class && $class->isSubclassOf(ClassMetadataFactory::class)) {
+                        break;
+                    }
+
+                    continue 2;
+                }
+
+                $methodCalls[$i] = ['setClassMetadataFactoryName', [ClassMetadataFactory::class]];
+            }
+
+            if ($metadataDriverImpl === null) {
+                continue;
+            }
+
+            $configurationDef->setMethodCalls($methodCalls);
+            $container->register('.' . $metadataDriverImpl, MappingDriver::class)
+                ->setDecoratedService($metadataDriverImpl)
+                ->setArguments([
+                    new Reference(sprintf('.%s.inner', $metadataDriverImpl)),
+                    new Reference('doctrine.id_generator_locator'),
+                ]);
+        }
+    }
+}

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubscriberPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\WellKnownSchemaFilterPass;
 use Doctrine\Common\Util\ClassUtils;
@@ -42,6 +43,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new DoctrineValidationPass('orm'));
         $container->addCompilerPass(new EntityListenerPass());
         $container->addCompilerPass(new ServiceRepositoryCompilerPass());
+        $container->addCompilerPass(new IdGeneratorPass());
         $container->addCompilerPass(new WellKnownSchemaFilterPass());
         $container->addCompilerPass(new DbalSchemaFilterPass());
         $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);

--- a/Mapping/ClassMetadataFactory.php
+++ b/Mapping/ClassMetadataFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Mapping;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory as BaseClassMetadataFactory;
+
+class ClassMetadataFactory extends BaseClassMetadataFactory
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents): void
+    {
+        parent::doLoadMetadata($class, $parent, $rootEntityFound, $nonSuperclassParents);
+
+        $customGeneratorDefinition = $class->customGeneratorDefinition;
+
+        if (! isset($customGeneratorDefinition['instance'])) {
+            return;
+        }
+
+        $class->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
+        $class->setIdGenerator($customGeneratorDefinition['instance']);
+        unset($customGeneratorDefinition['instance']);
+        $class->setCustomGeneratorDefinition($customGeneratorDefinition);
+    }
+}

--- a/Mapping/MappingDriver.php
+++ b/Mapping/MappingDriver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Mapping;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver as MappingDriverInterface;
+use Psr\Container\ContainerInterface;
+
+class MappingDriver implements MappingDriverInterface
+{
+    /** @var MappingDriverInterface */
+    private $driver;
+
+    /** @var ContainerInterface */
+    private $idGeneratorLocator;
+
+    public function __construct(MappingDriverInterface $driver, ContainerInterface $idGeneratorLocator)
+    {
+        $this->driver             = $driver;
+        $this->idGeneratorLocator = $idGeneratorLocator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllClassNames()
+    {
+        return $this->driver->getAllClassNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isTransient($className): bool
+    {
+        return $this->driver->isTransient($className);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadMetadataForClass($className, ClassMetadata $metadata): void
+    {
+        $this->driver->loadMetadataForClass($className, $metadata);
+
+        if (
+            $metadata->generatorType !== ClassMetadataInfo::GENERATOR_TYPE_CUSTOM
+            || ! isset($metadata->customGeneratorDefinition['class'])
+            || ! $this->idGeneratorLocator->has($metadata->customGeneratorDefinition['class'])
+        ) {
+            return;
+        }
+
+        $idGenerator = $this->idGeneratorLocator->get($metadata->customGeneratorDefinition['class']);
+        $metadata->setCustomGeneratorDefinition(['instance' => $idGenerator] + $metadata->customGeneratorDefinition);
+        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+    }
+}

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -150,6 +150,17 @@
         <service id="doctrine.orm.quote_strategy.default" class="%doctrine.orm.quote_strategy.default.class%" public="false" />
         <service id="doctrine.orm.quote_strategy.ansi" class="%doctrine.orm.quote_strategy.ansi.class%" public="false" />
 
+        <!-- custom id generators -->
+        <service id="doctrine.ulid_generator" class="Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator">
+            <argument type="service" id="ulid.factory" on-invalid="ignore" />
+            <tag name="doctrine.id_generator" />
+        </service>
+
+        <service id="doctrine.uuid_generator" class="Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator">
+            <argument type="service" id="uuid.factory" on-invalid="ignore" />
+            <tag name="doctrine.id_generator" />
+        </service>
+
         <!-- commands -->
         <service id="doctrine.cache_clear_metadata_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearMetadataCacheDoctrineCommand">
             <tag name="console.command" command="doctrine:cache:clear-metadata" />

--- a/Resources/doc/custom-id-generators.rst
+++ b/Resources/doc/custom-id-generators.rst
@@ -1,0 +1,44 @@
+Custom ID Generators
+====================
+
+Custom ID generators are classes that allow implementing custom logic to generate
+identifiers for your entities. They extend ``Doctrine\ORM\Id\AbstractIdGenerator``
+and implement the custom logic in the ``generate(EntityManager $em, $entity)``
+method. Before Doctrine bundle 2.3, custom ID generators were always created
+without any constructor arguments.
+
+Starting with Doctrine bundle 2.3, the ``CustomIdGenerator`` annotation can be
+used to reference any services tagged with the ``doctrine.id_generator`` tag.
+If you enable autoconfiguration (which is the default most of the time), Symfony
+will add this tag for you automatically if you implement your own id-generators.
+
+When using Symfony's Doctrine bridge and Uid component 5.3 or higher, two services
+are provided: ``doctrine.ulid_generator`` to generate ULIDs, and
+``doctrine.uuid_generator`` to generate UUIDs.
+
+.. code-block:: php
+
+    <?php
+    // User.php
+
+    use Doctrine\ORM\Mapping as ORM;
+
+    /**
+     * @ORM\Entity
+     */
+    class User
+    {
+        /**
+         * @Id
+         * @Column(type="uuid")
+         * @ORM\GeneratedValue(strategy="CUSTOM")
+         * @ORM\CustomIdGenerator('doctrine.uuid_generator')
+         */
+        private $id;
+
+        // ....
+    }
+
+See also
+https://www.doctrine-project.org/projects/doctrine-orm/en/2.8/reference/annotations-reference.html#annref_customidgenerator
+for more info about custom ID generators.

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -8,4 +8,5 @@ configuration options, console commands and even a web debug toolbar collector.
 
     installation
     entity-listeners
+    custom-id-generators
     configuration

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -42,11 +42,6 @@ class ContainerTest extends TestCase
         }
     }
 
-    /**
-     * https://github.com/doctrine/orm/pull/7953 needed, otherwise ORM classes we define services for trigger deprecations
-     *
-     * @group legacy
-     */
     public function testContainer(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/Tests/CustomIdGeneratorTest.php
+++ b/Tests/CustomIdGeneratorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\CustomIdGenerator;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\EntityManagerInterface;
+use Fixtures\Bundles\AnnotationsBundle\AnnotationsBundle;
+use Fixtures\Bundles\AnnotationsBundle\Entity\TestCustomIdGeneratorEntity;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class CustomIdGeneratorTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
+    public function testRepositoryServiceWiring(): void
+    {
+        $container = new ContainerBuilder(new ParameterBag([
+            'kernel.debug' => false,
+            'kernel.bundles' => ['AnnotationsBundle' => AnnotationsBundle::class],
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => 'test',
+            'kernel.runtime_environment' => '%%env(default:kernel.environment:APP_RUNTIME_ENV)%%',
+            'kernel.build_dir' => __DIR__ . '/../../../../', // src dir
+            'kernel.root_dir' => __DIR__ . '/../../../../', // src dir
+            'kernel.project_dir' => __DIR__ . '/../../../../', // src dir
+            'kernel.bundles_metadata' => [],
+            'kernel.charset' => 'UTF-8',
+            'kernel.container_class' => ContainerBuilder::class,
+            'kernel.secret' => 'test',
+            'container.build_id' => uniqid(),
+            'env(base64:default::SYMFONY_DECRYPTION_SECRET)' => 'foo',
+        ]));
+        $container->set('annotation_reader', new AnnotationReader());
+
+        $extension = new FrameworkExtension();
+        $container->registerExtension($extension);
+        $extension->load(['framework' => []], $container);
+
+        $extension = new DoctrineExtension();
+        $container->registerExtension($extension);
+        $extension->load([
+            [
+                'dbal' => [
+                    'driver' => 'pdo_sqlite',
+                    'charset' => 'UTF8',
+                ],
+                'orm' => [
+                    'mappings' => [
+                        'AnnotationsBundle' => [
+                            'type' => 'annotation',
+                            'dir' => __DIR__ . '/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity',
+                            'prefix' => 'Fixtures\Bundles\AnnotationsBundle\Entity',
+                        ],
+                    ],
+                ],
+            ],
+        ], $container);
+
+        $def = $container->register('my_id_generator', CustomIdGenerator::class);
+
+        $def->setAutoconfigured(true);
+
+        $container->addCompilerPass(new IdGeneratorPass());
+        $container->compile();
+
+        $em = $container->get('doctrine.orm.default_entity_manager');
+        assert($em instanceof EntityManagerInterface);
+
+        $metadata = $em->getClassMetadata(TestCustomIdGeneratorEntity::class);
+        $this->assertInstanceOf(CustomIdGenerator::class, $metadata->idGenerator);
+    }
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/TestCustomIdGeneratorEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/TestCustomIdGeneratorEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Fixtures\Bundles\AnnotationsBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TestCustomIdGeneratorEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator("my_id_generator")
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+}

--- a/Tests/DependencyInjection/Fixtures/CustomIdGenerator.php
+++ b/Tests/DependencyInjection/Fixtures/CustomIdGenerator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+
+class CustomIdGenerator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity)
+    {
+        return 42;
+    }
+}

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -30,11 +30,6 @@ class ServiceRepositoryTest extends TestCase
         self::markTestSkipped('This test requires ORM');
     }
 
-    /**
-     * https://github.com/doctrine/orm/pull/7953 needed, otherwise ORM classes we define services for trigger deprecations
-     *
-     * @group legacy
-     */
     public function testRepositoryServiceWiring(): void
     {
         $container = new ContainerBuilder(new ParameterBag([


### PR DESCRIPTION
Fixes #759

This PR enables referencing services when using the `@CustomIdGenerator()` annotation.

It works by creating a service locator of all services tagged as `doctrine.id_generator`, and checking that locator when a custom id generator is found. Usage:

```php
/**
 * @ORM\GeneratedValue(strategy="CUSTOM")
 * @ORM\CustomIdGenerator('doctrine.uuid_generator')
 */
```
