### PR TITLE
Allow toggling MetadataPhpArrayCaching manually

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -576,6 +576,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('quote_strategy')->defaultValue('doctrine.orm.quote_strategy.default')->end()
                     ->scalarNode('entity_listener_resolver')->defaultNull()->end()
                     ->scalarNode('repository_factory')->defaultValue('doctrine.orm.container_repository_factory')->end()
+                    ->scalarNode('enable_metadata_cache')->defaultValue(! $this->debug)->end()
                 ->end()
                 ->children()
                     ->arrayNode('second_level_cache')

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -915,21 +915,21 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if (isset($entityManager['metadata_cache_driver'])) {
             $this->loadCacheDriver('metadata_cache', $entityManager['name'], $entityManager['metadata_cache_driver'], $container);
         } else {
-            $this->createMetadataCache($entityManager['name'], $container);
+            $this->createMetadataCache($entityManager['name'], $entityManager['enable_metadata_cache'], $container);
         }
 
         $this->loadCacheDriver('result_cache', $entityManager['name'], $entityManager['result_cache_driver'], $container);
         $this->loadCacheDriver('query_cache', $entityManager['name'], $entityManager['query_cache_driver'], $container);
     }
 
-    private function createMetadataCache(string $objectManagerName, ContainerBuilder $container): void
+    private function createMetadataCache(string $objectManagerName, bool $enabled, ContainerBuilder $container): void
     {
         $aliasId = $this->getObjectManagerElementName(sprintf('%s_%s', $objectManagerName, 'metadata_cache'));
         $cacheId = sprintf('cache.doctrine.orm.%s.%s', $objectManagerName, 'metadata');
 
         $cache = new Definition(ArrayAdapter::class);
 
-        if (! $container->getParameter('kernel.debug')) {
+        if ($enabled) {
             $phpArrayFile         = '%kernel.cache_dir%' . sprintf('/doctrine/orm/%s_metadata.php', $objectManagerName);
             $cacheWarmerServiceId = $this->getObjectManagerElementName(sprintf('%s_%s', $objectManagerName, 'metadata_cache_warmer'));
 

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -311,6 +311,7 @@ Configuration Reference
                         quote_strategy:               doctrine.orm.quote_strategy.default
                         entity_listener_resolver:     ~
                         repository_factory:           ~
+                        enable_metadata_cache:        false
                         second_level_cache:
                             region_cache_driver:
                                 type: ~


### PR DESCRIPTION
After upgrading from 2.2 to 2.3 we noticed that the `metadata_cache_driver` option was deprecated.
It's now being toggled based on the value of `kernel.debug`.

This is a problem for us. We are running a very large (9 years old) Symfony 5.3 application with almost
10.000 PHP files. In `dev` environment we still like to have `debug` enabled, but we want caching
to be static. Cache invalidaton is managed by a background file watcher.

By introducing a `cache_metadata` configuration option we make it possible to manually toggle the
metadata caching while running in `kernel.debug`.

We profiled our application with PHP SPX and noticed that enabling the metadata cache reduces
request times with almost 100ms.