### PR TITLE
workaround for issue 1310

### DIFF
--- a/CacheWarmer/DoctrineMetadataCacheWarmer.php
+++ b/CacheWarmer/DoctrineMetadataCacheWarmer.php
@@ -45,8 +45,10 @@ class DoctrineMetadataCacheWarmer extends AbstractPhpFileCacheWarmer
         }
 
         $metadataFactory = $this->entityManager->getMetadataFactory();
-        if ($metadataFactory instanceof AbstractClassMetadataFactory && $metadataFactory->getLoadedMetadata()) {
-            throw new LogicException('DoctrineMetadataCacheWarmer must load metadata first, check priority of your warmers.');
+        if ($metadataFactory instanceof AbstractClassMetadataFactory) {
+            foreach (array_keys($metadataFactory->getLoadedMetadata()) as $class) {
+                $metadataFactory->setMetadataFor($class, null);
+            }
         }
 
         if (method_exists($metadataFactory, 'setCache')) {


### PR DESCRIPTION
This is a first hacky idea to start a discussion on how to fix https://github.com/doctrine/DoctrineBundle/issues/1310 properly.

So to make sure we properly warm up complete metadata we need to ensure the metadataFactory does not have anything loaded yet when we replace the cache and load all available metadata. Hence the `LogicException` that is causing issues now.

Since the `AbstractClassMetadataFactory` does not provide a `clearLoadedMetadata` (or similar) method I don't see many options.

- hacky solution I implemented here 
  - but it relies on `isset` checks inside `AbstractClassMetadataFactory` to work and ignore `null` values
  - it violates the contract I think as `setMetadataFor` is not meant to be called with `null`
  
- use reflection to set `AbstractClassMetadataFactory::$loadedMetadata` to an empty array?

- add `AbstractClassMetadataFactory::clearLoadedMetadata` on doctrine/persistence?

- other ideas?