### PR TITLE
add ability to override url with dsn params

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -45,10 +45,10 @@ class ConnectionFactory
             $this->initializeTypes();
         }
 
-        $connectionOverrideOptions = $params['connection_override_options'] ?? [];
+        $overriddenOptions = $params['connection_override_options'] ?? [];
         unset($params['connection_override_options']);
 
-        if (! isset($params['pdo']) && (! isset($params['charset']) || (! empty($connectionOverrideOptions) && isset($params['url'])))) {
+        if (! isset($params['pdo']) && (! isset($params['charset']) || $overriddenOptions)) {
             $wrapperClass = null;
 
             if (isset($params['wrapperClass'])) {
@@ -65,7 +65,7 @@ class ConnectionFactory
             }
 
             $connection = DriverManager::getConnection($params, $config, $eventManager);
-            $params     = array_merge($connection->getParams(), $connectionOverrideOptions);
+            $params     = array_merge($connection->getParams(), $overriddenOptions);
             $driver     = $connection->getDriver();
 
             if ($driver instanceof AbstractMySQLDriver) {

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -45,8 +45,12 @@ class ConnectionFactory
             $this->initializeTypes();
         }
 
-        if (! isset($params['pdo']) && ! isset($params['charset'])) {
+        $connectionOverrideOptions = $params['connection_override_options'] ?? [];
+        unset($params['connection_override_options']);
+
+        if (! isset($params['pdo']) && (! isset($params['charset']) || (! empty($connectionOverrideOptions) && isset($params['url'])))) {
             $wrapperClass = null;
+
             if (isset($params['wrapperClass'])) {
                 if (! is_subclass_of($params['wrapperClass'], Connection::class)) {
                     if (class_exists(DBALException::class)) {
@@ -61,7 +65,7 @@ class ConnectionFactory
             }
 
             $connection = DriverManager::getConnection($params, $config, $eventManager);
-            $params     = $connection->getParams();
+            $params     = array_merge($connection->getParams(), $connectionOverrideOptions);
             $driver     = $connection->getDriver();
 
             if ($driver instanceof AbstractMySQLDriver) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -319,10 +319,10 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->beforeNormalization()
                 ->ifTrue(static function ($v) {
-                    return ! ($v['override_url'] ?? false) && isset($v['url']);
+                    return empty($v['override_url']) && isset($v['url']);
                 })
                 ->then(static function ($v) {
-                    trigger_error('Not setting doctrine.dbal.override_url to true is deprecated. True is the only value that will be supported in doctrine-bundle 3.0.', E_USER_DEPRECATED);
+                    @trigger_error('Not setting doctrine.dbal.override_url to true is deprecated. True is the only value that will be supported in doctrine-bundle 3.0.', E_USER_DEPRECATED);
 
                     return $v;
                 })

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -217,10 +217,11 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('url')->info('A URL with connection information; any parameter value parsed from this string will override explicitly set parameters')->end()
                 ->scalarNode('dbname')->end()
-                ->scalarNode('host')->defaultValue('localhost')->end()
-                ->scalarNode('port')->defaultNull()->end()
-                ->scalarNode('user')->defaultValue('root')->end()
-                ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('host')->info('Defaults to "localhost" at runtime.')->end()
+                ->scalarNode('port')->info('Defaults to null at runtime.')->end()
+                ->scalarNode('user')->info('Defaults to "root" at runtime.')->end()
+                ->scalarNode('password')->info('Defaults to null at runtime.')->end()
+                ->booleanNode('override_url')->defaultValue(false)->info('Allows overriding parts of the "url" parameter with dbname, host, port, user, and/or password parameters.')->end()
                 ->scalarNode('application_name')->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('path')->end()
@@ -312,6 +313,16 @@ class Configuration implements ConfigurationInterface
                 ->then(static function ($v) {
                     $v['MultipleActiveResultSets'] = $v['multiple_active_result_sets'];
                     unset($v['multiple_active_result_sets']);
+
+                    return $v;
+                })
+            ->end()
+            ->beforeNormalization()
+                ->ifTrue(static function ($v) {
+                    return ! ($v['override_url'] ?? false) && isset($v['url']);
+                })
+                ->then(static function ($v) {
+                    trigger_error('Not setting doctrine.dbal.override_url to true is deprecated. True is the only value that will be supported in doctrine-bundle 3.0.', E_USER_DEPRECATED);
 
                     return $v;
                 })

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -51,6 +51,7 @@
         <xsd:attribute name="port" type="xsd:string" />
         <xsd:attribute name="user" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />
+        <xsd:attribute name="override-url" type="xsd:boolean" />
         <xsd:attribute name="application-name" type="xsd:string" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="unix-socket" type="xsd:string" />

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -22,6 +22,9 @@ Configuration Reference
                 connections:
                     # A collection of different named connections (e.g. default, conn2, etc)
                     default:
+                        # If true, allows overriding url parameters with explicitly set parameters.
+                        # "dbname", "host", "port", "user", and/or "password" can be overridden.
+                        override_url:         ~
                         dbname:               ~
                         host:                 localhost
                         port:                 ~
@@ -914,10 +917,11 @@ Doctrine DBAL Configuration
 .. note::
 
     When specifying a ``url`` parameter, any information extracted from that
-    URL will override explicitly set parameters. An example database URL
-    would be ``mysql://snoopy:redbaron@localhost/baseball``, and any explicitly
-    set driver, user, password and dbname parameter would be overridden by
-    this URL. See the Doctrine `DBAL documentation`_ for more information.
+    URL will override explicitly set parameters unless ``override_url`` is set
+    to ``true``. An example database URL would be
+    ``mysql://snoopy:redbaron@localhost/baseball``, and any explicitly set driver,
+    user, password and dbname parameter would be overridden by this URL.
+    See the Doctrine `DBAL documentation`_ for more information.
 
 Besides default Doctrine options, there are some Symfony-related ones that you
 can configure. The following block shows all possible configuration keys:
@@ -928,6 +932,7 @@ can configure. The following block shows all possible configuration keys:
 
         doctrine:
             dbal:
+                override_url:             true
                 url:                      mysql://user:secret@localhost:1234/otherdatabase # this would override the values below
                 dbname:                   database
                 host:                     localhost

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -72,11 +72,8 @@ class ConnectionFactoryTest extends TestCase
         $this->assertSame('utf8mb4', $connection->getParams()['charset']);
     }
 
-    public function testUrlOverride(): void
+    public function testConnectionOverrideOptions(): void
     {
-        $factory = new ConnectionFactory([]);
-        $url     = 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8';
-
         $params = [
             'dbname' => 'main_test',
             'host' => 'db_test',
@@ -85,16 +82,12 @@ class ConnectionFactoryTest extends TestCase
             'password' => 'wordpass',
         ];
 
-        $connection = $factory->createConnection([
-            'url' => $url,
+        $connection = (new ConnectionFactory([]))->createConnection([
+            'url' => 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8',
             'connection_override_options' => $params,
         ]);
 
-        $result = $connection->getParams();
-
-        foreach ($params as $paramKey => $expectedValue) {
-            self::assertSame($expectedValue, $result[$paramKey]);
-        }
+        $this->assertEquals($params, array_intersect_key($connection->getParams(), $params));
     }
 }
 

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -71,6 +71,31 @@ class ConnectionFactoryTest extends TestCase
 
         $this->assertSame('utf8mb4', $connection->getParams()['charset']);
     }
+
+    public function testUrlOverride(): void
+    {
+        $factory = new ConnectionFactory([]);
+        $url     = 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8';
+
+        $params = [
+            'dbname' => 'main_test',
+            'host' => 'db_test',
+            'port' => 5432,
+            'user' => 'tester',
+            'password' => 'wordpass',
+        ];
+
+        $connection = $factory->createConnection([
+            'url' => $url,
+            'connection_override_options' => $params,
+        ]);
+
+        $result = $connection->getParams();
+
+        foreach ($params as $paramKey => $expectedValue) {
+            self::assertSame($expectedValue, $result[$paramKey]);
+        }
+    }
 }
 
 /**

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -102,9 +102,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     public function testDbalLoadFromXmlSingleConnections(): void
     {
         $container = $this->loadContainer('dbal_service_single_connection');
-
-        // doctrine.dbal.mysql_connection
-        $config = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+        $config    = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
         $this->assertEquals('mysql_s3cr3t', $config['password']);
         $this->assertEquals('mysql_user', $config['user']);
@@ -116,9 +114,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     public function testDbalLoadUrlOverride(): void
     {
         $container = $this->loadContainer('dbal_allow_url_override');
-
-        // doctrine.dbal.mysql_connection
-        $config = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+        $config    = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
         $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
 
@@ -130,10 +126,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             'port' => 4321,
         ];
 
-        foreach ($expectedOverrides as $param => $value) {
-            $this->assertSame($value, $config[$param]);
-        }
-
+        $this->assertEquals($expectedOverrides, array_intersect_key($config, $expectedOverrides));
         $this->assertSame($expectedOverrides, $config['connection_override_options']);
         $this->assertFalse(isset($config['override_url']));
     }
@@ -141,9 +134,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     public function testDbalLoadPartialUrlOverrideSetsDefaults(): void
     {
         $container = $this->loadContainer('dbal_allow_partial_url_override');
-
-        // doctrine.dbal.mysql_connection
-        $config = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+        $config    = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
         $expectedDefaults = [
             'host' => 'localhost',
@@ -152,10 +143,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             'port' => null,
         ];
 
-        foreach ($expectedDefaults as $paramName => $defaultConfigValue) {
-            $this->assertSame($defaultConfigValue, $config[$paramName]);
-        }
-
+        $this->assertEquals($expectedDefaults, array_intersect_key($config, $expectedDefaults));
         $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
         $this->assertCount(1, $config['connection_override_options']);
         $this->assertSame('main_test', $config['connection_override_options']['dbname']);
@@ -165,9 +153,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     public function testDbalLoadSingleMasterSlaveConnection(): void
     {
         $container = $this->loadContainer('dbal_service_single_master_slave_connection');
-
-        // doctrine.dbal.mysql_connection
-        $param = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+        $param     = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
         $this->assertEquals(
             class_exists(PrimaryReadReplicaConnection::class) ?
@@ -206,9 +192,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     public function testDbalLoadPoolShardingConnection(): void
     {
         $container = $this->loadContainer('dbal_service_pool_sharding_connection');
-
-        // doctrine.dbal.mysql_connection
-        $param = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+        $param     = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
         $this->assertEquals('Doctrine\\DBAL\\Sharding\\PoolingShardConnection', $param['wrapperClass']);
         $this->assertEquals(new Reference('foo.shard_choser'), $param['shardChoser']);

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -113,6 +113,55 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('5.6.20', $config['serverVersion']);
     }
 
+    public function testDbalLoadUrlOverride(): void
+    {
+        $container = $this->loadContainer('dbal_allow_url_override');
+
+        // doctrine.dbal.mysql_connection
+        $config = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+
+        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
+
+        $expectedOverrides = [
+            'dbname' => 'main_test',
+            'user' => 'tester',
+            'password' => 'wordpass',
+            'host' => 'localhost',
+            'port' => 4321,
+        ];
+
+        foreach ($expectedOverrides as $param => $value) {
+            $this->assertSame($value, $config[$param]);
+        }
+
+        $this->assertSame($expectedOverrides, $config['connection_override_options']);
+        $this->assertFalse(isset($config['override_url']));
+    }
+
+    public function testDbalLoadPartialUrlOverrideSetsDefaults(): void
+    {
+        $container = $this->loadContainer('dbal_allow_partial_url_override');
+
+        // doctrine.dbal.mysql_connection
+        $config = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+
+        $expectedDefaults = [
+            'host' => 'localhost',
+            'user' => 'root',
+            'password' => null,
+            'port' => null,
+        ];
+
+        foreach ($expectedDefaults as $paramName => $defaultConfigValue) {
+            $this->assertSame($defaultConfigValue, $config[$paramName]);
+        }
+
+        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
+        $this->assertCount(1, $config['connection_override_options']);
+        $this->assertSame('main_test', $config['connection_override_options']['dbname']);
+        $this->assertFalse(isset($config['override_url']));
+    }
+
     public function testDbalLoadSingleMasterSlaveConnection(): void
     {
         $container = $this->loadContainer('dbal_service_single_master_slave_connection');
@@ -135,6 +184,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'mysql_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
+                'connection_override_options' => [],
             ],
             $param['primary'] ?? $param['master'] // TODO: Remove 'master' support here when we require dbal >= 2.11
         );
@@ -146,6 +196,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'replica_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld_replica.sock',
+                'override_url' => false,
             ],
             $param['replica']['replica1']
         );
@@ -169,6 +220,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'mysql_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
+                'connection_override_options' => [],
             ],
             $param['global']
         );
@@ -181,6 +233,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld_shard.sock',
                 'id' => 1,
+                'override_url' => false,
             ],
             $param['shards'][0]
         );
@@ -223,6 +276,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'driver' => 'pdo_mysql',
                 'driverOptions' => [],
                 'defaultTableOptions' => [],
+                'connection_override_options' => [],
             ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             new Reference('doctrine.dbal.default_connection.event_manager'),
@@ -262,6 +316,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'driver' => 'pdo_mysql',
                 'driverOptions' => [],
                 'defaultTableOptions' => [],
+                'connection_override_options' => [],
             ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             new Reference('doctrine.dbal.default_connection.event_manager'),
@@ -302,6 +357,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'sqlite_db',
                 'memory' => true,
                 'defaultTableOptions' => [],
+                'connection_override_options' => [],
             ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             new Reference('doctrine.dbal.default_connection.event_manager'),

--- a/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
@@ -12,11 +12,16 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class DbalTestKernel extends Kernel
 {
+    /** @var array<string, mixed> */
+    private $dbalConfig;
+
     /** @var string|null */
     private $projectDir;
 
-    public function __construct()
+    public function __construct(array $dbalConfig = ['driver' => 'pdo_sqlite'])
     {
+        $this->dbalConfig = $dbalConfig;
+
         parent::__construct('test', true);
     }
 
@@ -30,11 +35,11 @@ class DbalTestKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $loader->load(static function (ContainerBuilder $container): void {
+        $loader->load(function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', ['secret' => 'F00']);
 
             $container->loadFromExtension('doctrine', [
-                'dbal' => ['driver' => 'pdo_sqlite'],
+                'dbal' => $this->dbalConfig,
             ]);
 
             // Register a NullLogger to avoid getting the stderr default logger of FrameworkBundle

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_allow_partial_url_override.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_allow_partial_url_override.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal override-url="true" dbname="main_test" url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8" />
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_allow_url_override.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_allow_url_override.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal override-url="true" dbname="main_test" user="tester" password="wordpass" host="localhost" port="4321" url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8" />
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_allow_partial_url_override.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_allow_partial_url_override.yml
@@ -1,0 +1,5 @@
+doctrine:
+    dbal:
+        override_url: true
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        dbname: main_test

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_allow_url_override.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_allow_url_override.yml
@@ -1,0 +1,9 @@
+doctrine:
+    dbal:
+        override_url: true
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        dbname: main_test
+        user: tester
+        password: wordpass
+        host: localhost
+        port: 4321

--- a/Tests/UrlOverrideTest.php
+++ b/Tests/UrlOverrideTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests;
+
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\DbalTestKernel;
+use Generator;
+
+class UrlOverrideTest extends TestCase
+{
+    /**
+     * @dataProvider connectionDataProvider
+     */
+    public function testConnectionConfiguration(array $config, array $expectedParams): void
+    {
+        $kernel = new UrlOverrideTestKernel($config);
+        $kernel->boot();
+
+        $doctrine = $kernel->getContainer()->get('doctrine');
+        $params   = $doctrine->getConnection()->getParams();
+
+        foreach ($expectedParams as $paramName => $value) {
+            self::assertSame($value, $params[$paramName]);
+        }
+    }
+
+    public function connectionDataProvider(): Generator
+    {
+        yield [
+            [
+                'override_url' => true,
+                'url' => 'mysql://database/main?serverVersion=mariadb-10.5.8',
+                'password' => 'wordPass',
+                'host' => '127.0.0.1',
+            ],
+            [
+                'user' => 'root',
+                'password' => 'wordPass',
+                'host' => '127.0.0.1',
+                'port' => null,
+                'dbname' => 'main',
+            ],
+        ];
+
+        yield [
+            [
+                'override_url' => true,
+                'url' => 'mysql://someone@database/main?serverVersion=mariadb-10.5.8',
+                'user' => 'someone',
+            ],
+            [
+                'user' => 'someone',
+                'password' => null,
+                'host' => 'database',
+                'port' => null,
+                'dbname' => 'main',
+            ],
+        ];
+
+        yield [
+            [
+                'override_url' => true,
+                'url' => 'mysql://database/main?serverVersion=mariadb-10.5.8',
+            ],
+            [
+                'user' => 'root',
+                'password' => null,
+                'host' => 'database',
+                'port' => null,
+                'dbname' => 'main',
+            ],
+        ];
+    }
+}
+
+class UrlOverrideTestKernel extends DbalTestKernel
+{
+    public function __construct(array $dbalConfig)
+    {
+        parent::__construct($dbalConfig);
+    }
+}

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,6 +1,10 @@
 UPGRADE FROM 2.2 to 2.3
 =======================
 
+Configuration
+--------
+* Not setting `doctrine.dbal.override_url` to `true` when using a `url` parameter in a connection is deprecated.
+
 Commands
 --------
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/config": "^4.3.3|^5.0",
         "symfony/console": "^3.4.30|^4.3.3|^5.0",
         "symfony/dependency-injection": "^4.3.3|^5.0",
+        "symfony/deprecation-contracts": "^2.2",
         "symfony/doctrine-bridge": "^4.3.7|^5.0",
         "symfony/framework-bundle": "^3.4.30|^4.3.3|^5.0",
         "symfony/service-contracts": "^1.1.1|^2.0"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "symfony/config": "^4.3.3|^5.0",
         "symfony/console": "^3.4.30|^4.3.3|^5.0",
         "symfony/dependency-injection": "^4.3.3|^5.0",
-        "symfony/deprecation-contracts": "^2.2",
         "symfony/doctrine-bridge": "^4.3.7|^5.0",
         "symfony/framework-bundle": "^3.4.30|^4.3.3|^5.0",
         "symfony/service-contracts": "^1.1.1|^2.0"


### PR DESCRIPTION
Use case:

If you define a connection `url` in Symfony using a real `DATABASE_URL` env var for development, and you use the same server, but different database for tests - you have to override the *entire* `DATABASE_URL` in your `config/packages/test/doctrine.yaml` file.

This PR would allow you to override part of the `url` using any combination of `dbname`, `host`, `port`, `user`, and/or `password`. To preserve BC, we would add a `doctrine.dbal.override_url` `bool` configuration param. 

Example:

```
// config/packages/doctrine.yaml

doctrine:
    dbal:
        url: '%env(DATABASE_URL)%'
```

```
// config/packages/test/doctrine.yaml

doctrine:
    dbal:
        override_url: true
        dbname: main_test
```

Assuming there is a `DATABASE_DSN` env var set to `mysql://user:pass@host/main_database`, then in the `test` environment it would still use `mysql://user:pass@host` but with the `main_test` database.
