### PR TITLE
Add generic/template annotations to ServiceEntityRepository

### DIFF
--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -19,6 +19,9 @@ use LogicException;
  *         parent::__construct($registry, YourEntity::class);
  *     }
  * }
+ *
+ * @template T
+ * @template-extends EntityRepository<T>
  */
 class ServiceEntityRepository extends EntityRepository implements ServiceEntityRepositoryInterface
 {


### PR DESCRIPTION
When creating a `FooRepository` for my `Foo` class I can use the `ServiceEntityRepository` to autowire the repository. However, I want to tell Vimeo Psalm that the `FooRepository` is operating on/with my `Foo` entity class.

The `\Doctrine\ORM\EntityRepository` has generic/template annotations on the class level doc block for that, but I cannot leverage those because my repository class is extending `ServiceEntityRepository` and that one doesn't have generic/template annotations.

This PR suggests to add those.