### PR TITLE
add ability to override url dbname

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -43,10 +43,6 @@ class ConnectionFactory
             $this->initializeTypes();
         }
 
-        if (isset($params['override_url'], $params['url']) && $params['override_url']) {
-            $params['url'] = $this->overrideUrl($params);
-        }
-
         if (! isset($params['pdo']) && ! isset($params['charset'])) {
             $wrapperClass = null;
             if (isset($params['wrapperClass'])) {
@@ -56,6 +52,10 @@ class ConnectionFactory
 
                 $wrapperClass           = $params['wrapperClass'];
                 $params['wrapperClass'] = null;
+            }
+
+            if (isset($params['override_url'], $params['url']) && $params['override_url']) {
+                $params['url'] = $this->overrideUrl($params);
             }
 
             $connection = DriverManager::getConnection($params, $config, $eventManager);

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -134,13 +134,16 @@ class ConnectionFactory
         $this->initialized = true;
     }
 
-    private function overrideUrl(array $params): string
+    /**
+     * @param mixed[] $params
+     */
+    private function overrideUrl(array $params) : string
     {
         if (empty($params['dbname'])) {
             return $params['url'];
         }
 
-        $parsedUrl = parse_url($params['url']);
+        $parsedUrl         = parse_url($params['url']);
         $parsedUrl['path'] = sprintf('/%s', $params['dbname']);
 
         $newUrl = '';
@@ -163,7 +166,7 @@ class ConnectionFactory
                     $newUrl = sprintf('%s:%s', $newUrl, $parsedUrl[$key]);
                     break;
                 case 'host':
-                    $hostSeparator = !empty($parsedUrl['user']) ? '@' : '';
+                    $hostSeparator = ! empty($parsedUrl['user']) ? '@' : '';
 
                     $newUrl = sprintf(
                         '%s%s%s',

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -43,7 +43,7 @@ class ConnectionFactory
             $this->initializeTypes();
         }
 
-        if (isset($params['override_url']) && $params['override_url']) {
+        if (isset($params['override_url'], $params['url']) && $params['override_url']) {
             $params['url'] = $this->overrideUrl($params);
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,7 +197,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('port')->defaultNull()->end()
                 ->scalarNode('user')->defaultValue('root')->end()
                 ->scalarNode('password')->defaultNull()->end()
-                ->scalarNode('override_url')->defaultFalse()->end()
+                ->booleanNode('override_url')->end()
                 ->scalarNode('application_name')->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('path')->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,6 +197,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('port')->defaultNull()->end()
                 ->scalarNode('user')->defaultValue('root')->end()
                 ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('override_url')->defaultFalse()->end()
                 ->scalarNode('application_name')->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('path')->end()

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -50,6 +50,7 @@
         <xsd:attribute name="port" type="xsd:string" />
         <xsd:attribute name="user" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />
+        <xsd:attribute name="override-url" type="xsd:boolean" />
         <xsd:attribute name="application-name" type="xsd:string" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="unix-socket" type="xsd:string" />

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -63,6 +63,21 @@ class ConnectionFactoryTest extends TestCase
 
         $this->assertSame('utf8mb4', $connection->getParams()['charset']);
     }
+
+    public function testUrlOverride(): void
+    {
+        $factory = new ConnectionFactory([]);
+
+        $oldUrl = 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8';
+        $expectedUrl = 'mysql://root:password@database:3306/main_test?serverVersion=mariadb-10.5.8';
+        $params = ['url' => $oldUrl, 'override_url' => true, 'dbname' => 'main_test'];
+
+        $connection = $factory->createConnection($params);
+
+        $result = $connection->getParams();
+
+        self::assertSame($expectedUrl, $result['url']);
+    }
 }
 
 /**

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -64,13 +64,13 @@ class ConnectionFactoryTest extends TestCase
         $this->assertSame('utf8mb4', $connection->getParams()['charset']);
     }
 
-    public function testUrlOverride(): void
+    public function testUrlOverride() : void
     {
         $factory = new ConnectionFactory([]);
 
-        $oldUrl = 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8';
+        $oldUrl      = 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8';
         $expectedUrl = 'mysql://root:password@database:3306/main_test?serverVersion=mariadb-10.5.8';
-        $params = ['url' => $oldUrl, 'override_url' => true, 'dbname' => 'main_test'];
+        $params      = ['url' => $oldUrl, 'override_url' => true, 'dbname' => 'main_test'];
 
         $connection = $factory->createConnection($params);
 


### PR DESCRIPTION
Use case:

If you define a connection `url` in Symfony using the `DATABASE_URL` env var for development, and you use the same server, but different database for tests - you have to define the entire `DATABASE_URL` in your `config/packages/test/doctrine.yaml`

This PR would allow you to override the database used in the connection `url` by setting `dbname` in your `config/packages/{ENV}/doctrine.yaml`. To preserve BC, we would add a `doctrine.dbal.override_url` `bool` configuration param that defaults to `false`

Example:

```
// config/packages/doctrine.yaml

doctrine:
    dbal:
        url: mysql://user:pass@host/main_database
```

```
// config/packages/test/doctrine.yaml

doctrine:
    dbal:
        override_url: true
        dbname: main_test
```

In the `test` environment:
`doctrine.dbal.url === mysql://user:pass@host/main_test`

else

`doctrine.dbal.url === mysql://user:pass@host/main_database`