### PR TITLE
Add ServiceGeneratedValue annotation

### DIFF
--- a/Mapping/ClassMetadataFactory.php
+++ b/Mapping/ClassMetadataFactory.php
@@ -2,8 +2,11 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
+use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory as BaseClassMetadataFactory;
+
+use function assert;
 
 class ClassMetadataFactory extends BaseClassMetadataFactory
 {
@@ -16,13 +19,19 @@ class ClassMetadataFactory extends BaseClassMetadataFactory
 
         $customGeneratorDefinition = $class->customGeneratorDefinition;
 
-        if (! isset($customGeneratorDefinition['instance'])) {
+        $generator = $customGeneratorDefinition['instance'] ?? null;
+        if (! $generator) {
             return;
         }
 
+        if (isset($customGeneratorDefinition['method'], $customGeneratorDefinition['arguments'])) {
+            $generator = $generator->{$customGeneratorDefinition['method']}(...$customGeneratorDefinition['arguments']);
+            assert($generator instanceof AbstractIdGenerator);
+        }
+
         $class->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
-        $class->setIdGenerator($customGeneratorDefinition['instance']);
-        unset($customGeneratorDefinition['instance']);
+        $class->setIdGenerator($generator);
+        unset($customGeneratorDefinition['instance'], $customGeneratorDefinition['id'], $customGeneratorDefinition['method'], $customGeneratorDefinition['arguments']);
         $class->setCustomGeneratorDefinition($customGeneratorDefinition);
     }
 }

--- a/Mapping/MappingDriver.php
+++ b/Mapping/MappingDriver.php
@@ -4,8 +4,12 @@ namespace Doctrine\Bundle\DoctrineBundle\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver as MappingDriverInterface;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Psr\Container\ContainerInterface;
+
+use const PHP_VERSION_ID;
 
 class MappingDriver implements MappingDriverInterface
 {
@@ -45,15 +49,56 @@ class MappingDriver implements MappingDriverInterface
         $this->driver->loadMetadataForClass($className, $metadata);
 
         if (
-            $metadata->generatorType !== ClassMetadataInfo::GENERATOR_TYPE_CUSTOM
-            || ! isset($metadata->customGeneratorDefinition['class'])
-            || ! $this->idGeneratorLocator->has($metadata->customGeneratorDefinition['class'])
+            $metadata->generatorType === ClassMetadataInfo::GENERATOR_TYPE_CUSTOM
+            && isset($metadata->customGeneratorDefinition['class'])
+            && $this->idGeneratorLocator->has($metadata->customGeneratorDefinition['class'])
         ) {
+            $idGenerator = $this->idGeneratorLocator->get($metadata->customGeneratorDefinition['class']);
+            $metadata->setCustomGeneratorDefinition(['instance' => $idGenerator] + $metadata->customGeneratorDefinition);
+            $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+
             return;
         }
 
-        $idGenerator = $this->idGeneratorLocator->get($metadata->customGeneratorDefinition['class']);
-        $metadata->setCustomGeneratorDefinition(['instance' => $idGenerator] + $metadata->customGeneratorDefinition);
+        if ($metadata->generatorType !== ClassMetadataInfo::GENERATOR_TYPE_NONE) {
+            return;
+        }
+
+        $driver = $this->driver;
+        if ($driver instanceof MappingDriverChain) {
+            foreach ($driver->getDrivers() as $namespace => $driver) {
+                if (strpos($className, $namespace) === 0) {
+                    break;
+                }
+            }
+        }
+
+        if (! $driver instanceof AnnotationDriver) {
+            return;
+        }
+
+        $annotation = null;
+        foreach ($metadata->getReflectionClass()->getProperties() as $property) {
+            if (PHP_VERSION_ID >= 80000) {
+                $attributes = $property->getAttributes(ServiceGeneratedValue::class);
+                if ($attributes) {
+                    $annotation = $attributes[0]->newInstance();
+                    break;
+                }
+            }
+
+            $annotation = $driver->getReader()->getPropertyAnnotation($property, ServiceGeneratedValue::class);
+            if ($annotation) {
+                break;
+            }
+        }
+
+        if (! $annotation instanceof ServiceGeneratedValue) {
+            return;
+        }
+
+        $idGenerator = $this->idGeneratorLocator->get($annotation->id);
+        $metadata->setCustomGeneratorDefinition(['instance' => $idGenerator] + (array) $annotation);
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
     }
 }

