### PR TITLE
Add metadata for symfony.com/bundles

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,0 +1,9 @@
+branches:
+    - "1.12.x"
+    - "2.4.x"
+    - "2.5.x"
+maintained_branches:
+    - "2.4.x"
+    - "2.5.x"
+doc_dir: "Resources/doc/"
+dev_branch: "2.5.x"


### PR DESCRIPTION
Symfony has a new website where we present selected bundles and render their documentation.

https://symfony.com/bundles

I'd like to add this configuration file to the repository. It allows us to include DoctrineBundle on that page.