### PR TITLE
Fix tests compatibility with doctrine-bridge 5.x

### DIFF
--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1091,7 +1091,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $defaultEventManagerArguments = $defaultEventManager->getArguments();
 
         if (isset($defaultEventManagerArguments[1][1])) {
-            $this->assertSame([['loadClassMetadata'], 'doctrine.orm.em1_listeners.attach_entity_listeners'], $defaultEventManager->getArgument(1)[1]);
+            $this->assertSame([['loadClassMetadata'], 'doctrine.orm.em1_listeners.attach_entity_listeners'], $defaultEventManager->getArgument(1)[2]);
         } else {
             $this->assertDICDefinitionMethodCallOnce($defaultEventManager, 'addEventListener', [['loadClassMetadata'], new Reference('doctrine.orm.em1_listeners.attach_entity_listeners')]);
         }
@@ -1101,7 +1101,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $foobarEventManagerArguments = $foobarEventManager->getArguments();
 
         if (isset($foobarEventManagerArguments[1][1])) {
-            $this->assertSame([['loadClassMetadata'], 'doctrine.orm.em2_listeners.attach_entity_listeners'], $foobarEventManager->getArgument(1)[1]);
+            $this->assertSame([['loadClassMetadata'], 'doctrine.orm.em2_listeners.attach_entity_listeners'], $foobarEventManager->getArgument(1)[2]);
         } else {
             $this->assertDICDefinitionMethodCallOnce($foobarEventManager, 'addEventListener', [['loadClassMetadata'], new Reference('doctrine.orm.em2_listeners.attach_entity_listeners')]);
         }


### PR DESCRIPTION
With DoctrineBridge 5.x, there are 3 listeners instead of 2. The `attach_entity_listener` is always the last one.

cc @ostrolucky 