### PR TITLE
Support setting PSR-6 caches with ORM 2.9+

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -724,7 +724,6 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('type')->defaultNull()->end()
                 ->scalarNode('id')->end()
                 ->scalarNode('pool')->end()
-                ->scalarNode('psr6')->defaultFalse()->end()
             ->end();
 
         if ($name === 'metadata_cache_driver') {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -724,6 +724,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('type')->defaultNull()->end()
                 ->scalarNode('id')->end()
                 ->scalarNode('pool')->end()
+                ->scalarNode('psr6')->defaultFalse()->end()
             ->end();
 
         if ($name === 'metadata_cache_driver') {

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -11,6 +11,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
@@ -26,6 +27,7 @@ use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\UnitOfWork;
 use LogicException;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
@@ -1038,7 +1040,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
     {
         $serviceId = sprintf('doctrine.orm.cache.provider.%s', $poolName);
 
-        $definition = $container->register($serviceId);
+        $definition = $container->register($serviceId, CacheProvider::class);
         $definition->setFactory([DoctrineProvider::class, 'wrap']);
         $definition->addArgument(new Reference($poolName));
 
@@ -1077,7 +1079,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                     new Definition(PhpArrayAdapter::class, [
                         $phpArrayFile,
                         // Wrapping the DoctrineProvider created above in a CacheAdapter unwraps the pool from the provider
-                        (new Definition())
+                        (new Definition(CacheItemPoolInterface::class))
                             ->setFactory([CacheAdapter::class, 'wrap'])
                             ->addArgument(new Reference($decoratedMetadataCacheServiceId)),
                     ])

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -918,7 +918,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         // Create a wrapper as required
         if ($isPsr6 && ! $usePsr6) {
-            $wrappedServiceId = sprintf('cache.doctrine.orm.provider.%s.%s', $objectManagerName, $cacheName);
+            $wrappedServiceId = sprintf('doctrine.orm.cache.provider.%s.%s', $objectManagerName, $cacheName);
 
             $definition = $container->register($wrappedServiceId, CacheProvider::class);
             $definition->setFactory([DoctrineProvider::class, 'wrap']);
@@ -1050,17 +1050,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         $transportFactoryDefinition->addTag('messenger.transport_factory');
-    }
-
-    private function createPoolCacheDefinition(ContainerBuilder $container, string $poolName): string
-    {
-        $serviceId = sprintf('doctrine.orm.cache.provider.%s', $poolName);
-
-        $definition = $container->register($serviceId, CacheProvider::class);
-        $definition->setFactory([DoctrineProvider::class, 'wrap']);
-        $definition->addArgument(new Reference($poolName));
-
-        return $serviceId;
     }
 
     private function createArrayAdapterCachePool(ContainerBuilder $container, string $objectManagerName, string $cacheName): string

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -28,7 +28,6 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 use function class_exists;
 use function interface_exists;
-use function method_exists;
 
 class ContainerTest extends TestCase
 {
@@ -65,13 +64,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(Reader::class, $container->get('doctrine.orm.metadata.annotation_reader'));
         $this->assertInstanceOf(Configuration::class, $container->get('doctrine.orm.default_configuration'));
         $this->assertInstanceOf(MappingDriverChain::class, $container->get('doctrine.orm.default_metadata_driver'));
-
-        if (method_exists(Configuration::class, 'setMetadataCache')) {
-            $this->assertInstanceOf(PhpArrayAdapter::class, $container->get('doctrine.orm.default_metadata_cache'));
-        } else {
-            $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_metadata_cache'));
-        }
-
+        $this->assertInstanceOf(PhpArrayAdapter::class, $container->get('doctrine.orm.default_metadata_cache'));
         $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_query_cache'));
         $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_result_cache'));
         $this->assertInstanceOf(EntityManager::class, $container->get('doctrine.orm.default_entity_manager'));

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\DbalTestKernel;
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration as DBALConfiguration;
 use Doctrine\DBAL\Connection;
@@ -23,7 +24,7 @@ use Symfony\Bridge\Doctrine\Logger\DbalLogger;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
-use Symfony\Component\Cache\DoctrineProvider;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 use function class_exists;
 use function interface_exists;
@@ -63,7 +64,13 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(Reader::class, $container->get('doctrine.orm.metadata.annotation_reader'));
         $this->assertInstanceOf(Configuration::class, $container->get('doctrine.orm.default_configuration'));
         $this->assertInstanceOf(MappingDriverChain::class, $container->get('doctrine.orm.default_metadata_driver'));
-        $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_metadata_cache'));
+
+        if (method_exists(Configuration::class, 'setMetadataCache')) {
+            $this->assertInstanceOf(PhpArrayAdapter::class, $container->get('doctrine.orm.default_metadata_cache'));
+        } else {
+            $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_metadata_cache'));
+        }
+
         $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_query_cache'));
         $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_result_cache'));
         $this->assertInstanceOf(EntityManager::class, $container->get('doctrine.orm.default_entity_manager'));

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 use function class_exists;
 use function interface_exists;
+use function method_exists;
 
 class ContainerTest extends TestCase
 {

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1321,7 +1321,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * @param list<mixed> $params
-     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionMethodCallAt(
@@ -1350,7 +1349,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * Assertion for the DI Container, check if the given definition contains a method call with the given parameters.
      *
      * @param list<mixed> $params
-     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionMethodCallOnce(
@@ -1384,7 +1382,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * @param list<mixed> $params
-     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionMethodCallCount(
@@ -1418,7 +1415,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * Assertion for the DI Container, check if the given definition does not contain a method call with the given parameters.
      *
      * @param list<mixed> $params
-     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionNoMethodCall(

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\ORM\Configuration as OrmConfiguration;
 use Doctrine\ORM\EntityManagerInterface;
 use Generator;
 use InvalidArgumentException;
@@ -431,11 +430,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('doctrine.orm.em2_configuration', (string) $arguments[1]);
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_metadata_cache'));
-        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
-            $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
-        } else {
-            $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
-        }
+        $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_query_cache'));
         $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
@@ -479,18 +474,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_service_multiple_entity_managers');
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_metadata_cache'));
-        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
-            $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
-        } else {
-            $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
-        }
+        $this->assertDICDefinitionClass($definition, PhpArrayAdapter::class);
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em2_metadata_cache'));
-        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
-            $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
-        } else {
-            $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
-        }
+        $this->assertDICDefinitionClass($definition, PhpArrayAdapter::class);
     }
 
     public function testDependencyInjectionImportsOverrideDefaults(): void
@@ -505,13 +492,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setAutoGenerateProxyClasses', ['%doctrine.orm.auto_generate_proxy_classes%']);
 
         $cacheDefinition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
-        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
-            $this->assertEquals(PhpArrayAdapter::class, $cacheDefinition->getClass());
-            $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setMetadataCache', [new Reference('doctrine.orm.default_metadata_cache')]);
-        } else {
-            $this->assertEquals([DoctrineProvider::class, 'wrap'], $cacheDefinition->getFactory());
-            $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setMetadataCacheImpl', [new Reference('doctrine.orm.default_metadata_cache')]);
-        }
+        $this->assertEquals(PhpArrayAdapter::class, $cacheDefinition->getClass());
+        $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setMetadataCache', [new Reference('doctrine.orm.default_metadata_cache')]);
     }
 
     public function testSingleEntityManagerMultipleMappingBundleDefinitions(): void
@@ -1339,6 +1321,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * @param list<mixed> $params
+     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionMethodCallAt(
@@ -1367,6 +1350,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * Assertion for the DI Container, check if the given definition contains a method call with the given parameters.
      *
      * @param list<mixed> $params
+     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionMethodCallOnce(
@@ -1400,6 +1384,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * @param list<mixed> $params
+     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionMethodCallCount(
@@ -1433,6 +1418,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
      * Assertion for the DI Container, check if the given definition does not contain a method call with the given parameters.
      *
      * @param list<mixed> $params
+     *
      * @psalm-param Params $params
      */
     private function assertDICDefinitionNoMethodCall(

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -7,17 +7,19 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilter
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\WellKnownSchemaFilterPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\Configuration as OrmConfiguration;
 use Doctrine\ORM\EntityManagerInterface;
 use Generator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -429,16 +431,20 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('doctrine.orm.em2_configuration', (string) $arguments[1]);
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_metadata_cache'));
-        $this->assertEquals(DoctrineProvider::class, $definition->getClass());
+        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
+            $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
+        } else {
+            $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
+        }
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_query_cache'));
-        $this->assertEquals(DoctrineProvider::class, $definition->getClass());
+        $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
         $arguments = $definition->getArguments();
         $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('cache.doctrine.orm.em1.query', (string) $arguments[0]);
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_result_cache'));
-        $this->assertEquals(DoctrineProvider::class, $definition->getClass());
+        $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
         $arguments = $definition->getArguments();
         $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('cache.doctrine.orm.em1.result', (string) $arguments[0]);
@@ -473,10 +479,18 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->loadContainer('orm_service_multiple_entity_managers');
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_metadata_cache'));
-        $this->assertDICDefinitionClass($definition, DoctrineProvider::class);
+        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
+            $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
+        } else {
+            $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
+        }
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em2_metadata_cache'));
-        $this->assertDICDefinitionClass($definition, DoctrineProvider::class);
+        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
+            $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
+        } else {
+            $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
+        }
     }
 
     public function testDependencyInjectionImportsOverrideDefaults(): void
@@ -487,11 +501,17 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $container = $this->loadContainer('orm_imports');
 
-        $cacheDefinition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
-        $this->assertEquals(DoctrineProvider::class, $cacheDefinition->getClass());
-
         $configDefinition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setAutoGenerateProxyClasses', ['%doctrine.orm.auto_generate_proxy_classes%']);
+
+        $cacheDefinition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_metadata_cache'));
+        if (method_exists(OrmConfiguration::class, 'setMetadataCache')) {
+            $this->assertEquals(PhpArrayAdapter::class, $cacheDefinition->getClass());
+            $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setMetadataCache', [new Reference('doctrine.orm.default_metadata_cache')]);
+        } else {
+            $this->assertEquals([DoctrineProvider::class, 'wrap'], $cacheDefinition->getFactory());
+            $this->assertDICDefinitionMethodCallOnce($configDefinition, 'setMetadataCacheImpl', [new Reference('doctrine.orm.default_metadata_cache')]);
+        }
     }
 
     public function testSingleEntityManagerMultipleMappingBundleDefinitions(): void
@@ -717,7 +737,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionClass($myEntityRegionDef, '%doctrine.orm.second_level_cache.default_region.class%');
         $this->assertDICDefinitionClass($loggerChainDef, '%doctrine.orm.second_level_cache.logger_chain.class%');
         $this->assertDICDefinitionClass($loggerStatisticsDef, '%doctrine.orm.second_level_cache.logger_statistics.class%');
-        $this->assertDICDefinitionClass($cacheDriverDef, DoctrineProvider::class);
+        $this->assertEquals([DoctrineProvider::class, 'wrap'], $cacheDriverDef->getFactory());
         $this->assertDICDefinitionMethodCallOnce($configDef, 'setSecondLevelCacheConfiguration');
         $this->assertDICDefinitionMethodCallCount($slcFactoryDef, 'setRegion', [], 3);
         $this->assertDICDefinitionMethodCallCount($loggerChainDef, 'setLogger', [], 3);

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1001,25 +1001,25 @@ class DoctrineExtensionTest extends TestCase
         return [
             'query_cache_default' => [
                 'expectedAliasName' => 'doctrine.orm.default_query_cache',
-                'expectedAliasTarget' => 'cache.doctrine.orm.provider.default.query',
+                'expectedAliasTarget' => 'doctrine.orm.cache.provider.default.query',
                 'cacheName' => 'query_cache_driver',
                 'cacheConfig' => ['type' => null],
             ],
             'result_cache_default' => [
                 'expectedAliasName' => 'doctrine.orm.default_result_cache',
-                'expectedAliasTarget' => 'cache.doctrine.orm.provider.default.result',
+                'expectedAliasTarget' => 'doctrine.orm.cache.provider.default.result',
                 'cacheName' => 'result_cache_driver',
                 'cacheConfig' => ['type' => null],
             ],
             'query_cache_pool' => [
                 'expectedAliasName' => 'doctrine.orm.default_query_cache',
-                'expectedAliasTarget' => 'cache.doctrine.orm.provider.default.query',
+                'expectedAliasTarget' => 'doctrine.orm.cache.provider.default.query',
                 'cacheName' => 'query_cache_driver',
                 'cacheConfig' => ['type' => 'pool', 'pool' => 'query_cache_pool'],
             ],
             'result_cache_pool' => [
                 'expectedAliasName' => 'doctrine.orm.default_result_cache',
-                'expectedAliasTarget' => 'cache.doctrine.orm.provider.default.result',
+                'expectedAliasTarget' => 'doctrine.orm.cache.provider.default.result',
                 'cacheName' => 'result_cache_driver',
                 'cacheConfig' => ['type' => 'pool', 'pool' => 'result_cache_pool'],
             ],

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "sort-packages": true
     },
     "conflict": {
-        "doctrine/orm": "<2.6",
+        "doctrine/orm": "<2.9",
         "twig/twig": "<1.34|>=2.0,<2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/dbal": "^2.9.0|^3.0",
         "doctrine/persistence": "^1.3.3|^2.0",
         "doctrine/sql-formatter": "^1.0.1",


### PR DESCRIPTION
This adds support for doctrine/cache 2.0 as well as the new `setMetadataCache` method being introduced to ORM in https://github.com/doctrine/orm/pull/8651. This removes the need to wrap the configured cache pool in a doctrine/cache wrapper and injects this pool directly. If a service is configured as metadata cache, or ORM < 2.9 is installed, this will continue to use the then deprecated `setMetadataCacheImpl` to inject the cache. It will however wrap the cache pool in the compatibility layer provided by doctrine/cache to remove the need for Symfony to maintain their own adapter for doctrine/cache (see https://github.com/symfony/symfony/pull/40908).