### PR TITLE
Revert "Disallow mixed use of simplified and non-simplified configuration

### DIFF
--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -216,18 +216,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals(['engine' => 'InnoDB'], $param['defaultTableOptions']);
     }
 
-    public function testMixedUseOfSimplifiedAndMultipleConnectionsStyleIsInvalid(): void
-    {
-        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "dbal" connections. You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
-        $this->loadContainer('dbal_service_{single,multiple}_connectio{n,ns}');
-    }
-
-    public function testMixedUseOfSimplifiedAndMultipleEntityManagersStyleIsInvalid(): void
-    {
-        $this->expectExceptionObject(new InvalidArgumentException('Seems like you have configured multiple "entity_managers". You need to use the long configuration syntax in every doctrine configuration file, or in none of them.'));
-        $this->loadContainer('orm_service_{simple_single,multiple}_entity_manage{r,rs}');
-    }
-
     public function testDbalLoadPoolShardingConnection(): void
     {
         $container = $this->loadContainer('dbal_service_pool_sharding_connection');

--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -7,36 +7,6 @@ Configuration
  * Setting the `host`, `port`, `user`, `password`, `path`, `dbname`, `unix_socket`
    or `memory` configuration options while the `url` one is set has been deprecated.
  * The `override_url` configuration option has been deprecated.
- * Combined use of simplified connection configuration in DBAL (without `connections` key) 
-   and multiple connection configuration is disallowed now. If you experience this issue, instead of
-```yaml
-doctrine:
-    dbal:
-      url: '%env(DATABASE_URL)%'
-```
-use
-```yaml
-doctrine:
-  dbal:
-    connections:
-      default:
-        url: '%env(DATABASE_URL)%'        
-```
-* Combined use of simplified entity manager configuration in ORM (without `entity_managers` key)
-  and multiple entity managers configuration is disallowed now. If you experience this issue, instead of
-```yaml
-doctrine:
-  orm:
-    mappings:
-```
-use
-```yaml
-doctrine:
-  orm:
-    entity_managers:
-      default:
-        mappings:        
-```
 
 ConnectionFactory
 --------


### PR DESCRIPTION
Context: #1362

This reverts problematic parts of commit 759018e

We will go with something else instead. Most likely deprecating it in some form and trigger error later.