### PR TITLE
Make configuration error message better understandable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
                         }
 
                         if ($connection && $hasExplicitlyDefinedConnectionsAtLeastOnce) {
-                            throw new InvalidArgumentException('Either explicitly define DBAL connections in all doctrine-bundle configuration files, or in none of them');
+                            throw new InvalidArgumentException('Seems like you have configured multiple "dbal" connections. You need to use the long configuration syntax in every doctrine configuration file, or in none of them.');
                         }
 
                         $v['default_connection'] = isset($v['default_connection']) ? (string) $v['default_connection'] : 'default';
@@ -413,7 +413,7 @@ class Configuration implements ConfigurationInterface
                             }
 
                             if ($entityManager && $hasExplicitlyDefinedEntityManagersAtLeastOnce) {
-                                throw new InvalidArgumentException('Either explicitly define entity managers in all doctrine-bundle configuration files, or in none of them');
+                                throw new InvalidArgumentException('Seems like you have configured multiple "entity_managers". You need to use the long configuration syntax in every doctrine configuration file, or in none of them.');
                             }
 
                             $v['default_entity_manager'] = isset($v['default_entity_manager']) ? (string) $v['default_entity_manager'] : 'default';

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -218,13 +218,13 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testMixedUseOfSimplifiedAndMultipleConnectionsStyleIsInvalid(): void
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Either explicitly define DBAL connections in all doctrine-bundle configuration files, or in none of them'));
+        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "entity_managers". You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
         $this->loadContainer('dbal_service_{single,multiple}_connectio{n,ns}');
     }
 
     public function testMixedUseOfSimplifiedAndMultipleEntityManagersStyleIsInvalid(): void
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Either explicitly define entity managers in all doctrine-bundle configuration files, or in none of them'));
+        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "dbal" connections. You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
         $this->loadContainer('orm_service_{simple_single,multiple}_entity_manage{r,rs}');
     }
 

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -218,13 +218,13 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testMixedUseOfSimplifiedAndMultipleConnectionsStyleIsInvalid(): void
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "entity_managers". You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
+        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "dbal" connections. You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
         $this->loadContainer('dbal_service_{single,multiple}_connectio{n,ns}');
     }
 
     public function testMixedUseOfSimplifiedAndMultipleEntityManagersStyleIsInvalid(): void
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "dbal" connections. You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
+        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "entity_managers". You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
         $this->loadContainer('orm_service_{simple_single,multiple}_entity_manage{r,rs}');
     }
 


### PR DESCRIPTION
This simply changes the message of the newly introduces check of the configuration syntax.
The previous message imposed a lot of research to get it fixed.

Hope this message is will help users to spot the problem a bit more quickly.