### PR TITLE
[Doc] Fix minor RST syntax issue

### DIFF
--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -30,9 +30,8 @@ adding the following line in the ``config/bundles.php`` file of your project::
         // ...
     ];
 
-
 If you don't have a ``config/bundles.php`` file in your project, chances are that
- you're using an older Symfony version. In this case, you should have an
+you're using an older Symfony version. In this case, you should have an
 ``app/AppKernel.php`` file instead. Edit such file::
 
     <?php


### PR DESCRIPTION
The single extra white space before `you're using an older ...` seems minor ... but RST considers it (and renders it as) a definition list. I found this while browsing https://symfony.com/bundles/DoctrineBundle/current/installation.html#step-2-enable-the-bundle and seeing the strange rendering of that paragraph.