### PR TITLE
Add MappingDriver::getDriver()

### DIFF
--- a/Mapping/MappingDriver.php
+++ b/Mapping/MappingDriver.php
@@ -56,4 +56,12 @@ class MappingDriver implements MappingDriverInterface
         $metadata->setCustomGeneratorDefinition(['instance' => $idGenerator] + $metadata->customGeneratorDefinition);
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
     }
+
+    /**
+     * Returns the inner driver
+     */
+    public function getDriver(): MappingDriverInterface
+    {
+        return $this->driver;
+    }
 }


### PR DESCRIPTION
This PR fixes a BC break with #1284 that doesn't allow getting MappingDriverChain with the newly introduced MappingDriver class.
This PR will help solve issue [841](https://github.com/symfony/maker-bundle/issues/841) on the Symfony maker bundle.