### PR TITLE
Adding PHP Attributes code sample

### DIFF
--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -11,7 +11,7 @@ Full example:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
+    .. code-block:: annotation
 
         <?php
         // User.php
@@ -28,7 +28,7 @@ Full example:
             // ....
         }
     
-    .. code-block:: php-attributes
+    .. code-block:: attribute
 
         <?php
         // User.php

--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -9,22 +9,39 @@ which entity manager it should be registered with.
 
 Full example:
 
-.. code-block:: php
+.. configuration-block::
 
-    <?php
-    // User.php
+    .. code-block:: php-annotations
 
-    use Doctrine\ORM\Mapping as ORM;
+        <?php
+        // User.php
 
-    /**
-     * @ORM\Entity
-     * @ORM\EntityListeners({"App\UserListener"})
-     */
-    class User
-    {
-        // ....
-    }
+        use Doctrine\ORM\Mapping as ORM;
+        use App\UserListener;
 
+        /**
+         * @ORM\Entity
+         * @ORM\EntityListeners({UserListener::class})
+         */
+        class User
+        {
+            // ....
+        }
+    
+    .. code-block:: php-attributes
+
+        <?php
+        // User.php
+
+        use Doctrine\ORM\Mapping as ORM;
+        use App\UserListener;
+
+        #[ORM\Entity]
+        #[ORM\EntityListeners([UserListener::class])]
+        class User
+        {
+            // ....
+        }
 
 .. configuration-block::
 


### PR DESCRIPTION
Since it's an array, it would be better to show how *multiple* listeners can be defined. It this the right syntax?:
```php
#[ORM\EntityListeners([Foo::class, Bar::class])]
```