### PR TITLE
Make DoctrineBundle compatible with ORM 2.9

### DIFF
--- a/Command/Proxy/ClearMetadataCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearMetadataCacheDoctrineCommand.php
@@ -28,8 +28,13 @@ class ClearMetadataCacheDoctrineCommand extends MetadataCommand
 
         $this
             ->setName('doctrine:cache:clear-metadata')
-            ->setDescription('Clears all metadata cache for an entity manager')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setDescription('Clears all metadata cache for an entity manager');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/ClearQueryCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearQueryCacheDoctrineCommand.php
@@ -21,8 +21,13 @@ class ClearQueryCacheDoctrineCommand extends QueryCommand
 
         $this
             ->setName('doctrine:cache:clear-query')
-            ->setDescription('Clears all query cache for an entity manager')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setDescription('Clears all query cache for an entity manager');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/ClearResultCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearResultCacheDoctrineCommand.php
@@ -21,8 +21,13 @@ class ClearResultCacheDoctrineCommand extends ResultCommand
 
         $this
             ->setName('doctrine:cache:clear-result')
-            ->setDescription('Clears result cache for an entity manager')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setDescription('Clears result cache for an entity manager');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/CollectionRegionDoctrineCommand.php
+++ b/Command/Proxy/CollectionRegionDoctrineCommand.php
@@ -20,8 +20,13 @@ class CollectionRegionDoctrineCommand extends CollectionRegionCommand
         parent::configure();
 
         $this
