### PR TITLE
Loosen dependency on symfony/validator bundle

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -47,6 +47,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransportFactory;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
 
 use function array_intersect_key;
 use function array_keys;
@@ -496,6 +497,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
             if (interface_exists(PropertyInfoExtractorInterface::class)) {
                 $this->loadPropertyInfoExtractor($name, $container);
+            }
+
+            if (! interface_exists(LoaderInterface::class)) {
+                continue;
             }
 
             $this->loadValidatorLoader($name, $container);


### PR DESCRIPTION
Fixes #1377 

This PR skips registering a `doctrine.orm.<name>_entity_manager.validator_loader` service if the `Symfony\Component\Validator\Mapping\Loader\LoaderInterface` is not present. 

Not sure how to properly test this tbh. 