### PR TITLE
Add template definitions to ServiceEntityRepository

### DIFF
--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -19,6 +19,9 @@ use LogicException;
  *         parent::__construct($registry, YourEntity::class);
  *     }
  * }
+ *
+ * @template T
+ * @template-extends EntityRepository<T>
  */
 class ServiceEntityRepository extends EntityRepository implements ServiceEntityRepositoryInterface
 {


### PR DESCRIPTION
Since `ServiceEntityRepository` doesn't define any `@template`s it's impossible to tell Psalm what `T` is. With this PR the following would become possible:

```php
/**
 * @template-extends ServiceEntityRepository<User>
 */
class UserRepository extends ServiceEntityRepository
{
    public function __construct(ManagerRegistry $registry)
    {
        parent::__construct($registry, User::class);
    }
}
```

whereas right now the only option is to avoid `ServiceEntityRepository` and extend `EntityRepository` directly.