### PR TITLE
Undo deprecation of `metadata_cache_driver`

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -731,12 +731,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('pool')->end()
             ->end();
 
-        if ($name === 'metadata_cache_driver') {
-            $node->setDeprecated(...$this->getDeprecationMsg(
-                'The "metadata_cache_driver" configuration key is deprecated. Remove the configuration to have the cache created automatically.',
-                '2.3'
-            ));
-        } else {
+        if ($name !== 'metadata_cache_driver') {
             $node->addDefaultsIfNotSet();
         }
 

--- a/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -57,10 +57,8 @@ class CacheCompatibilityPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /** @group legacy */
     public function testMetadataCacheConfigUsingPsr6ServiceDefinedByApplication(): void
     {
-        $this->expectDeprecation('%aThe "metadata_cache_driver" configuration key is deprecated.%a');
         (new class (false) extends TestKernel {
             public function registerContainerConfiguration(LoaderInterface $loader): void
             {

--- a/UPGRADE-2.5.md
+++ b/UPGRADE-2.5.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 2.4 to 2.5
+=======================
+
+Configuration
+--------
+ * The `metadata_cache_driver` configuration key is no longer deprecated.
+


### PR DESCRIPTION
This allows projects to still choose to opt-in on caching the metadata.

When the configuration key is not defined or used, the cache is created automatically.

See #1393

I targeted `2.5.x`. Is that correct?