### PR TITLE
Deprecate mixing the `url` option with `host`, `dbname` and a few others

### DIFF
--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -4,6 +4,8 @@ UPGRADE FROM 2.3 to 2.4
 Configuration
 --------
 
+ * Setting the `host`, `port`, `user`, `password`, `path`, `dbname`, `unix_socket`
+   or `memory` configuration options while the `url` one is set has been deprecated.
  * The `override_url` configuration option has been deprecated.
  * Combined use of simplified connection configuration in DBAL (without `connections` key) 
    and multiple connection configuration is disallowed now. If you experience this issue, instead of


### PR DESCRIPTION
As proposed in #1331

For discussion. (I'll take care of tests once the discussion has settled.)