### PR TITLE
Disable schema validation no matter the profiling configuration

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -156,6 +156,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         unset($connection['logging']);
 
+        $dataCollectorDefinition = $container->getDefinition('data_collector.doctrine');
+        $dataCollectorDefinition->replaceArgument(1, $connection['profiling_collect_schema_errors']);
+
         if ($connection['profiling']) {
             $profilingAbstractId = $connection['profiling_collect_backtrace'] ?
                 'doctrine.dbal.logger.backtrace' :
@@ -164,9 +167,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $profilingLoggerId = $profilingAbstractId . '.' . $name;
             $container->setDefinition($profilingLoggerId, new ChildDefinition($profilingAbstractId));
             $profilingLogger = new Reference($profilingLoggerId);
-            $container->getDefinition('data_collector.doctrine')
-                ->addMethodCall('addLogger', [$name, $profilingLogger])
-                ->replaceArgument(1, $connection['profiling_collect_schema_errors']);
+            $dataCollectorDefinition->addMethodCall('addLogger', [$name, $profilingLogger]);
 
             if ($logger !== null) {
                 $chainLogger = $container->register(

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1204,6 +1204,21 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'setRepositoryFactory', ['repository_factory']);
     }
 
+    public function testDisableSchemaValidation(): void
+    {
+        $container           = $this->loadContainer('dbal_collect_schema_errors_enable');
+        $collectorDefinition = $container->getDefinition('data_collector.doctrine');
+        $this->assertTrue($collectorDefinition->getArguments()[1]);
+
+        $container           = $this->loadContainer('dbal_collect_schema_errors_disable');
+        $collectorDefinition = $container->getDefinition('data_collector.doctrine');
+        $this->assertFalse($collectorDefinition->getArguments()[1]);
+
+        $container           = $this->loadContainer('dbal_collect_schema_errors_disable_no_profiling');
+        $collectorDefinition = $container->getDefinition('data_collector.doctrine');
+        $this->assertFalse($collectorDefinition->getArguments()[1]);
+    }
+
     private function loadContainer(
         string $fixture,
         array $bundles = ['YamlBundle'],

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_collect_schema_errors_disable.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_collect_schema_errors_disable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="mysql">
+            <connection
+                name="profile_without_schema_validator"
+                logging="false"
+                profiling="true"
+                profiling-collect-schema-errors="false" />
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_collect_schema_errors_disable_no_profiling.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_collect_schema_errors_disable_no_profiling.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="mysql">
+            <connection
+                name="profile_without_schema_validator_no_profiling"
+                logging="false"
+                profiling="false"
+                profiling-collect-schema-errors="false" />
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_collect_schema_errors_enable.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_collect_schema_errors_enable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="mysql">
+            <connection
+                name="profile_with_schema_validator"
+                logging="false"
+                profiling="true"
+                profiling-collect-schema-errors="true" />
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_collect_schema_errors_disable.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_collect_schema_errors_disable.yml
@@ -1,0 +1,8 @@
+doctrine:
+    dbal:
+        default_connection: mysql
+        connections:
+            profile_without_schema_validator:
+                logging: false
+                profiling: true
+                profiling_collect_schema_errors: false

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_collect_schema_errors_disable_no_profiling.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_collect_schema_errors_disable_no_profiling.yml
@@ -1,0 +1,8 @@
+doctrine:
+    dbal:
+        default_connection: mysql
+        connections:
+            profile_without_schema_validator_no_profiling:
+                logging: false
+                profiling: false
+                profiling_collect_schema_errors: false

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_collect_schema_errors_enable.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_collect_schema_errors_enable.yml
@@ -1,0 +1,8 @@
+doctrine:
+    dbal:
+        default_connection: mysql
+        connections:
+            profile_with_schema_validator:
+                logging: false
+                profiling: true
+                profiling_collect_schema_errors: true


### PR DESCRIPTION
On Symfony, there is a way with `APP_ENV=dev` and `APP_DEBUG=false` to have the profiling disable but still have the DataCollector running.

In this particular case, the schema validation will occured even if the configuration disable it.
The funny thing is that it's slower with debug disable...

Question: the correct fix shouldn't be to remove the collector when profiling is disabled?