### PR TITLE
Add "attribute" type to "mapping" for AttributeDriver

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -31,6 +31,7 @@
         <!-- metadata -->
         <parameter key="doctrine.orm.metadata.driver_chain.class">Doctrine\Persistence\Mapping\Driver\MappingDriverChain</parameter>
         <parameter key="doctrine.orm.metadata.annotation.class">Doctrine\ORM\Mapping\Driver\AnnotationDriver</parameter>
+        <parameter key="doctrine.orm.metadata.attribute.class">Doctrine\ORM\Mapping\Driver\AttributeDriver</parameter>
         <parameter key="doctrine.orm.metadata.xml.class">Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver</parameter>
         <parameter key="doctrine.orm.metadata.yml.class">Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver</parameter>
         <parameter key="doctrine.orm.metadata.php.class">Doctrine\ORM\Mapping\Driver\PHPDriver</parameter>


### PR DESCRIPTION
In the new Doctrine ORM 2.9 there is the possibility to use Attributes to map entities but in this bundle, there's no `type` defined to use `AttributeDriver`