### PR TITLE
Register remember me schema subscriber from Symfony Bridge

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -28,6 +28,7 @@ use Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaSubscriber;
 use Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber;
+use Symfony\Bridge\Doctrine\SchemaListener\RememberMeTokenProviderDoctrineSchemaSubscriber;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
@@ -407,6 +408,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         // available in Symfony 5.1 and higher
         if (! class_exists(PdoCacheAdapterDoctrineSchemaSubscriber::class)) {
             $container->removeDefinition('doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber');
+        }
+
+        // available in Symfony 5.3 and higher
+        if (! class_exists(RememberMeTokenProviderDoctrineSchemaSubscriber::class)) {
+            $container->removeDefinition('doctrine.orm.listeners.doctrine_token_provider_schema_subscriber');
         }
 
         if (! class_exists(UlidGenerator::class)) {

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -137,6 +137,10 @@
             <argument type="collection" /> <!-- PdoAdapter instances -->
             <tag name="doctrine.event_subscriber" />
         </service>
+        <service id="doctrine.orm.listeners.doctrine_token_provider_schema_subscriber" class="Symfony\Bridge\Doctrine\SchemaListener\RememberMeTokenProviderDoctrineSchemaSubscriber">
+            <argument type="tagged" tag="security.remember_me_handler" />
+            <tag name="doctrine.event_subscriber" />
+        </service>
 
         <!-- naming strategy -->
         <service id="doctrine.orm.naming_strategy.default" class="%doctrine.orm.naming_strategy.default.class%" public="false" />


### PR DESCRIPTION
This PR registers the `RememberMeTokenProviderDoctrineSchemaSubscriber` schema listener that will be introduced in symfony/symfony#40145 . This way, Doctrine's schema system can help the user create and update their remember me table.