### PR TITLE
#1282 Fix DBAL < 2.11 BC layer in doctrine:query:sql

### DIFF
--- a/Command/Proxy/RunSqlDoctrineCommand.php
+++ b/Command/Proxy/RunSqlDoctrineCommand.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
+use Doctrine\DBAL\Tools\Console\ConnectionProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,6 +15,16 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class RunSqlDoctrineCommand extends RunSqlCommand
 {
+    /** @var ConnectionProvider|null */
+    private $connectionProvider;
+
+    public function __construct(?ConnectionProvider $connectionProvider = null)
+    {
+        parent::__construct($connectionProvider);
+
+        $this->connectionProvider = $connectionProvider;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -45,11 +56,13 @@ EOT
     {
         @trigger_error(sprintf('The "%s" (doctrine:query:sql) is deprecated, use dbal:run-sql command instead.', self::class), E_USER_DEPRECATED);
 
-        DoctrineCommandHelper::setApplicationConnection($this->getApplication(), $input->getOption('connection'));
+        if (! $this->connectionProvider) {
+            DoctrineCommandHelper::setApplicationConnection($this->getApplication(), $input->getOption('connection'));
 
-        // compatibility with doctrine/dbal 2.11+
-        // where this option is also present and unsupported before we are not switching to use a ConnectionProvider
-        $input->setOption('connection', null);
+            // compatibility with doctrine/dbal 2.11+
+            // where this option is also present and unsupported before we are not switching to use a ConnectionProvider
+            $input->setOption('connection', null);
+        }
 
         return parent::execute($input, $output);
     }


### PR DESCRIPTION
This BC layer didn't work correctly with dbal:^2.11,<3.0 when --connection option was used