### PR TITLE
Add "dbname_suffix" config option to vary the dbname per env

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -57,7 +57,7 @@ class ConnectionFactory
         $overriddenOptions = $params['connection_override_options'] ?? [];
         unset($params['connection_override_options']);
 
-        if (! isset($params['pdo']) && (! isset($params['charset']) || $overriddenOptions)) {
+        if (! isset($params['pdo']) && (! isset($params['charset']) || $overriddenOptions || isset($params['dbname_suffix']))) {
             $wrapperClass = null;
 
             if (isset($params['wrapperClass'])) {
@@ -76,6 +76,10 @@ class ConnectionFactory
             $connection = DriverManager::getConnection($params, $config, $eventManager);
             $params     = array_merge($connection->getParams(), $overriddenOptions);
             $driver     = $connection->getDriver();
+
+            if (isset($params['dbname']) && isset($params['dbname_suffix'])) {
+                $params['dbname'] .= $params['dbname_suffix'];
+            }
 
             if ($driver instanceof AbstractMySQLDriver) {
                 $params['charset'] = 'utf8mb4';

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -239,6 +239,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('user')->info('Defaults to "root" at runtime.')->end()
                 ->scalarNode('password')->info('Defaults to null at runtime.')->end()
                 ->booleanNode('override_url')->defaultValue(false)->info('Allows overriding parts of the "url" parameter with dbname, host, port, user, and/or password parameters.')->end()
+                ->scalarNode('dbname_suffix')->end()
                 ->scalarNode('application_name')->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('path')->end()

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -52,6 +52,7 @@
         <xsd:attribute name="user" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />
         <xsd:attribute name="override-url" type="xsd:boolean" />
+        <xsd:attribute name="dbname-suffix" type="xsd:string" />
         <xsd:attribute name="application-name" type="xsd:string" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="unix-socket" type="xsd:string" />

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -31,6 +31,7 @@ Configuration Reference
                         user:                 root
                         password:             ~
                         charset:              "UTF8"
+                        dbname_suffix:        ~
 
                         # SQLite specific
                         path:                 ~
@@ -939,6 +940,7 @@ can configure. The following block shows all possible configuration keys:
                 port:                     1234
                 user:                     user
                 password:                 secret
+                dbname_suffix:            _test
                 driver:                   pdo_mysql
                 driver_class:             MyNamespace\MyDriverImpl
                 options:

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -96,6 +96,16 @@ class ConnectionFactoryTest extends TestCase
 
         $this->assertEquals($params, array_intersect_key($connection->getParams(), $params));
     }
+
+    public function testDbnameSuffix(): void
+    {
+        $connection = (new ConnectionFactory([]))->createConnection([
+            'url' => 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8',
+            'dbname_suffix' => '_test',
+        ]);
+
+        $this->assertSame('main_test', $connection->getParams()['dbname']);
+    }
 }
 
 /**

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -166,6 +166,15 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertFalse(isset($config['override_url']));
     }
 
+    public function testDbalDbnameSuffix(): void
+    {
+        $container = $this->loadContainer('dbal_dbname_suffix');
+        $config    = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
+
+        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
+        $this->assertSame('_test', $config['dbname_suffix']);
+    }
+
     public function testDbalLoadSingleMasterSlaveConnection(): void
     {
         $container = $this->loadContainer('dbal_service_single_master_slave_connection');

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_dbname_suffix.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_dbname_suffix.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8" dbname-suffix="_test" />
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_dbname_suffix.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_dbname_suffix.yml
@@ -1,0 +1,4 @@
+doctrine:
+    dbal:
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        dbname_suffix: _test


### PR DESCRIPTION
This should provide better flexibility than #1290 when needing to vary the dbname per env (think tests of course)