--- a/Mapping/ServiceGeneratedValue.php
+++ b/Mapping/ServiceGeneratedValue.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Mapping;
+
+use Attribute;
+use Doctrine\ORM\Mapping\Annotation;
+use InvalidArgumentException;
+
+use function array_shift;
+use function is_array;
+
+/**
+ * @Annotation
+ * @Target("PROPERTY")
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ServiceGeneratedValue implements Annotation
+{
+    /**
+     * The service id of the id-generator to use.
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * A method of the id-generator service that should be used to get the actual id-generator to use.
+     *
+     * @var string|null
+     */
+    public $method;
+
+    /**
+     * The arguments to pass to the previous method to configure the actual id-generator.
+     *
+     * @var mixed[]
+     */
+    public $arguments = [];
+
+    /**
+     * @param string|mixed[] $id
+     * @param mixed[]        ...$arguments
+     */
+    public function __construct($id, ?string $method = null, ...$arguments)
+    {
+        if (is_array($id)) {
+            if (is_array($id['value'] ?? null)) {
+                $arguments = $id['value'];
+                $id        = array_shift($arguments);
+                $method    = array_shift($arguments);
+            } else {
+                $arguments = $id['arguments'] ?? [];
+                $method    = $id['method'] ?? null;
+                $id        = $id['id'] ?? null;
+            }
+
+            if ($id === null) {
+                throw new InvalidArgumentException('Annotation "@ServiceGeneratedValue()" is missing argument #1 ($id).');
+            }
+        }
+
+        $this->id        = $id;
+        $this->method    = $method;
+        $this->arguments = $arguments;
+    }
+}

--- a/Resources/doc/custom-id-generators.rst
+++ b/Resources/doc/custom-id-generators.rst
@@ -32,7 +32,7 @@ are provided: ``doctrine.ulid_generator`` to generate ULIDs, and
          * @Id
          * @Column(type="uuid")
          * @ORM\GeneratedValue(strategy="CUSTOM")
-         * @ORM\CustomIdGenerator('doctrine.uuid_generator')
+         * @ORM\CustomIdGenerator("doctrine.uuid_generator")
          */
         private $id;
 
@@ -42,3 +42,41 @@ are provided: ``doctrine.ulid_generator`` to generate ULIDs, and
 See also
 https://www.doctrine-project.org/projects/doctrine-orm/en/2.8/reference/annotations-reference.html#annref_customidgenerator
 for more info about custom ID generators.
+
+Doctrine bundle 2.3 also provides the `@ServiceGeneratedValue` annotation
+that you can use instead of the `@GeneratedValue` + `@CustomIdGenerator` combo:
+
+.. code-block:: php
+
+    <?php
+    // User.php
+
+    use Doctrine\Bundle\DoctrineBundle\Mapping\ServiceGeneratedValue;
+    use Doctrine\ORM\Mapping as ORM;
+
+    /**
+     * @ORM\Entity
+     */
+    class User
+    {
+        /**
+         * @Id
+         * @Column(type="integer")
+         * @ServiceGeneratedValue("my_id_generator")
+         */
+        private $id;
+
+        // ....
+    }
+
+If the id-generator service supports it, this annotation allows defining a method
+that should be called on the service to configure it. This possibility is leveraged
+by the `doctrine.uuid_generator` service to allow configuring which type of UUID
+should be generated, if the defaults don't suit your needs.
+
+E.g. ``@ServiceGeneratedValue("doctrine.uuid_generator", "randomBased")`` will
+generate UUIDv4 random-based UUIDs instead of the default ones (usually UUIDv6.)
+
+This more advanced example will populate a property by generating a name-based
+UUIDv5 that would hash the return-value of ``$entity->getEmail()`` with ``some-UUID-namespace``:
+``@ServiceGeneratedValue("doctrine.uuid_generator", "nameBased", "getEmail", "some-UUID-namespace")``

--- a/Tests/CustomIdGeneratorTest.php
+++ b/Tests/CustomIdGeneratorTest.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\EntityManagerInterface;
 use Fixtures\Bundles\AnnotationsBundle\AnnotationsBundle;
 use Fixtures\Bundles\AnnotationsBundle\Entity\TestCustomIdGeneratorEntity;
+use Fixtures\Bundles\AnnotationsBundle\Entity\TestServiceGeneratedValueEntity;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -81,5 +82,9 @@ class CustomIdGeneratorTest extends TestCase
 
         $metadata = $em->getClassMetadata(TestCustomIdGeneratorEntity::class);
         $this->assertInstanceOf(CustomIdGenerator::class, $metadata->idGenerator);
