### PR TITLE
Fix tests (DBAL 3, Symfony 6)

### DIFF
--- a/Command/Proxy/DoctrineCommandHelper.php
+++ b/Command/Proxy/DoctrineCommandHelper.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 use function assert;
+use function class_exists;
 
 /**
  * Provides some helper and convenience methods to configure doctrine commands in the context of bundles
@@ -25,7 +26,10 @@ abstract class DoctrineCommandHelper
         $em = $application->getKernel()->getContainer()->get('doctrine')->getManager($emName);
         assert($em instanceof EntityManagerInterface);
         $helperSet = $application->getHelperSet();
-        $helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
+        if (class_exists(ConnectionHelper::class)) {
+            $helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
+        }
+
         $helperSet->set(new EntityManagerHelper($em), 'em');
     }
 

--- a/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -17,7 +17,6 @@ class CacheCompatibilityPassTest extends TestCase
 
     public function testCacheConfigUsingServiceDefinedByApplication(): void
     {
-        $this->expectNotToPerformAssertions();
         (new class () extends TestKernel {
             public function registerContainerConfiguration(LoaderInterface $loader): void
             {
@@ -54,6 +53,8 @@ class CacheCompatibilityPassTest extends TestCase
                 });
             }
         })->boot();
+
+        $this->addToAssertionCount(1);
     }
 
     /** @group legacy */

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -41,7 +41,9 @@ class ProfilerTest extends BaseTestCase
     {
         $this->logger = new DebugStack();
         $registry     = $this->getMockBuilder(ManagerRegistry::class)->getMock();
-        $registry->expects($this->once())->method('getManagers')->willReturn([]);
+        $registry->method('getConnectionNames')->willReturn([]);
+        $registry->method('getManagerNames')->willReturn([]);
+        $registry->method('getManagers')->willReturn([]);
         $this->collector = new DoctrineDataCollector($registry);
         $this->collector->addLogger('foo', $this->logger);
 


### PR DESCRIPTION
Doctrine ORM 2.10 will allow the installation of DBAL 3. This breaks our tests currently and this PR is my attempt to fix that.