-            ->setName('doctrine:cache:clear-collection-region')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:cache:clear-collection-region');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/ConvertMappingDoctrineCommand.php
+++ b/Command/Proxy/ConvertMappingDoctrineCommand.php
@@ -25,8 +25,13 @@ class ConvertMappingDoctrineCommand extends ConvertMappingCommand
     {
         parent::configure();
         $this
-            ->setName('doctrine:mapping:convert')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:mapping:convert');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/CreateSchemaDoctrineCommand.php
+++ b/Command/Proxy/CreateSchemaDoctrineCommand.php
@@ -22,8 +22,13 @@ class CreateSchemaDoctrineCommand extends CreateCommand
 
         $this
             ->setName('doctrine:schema:create')
-            ->setDescription('Executes (or dumps) the SQL needed to generate the database schema')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setDescription('Executes (or dumps) the SQL needed to generate the database schema');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/DropSchemaDoctrineCommand.php
+++ b/Command/Proxy/DropSchemaDoctrineCommand.php
@@ -21,8 +21,13 @@ class DropSchemaDoctrineCommand extends DropCommand
 
         $this
             ->setName('doctrine:schema:drop')
-            ->setDescription('Executes (or dumps) the SQL needed to drop the current database schema')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setDescription('Executes (or dumps) the SQL needed to drop the current database schema');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/EnsureProductionSettingsDoctrineCommand.php
+++ b/Command/Proxy/EnsureProductionSettingsDoctrineCommand.php
@@ -20,8 +20,13 @@ class EnsureProductionSettingsDoctrineCommand extends EnsureProductionSettingsCo
         parent::configure();
 
         $this
-            ->setName('doctrine:ensure-production-settings')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:ensure-production-settings');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/EntityRegionCacheDoctrineCommand.php
+++ b/Command/Proxy/EntityRegionCacheDoctrineCommand.php
@@ -20,8 +20,13 @@ class EntityRegionCacheDoctrineCommand extends EntityRegionCommand
         parent::configure();
 
         $this
-            ->setName('doctrine:cache:clear-entity-region')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:cache:clear-entity-region');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/InfoDoctrineCommand.php
+++ b/Command/Proxy/InfoDoctrineCommand.php
@@ -18,8 +18,13 @@ class InfoDoctrineCommand extends InfoCommand
     protected function configure()
     {
         $this
-            ->setName('doctrine:mapping:info')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:mapping:info');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/QueryRegionCacheDoctrineCommand.php
+++ b/Command/Proxy/QueryRegionCacheDoctrineCommand.php
@@ -20,8 +20,13 @@ class QueryRegionCacheDoctrineCommand extends QueryRegionCommand
         parent::configure();
 
         $this
-            ->setName('doctrine:cache:clear-query-region')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:cache:clear-query-region');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/RunDqlDoctrineCommand.php
+++ b/Command/Proxy/RunDqlDoctrineCommand.php
@@ -21,7 +21,6 @@ class RunDqlDoctrineCommand extends RunDqlCommand
 
         $this
             ->setName('doctrine:query:dql')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command executes the given DQL query and
 outputs the results:
@@ -39,6 +38,12 @@ show:
 <info>php %command.full_name% "SELECT u FROM UserBundle:User u" --first-result=0 --max-result=30</info>
 EOT
         );
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/UpdateSchemaDoctrineCommand.php
+++ b/Command/Proxy/UpdateSchemaDoctrineCommand.php
@@ -21,8 +21,13 @@ class UpdateSchemaDoctrineCommand extends UpdateCommand
         parent::configure();
 
         $this
-            ->setName('doctrine:schema:update')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:schema:update');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Command/Proxy/ValidateSchemaCommand.php
+++ b/Command/Proxy/ValidateSchemaCommand.php
@@ -20,8 +20,13 @@ class ValidateSchemaCommand extends DoctrineValidateSchemaCommand
         parent::configure();
 
         $this
-            ->setName('doctrine:schema:validate')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+            ->setName('doctrine:schema:validate');
+
+        if ($this->getDefinition()->hasOption('em')) {
+            return;
+        }
+
+        $this->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
     }
 
     /**

--- a/Tests/Command/Proxy/InfoDoctrineCommandTest.php
+++ b/Tests/Command/Proxy/InfoDoctrineCommandTest.php
@@ -7,12 +7,15 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Kernel;
+
+use array_merge;
 
 class InfoDoctrineCommandTest extends TestCase
 {
@@ -31,13 +34,13 @@ class InfoDoctrineCommandTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            'You do not have any mapped Doctrine ORM entities according to the current configuration.',
+            'You do not have any mapped Doctrine ORM entities',
             $commandTester->getDisplay()
         );
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|Kernel
+     * @return MockObject|Kernel
      */
     private function setupKernelMocks()
     {
@@ -45,6 +48,7 @@ class InfoDoctrineCommandTest extends TestCase
         $configuration->setMetadataDriverImpl(new MappingDriverChain());
 
         $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+
         $manager = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
         $manager->method('getConnection')->willReturn($connection);
         $manager->method('getConfiguration')->willReturn($configuration);

--- a/Tests/Command/Proxy/InfoDoctrineCommandTest.php
+++ b/Tests/Command/Proxy/InfoDoctrineCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Command\Proxy;
+
+use Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class InfoDoctrineCommandTest extends TestCase
+{
+    public function testExecute(): void
+    {
+        $kernel = $this->setupKernelMocks();
+
+        $application = new Application($kernel);
+        $application->add(new InfoDoctrineCommand());
+
+        $command = $application->find('doctrine:mapping:info');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            array_merge(['command' => $command->getName()])
+        );
+
+        $this->assertStringContainsString(
+            'You do not have any mapped Doctrine ORM entities according to the current configuration.',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|Kernel
+     */
+    private function setupKernelMocks()
+    {
+        $configuration = new Configuration();
+        $configuration->setMetadataDriverImpl(new MappingDriverChain());
+
+        $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $manager = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
+        $manager->method('getConnection')->willReturn($connection);
+        $manager->method('getConfiguration')->willReturn($configuration);
+
+        $registry = $this->getMockBuilder(ManagerRegistry::class)->disableOriginalConstructor()->getMock();
+        $registry->method('getManager')->willReturn($manager);
+
+        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $container->method('get')->willReturn($registry);
+
+        $kernel = $this->getMockBuilder(Kernel::class)->disableOriginalConstructor()->getMock();
+        $kernel->method('getBundles')->willReturn([]);
+        $kernel->method('getContainer')->willReturn($container);
+
+        return $kernel;
+    }
+}

--- a/Tests/Command/Proxy/InfoDoctrineCommandTest.php
+++ b/Tests/Command/Proxy/InfoDoctrineCommandTest.php
@@ -40,9 +40,9 @@ class InfoDoctrineCommandTest extends TestCase
     }
 
     /**
-     * @return MockObject|Kernel
+     * @return MockObject&Kernel
      */
-    private function setupKernelMocks()
+    private function setupKernelMocks(): MockObject
     {
         $configuration = new Configuration();
         $configuration->setMetadataDriverImpl(new MappingDriverChain());
@@ -59,7 +59,9 @@ class InfoDoctrineCommandTest extends TestCase
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $container->method('get')->willReturn($registry);
 
-        $kernel = $this->getMockBuilder(Kernel::class)->disableOriginalConstructor()->getMock();
+        $kernel = $this->getMockBuilder(Kernel::class);
+        $kernel->disableOriginalConstructor();
+        $kernel = $kernel->getMock();
         $kernel->method('getBundles')->willReturn([]);
         $kernel->method('getContainer')->willReturn($container);
 

--- a/Tests/Command/Proxy/InfoDoctrineCommandTest.php
+++ b/Tests/Command/Proxy/InfoDoctrineCommandTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
-use array_merge;
+use function array_merge;
 
 class InfoDoctrineCommandTest extends TestCase
 {

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
+use Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand;
+use Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\DbalTestKernel;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventManager;
@@ -72,6 +74,8 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ProxyCacheWarmer::class, $container->get('doctrine.orm.proxy_cache_warmer'));
         $this->assertInstanceOf(ManagerRegistry::class, $container->get('doctrine'));
         $this->assertInstanceOf(UniqueEntityValidator::class, $container->get('doctrine.orm.validator.unique'));
+        $this->assertInstanceOf(InfoDoctrineCommand::class, $container->get('doctrine.mapping_info_command'));
+        $this->assertInstanceOf(UpdateSchemaDoctrineCommand::class, $container->get('doctrine.schema_update_command'));
 
         $this->assertSame($container->get('my.platform'), $container->get('doctrine.dbal.default_connection')->getDatabasePlatform());
 


### PR DESCRIPTION
In ORM 2.9 similar to DBAL 2.11 we introduce a new way of injecting the `EntityManager` into commands via registries/providers. These register the option `em`, which would lead to conflicts in the proxy commands due to redefinition of the option.

The same change was already made for dbal in 86d2469d6be06d55ad7b9e2f076f6942476f2e87

Once ORM 2.9 is out we can think of increasing the `doctrine/orm` dependency from 2.6 to 2.9, since both support PHP 7.1. Then we can replace the whole proxy command code with proper dependency injection and shipping an entity manager provider.

This PR adds one test for one proxy command to test the variable entity manager option behavior. In addition since commands are services for a while already, the `ContainerTest` is also extended to fetch two out of the container 