+
+        $metadata = $em->getClassMetadata(TestServiceGeneratedValueEntity::class);
+        $this->assertInstanceOf(CustomIdGenerator::class, $metadata->idGenerator);
+        $this->assertSame(123, $metadata->idGenerator->value);
     }
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/TestServiceGeneratedValueEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/TestServiceGeneratedValueEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Fixtures\Bundles\AnnotationsBundle\Entity;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\ServiceGeneratedValue;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TestServiceGeneratedValueEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ServiceGeneratedValue(id="my_id_generator", method="theMethod", arguments={123})
+     *
+     * @var int
+     */
+    public $id;
+}

--- a/Tests/DependencyInjection/Fixtures/CustomIdGenerator.php
+++ b/Tests/DependencyInjection/Fixtures/CustomIdGenerator.php
@@ -7,8 +7,19 @@ use Doctrine\ORM\Id\AbstractIdGenerator;
 
 class CustomIdGenerator extends AbstractIdGenerator
 {
+    /** @var int */
+    public $value = 42;
+
     public function generate(EntityManager $em, $entity)
     {
-        return 42;
+        return $this->value;
+    }
+
+    public function theMethod(int $value): self
+    {
+        $clone        = clone $this;
+        $clone->value = $value;
+
+        return $clone;
     }
 }

--- a/Tests/Mapping/ContainerEntityListenerResolverTest.php
+++ b/Tests/Mapping/ContainerEntityListenerResolverTest.php
@@ -5,8 +5,8 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\Mapping;
 use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
@@ -15,7 +15,7 @@ class ContainerEntityListenerResolverTest extends TestCase
     /** @var ContainerEntityListenerResolver */
     private $resolver;
 
-    /** @var ContainerInterface|PHPUnit_Framework_MockObject_MockObject */
+    /** @var ContainerInterface|MockObject */
     private $container;
 
     public static function setUpBeforeClass(): void

--- a/Tests/Mapping/MappingDriverTest.php
+++ b/Tests/Mapping/MappingDriverTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Mapping;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver;
+use Doctrine\Bundle\DoctrineBundle\Mapping\ServiceGeneratedValue;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+
+class MappingDriverTest extends TestCase
+{
+    public function testServiceGeneratedValueAnnotation(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->any())->method('has')->with('id-generator')->willReturn(true);
+        $container->expects($this->any())->method('get')->with('id-generator')->willReturn('the-id-generator');
+
+        $annotDriver   = new AnnotationDriver(new AnnotationReader());
+        $mappingDriver = new MappingDriver($annotDriver, $container);
+
+        $class               = ServiceGeneratedValueAnnotated::class;
+        $metadata            = new ClassMetadataInfo($class);
+        $metadata->reflClass = new ReflectionClass($class);
+        $mappingDriver->loadMetadataForClass($class, $metadata);
+
+        $expected = [
+            'instance' => 'the-id-generator',
+            'id' => 'id-generator',
+            'method' => 'configure',
+            'arguments' => [123],
+        ];
+        $this->assertSame($expected, $metadata->customGeneratorDefinition);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testServiceGeneratedValueAttribute(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->any())->method('has')->with('id-generator')->willReturn(true);
+        $container->expects($this->any())->method('get')->with('id-generator')->willReturn('the-id-generator');
+
+        $annotDriver   = new AnnotationDriver(new AnnotationReader());
+        $mappingDriver = new MappingDriver($annotDriver, $container);
+
+        $class               = ServiceGeneratedValueAttributed::class;
+        $metadata            = new ClassMetadataInfo($class);
+        $metadata->reflClass = new ReflectionClass($class);
+        $mappingDriver->loadMetadataForClass($class, $metadata);
+
+        $expected = [
+            'instance' => 'the-id-generator',
+            'id' => 'id-generator',
+            'method' => 'configure',
+            'arguments' => [234],
+        ];
+        $this->assertSame($expected, $metadata->customGeneratorDefinition);
+    }
+}
+
+/** @ORM\Entity() */
+class ServiceGeneratedValueAnnotated
+{
+    /**
+     * @ServiceGeneratedValue(id="id-generator", method="configure", arguments={123})
+     *
+     * @var int
+     */
+    public $id;
+}
+
+/** @ORM\Entity() */
+class ServiceGeneratedValueAttributed
+{
+    /** @var int */
+    #[ServiceGeneratedValue('id-generator', 'configure', 234)]
+    public $id;
+}


### PR DESCRIPTION
Ths PR provides a `@ServiceGeneratedValue` annotation that one can use instead of the `@GeneratedValue` + `@CustomIdGenerator` combo.

See the [attached doc](https://github.com/doctrine/DoctrineBundle/pull/1295/files#diff-5edb9a6ef4c360d831febebdbdc972c4a6de5d673a57f2725339fecc09ac76ce) for more details and examples.