### PR TITLE
Deprecate not defining entity_managers and connections due merge issues 

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -89,6 +89,10 @@ class Configuration implements ConfigurationInterface
                             unset($v[$key]);
                         }
 
+                        if ($connection) {
+                            @trigger_error('Not defining "doctrine.dbal.connections" configuration option is deprecated since doctrine-bundle 2.4.', E_USER_DEPRECATED);
+                        }
+
                         $v['default_connection'] = isset($v['default_connection']) ? (string) $v['default_connection'] : 'default';
                         $v['connections']        = [$v['default_connection'] => $connection];
 
@@ -244,7 +248,7 @@ class Configuration implements ConfigurationInterface
 
                 if ($deprecatedValues) {
                     $message = count($deprecatedValues) > 1 ? 'options are' : 'option is';
-                    @trigger_error(sprintf('The "doctrine.dbal.%s" %s deprecated since DoctrineBundle 2.4, use the "doctrine.dbal.url" option instead.', implode('", "doctrine.dbal.', array_keys($deprecatedValues)), $message), E_USER_DEPRECATED);
+                    @trigger_error(sprintf('The "doctrine.dbal.%s" %s deprecated since doctrine-bundle 2.4, use the "doctrine.dbal.url" option instead.', implode('", "doctrine.dbal.', array_keys($deprecatedValues)), $message), E_USER_DEPRECATED);
                 }
 
                 return $values;
@@ -391,6 +395,10 @@ class Configuration implements ConfigurationInterface
 
                                 $entityManager[$key] = $v[$key];
                                 unset($v[$key]);
+                            }
+
+                            if ($entityManager) {
+                                @trigger_error('Not defining "doctrine.orm.entity_managers" configuration option is deprecated since doctrine-bundle 2.4.', E_USER_DEPRECATED);
                             }
 
                             $v['default_entity_manager'] = isset($v['default_entity_manager']) ? (string) $v['default_entity_manager'] : 'default';

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -209,7 +209,7 @@ class DoctrineExtensionTest extends TestCase
         $this->expectExceptionMessage(
             'Configuring the ORM layer requires to configure the DBAL layer as well.'
         );
-        $extension->load([['orm' => ['auto_mapping' => true]]], $this->getContainer());
+        $extension->load([['orm' => ['entity_managers' => ['default' => ['auto_mapping' => true]]]]], $this->getContainer());
     }
 
     /** @return mixed[][][][] */
@@ -943,7 +943,7 @@ class DoctrineExtensionTest extends TestCase
 
         $config = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
-            ->addEntityManager([$cacheName => $cacheConfig])
+            ->addEntityManager(['entity_managers' => ['default' => [$cacheName => $cacheConfig]]])
             ->build();
 
         $extension->load([$config], $container);

--- a/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
@@ -46,7 +46,7 @@ class DbalTestKernel extends Kernel
             $container->loadFromExtension('framework', ['secret' => 'F00']);
 
             $container->loadFromExtension('doctrine', [
-                'dbal' => $this->dbalConfig,
+                'dbal' => ['connections' => ['default' => $this->dbalConfig]],
             ]);
 
             // Register a NullLogger to avoid getting the stderr default logger of FrameworkBundle

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -39,14 +39,18 @@ class TestKernel extends Kernel
             $container->loadFromExtension('framework', ['secret' => 'F00']);
 
             $container->loadFromExtension('doctrine', [
-                'dbal' => ['driver' => 'pdo_sqlite'],
+                'dbal' => ['connections' => ['default' => ['driver' => 'pdo_sqlite']]],
                 'orm' => [
                     'auto_generate_proxy_classes' => true,
-                    'mappings' => [
-                        'RepositoryServiceBundle' => [
-                            'type' => 'annotation',
-                            'dir' => __DIR__ . '/Bundles/RepositoryServiceBundle/Entity',
-                            'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Entity',
+                    'entity_managers' => [
+                        'default' => [
+                            'mappings' => [
+                                'RepositoryServiceBundle' => [
+                                    'type' => 'annotation',
+                                    'dir' => __DIR__ . '/Bundles/RepositoryServiceBundle/Entity',
+                                    'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Entity',
+                                ],
+                            ],
                         ],
                     ],
                 ],

--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -5,6 +5,34 @@ Configuration
 --------
 
  * The `override_url` configuration option has been deprecated.
+ * Simplified configuration of DBAL connections when using single connection only has been deprecated. That means defining`doctrine.dbal.connections` explicitly is required now. Instead of using
+```yaml
+doctrine:
+  dbal:
+    url: '%env(DATABASE_URL)%'
+```
+use
+```yaml
+doctrine:
+  dbal:
+    connections:
+      default:
+        url: '%env(DATABASE_URL)%'        
+```
+ * Simplified configuration of ORM entity managers when using single entity manager only has been deprecated. That means defining`doctrine.orm.entity_managers` explicitly is required now. Instead of using
+```yaml
+doctrine:
+  orm:
+    mappings:
+```
+use
+```yaml
+doctrine:
+  orm:
+    entity_managers:
+      default:
+        mappings:        
+```
 
 ConnectionFactory
 --------


### PR DESCRIPTION
Context: https://github.com/doctrine/DoctrineBundle/issues/1337

### Description:
This reverts ab047c6f24420c44c7ad08cf2487ab47d4cba46d and ae0a3c649af899f95a2f45fa7dca79ba6a7b27c9

What wasn't accounted previously when deciding to implement these simplifications are issues when merging. Given following relevant parts of configs:

/doctrine.yaml
```yaml
doctrine:
    orm:
        default_entity_manager: app
        entity_managers:
            app:
            extra_manager:
```
/prod/doctrine.yaml
```yaml
doctrine:
    orm:
        metadata_cache_driver:
```

there are 2 issues:

* Issue no. 1:  When APP_ENV=prod, default_entity_manager is changed to `default`. And doctrine.orm.default.entity_manager is created, despite explicitly used configuration not using it
* Issue no. 2: When reading /prod/doctrine.yaml, instinctively, since there is no entity manager specified there, developers have impression options defined directly under doctrine.orm.* will be applied to all entity managers. But that's not what bundles does. Instead, it applies it to default entity manager only

These are the limitations of symfony/config component. When evaluating /prod/doctrine.yaml, in Configuration.php we don't have an access to values from /doctrine.yaml


### Status of this PR

This is not a finished PR, couple more deprecation fixes need to be done in our tests, as well as updates in .rst files. I will leave this here unfinished for couple days to give some room for possible discussion about alternatives, after that I'll finish it.

What I don't want to do is doing the job of Config component (merging and normalization) ourselves in DoctrineExtension, as that may be error prone. And even if we did, we can't fix issue no. 2 without breaking BC.