### PR TITLE
added DatabaseDriverFactory to be injectable

### DIFF
--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
-use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
+use Doctrine\Bundle\DoctrineBundle\ORM\Mapping\Driver\DatabaseDriverFactoryInterface;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
@@ -33,12 +33,16 @@ class ImportMappingDoctrineCommand extends DoctrineCommand
     /** @var string[] */
     private $bundles;
 
+    /** @var DatabaseDriverFactoryInterface */
+    private $databaseDriverFactory;
+
     /** @param string[] $bundles */
-    public function __construct(ManagerRegistry $doctrine, array $bundles)
+    public function __construct(ManagerRegistry $doctrine, DatabaseDriverFactoryInterface $databaseDriverFactory, array $bundles)
     {
         parent::__construct($doctrine);
 
         $this->bundles = $bundles;
+        $this->databaseDriverFactory = $databaseDriverFactory;
     }
 
     /**
@@ -125,7 +129,7 @@ EOT
 
         $em = $this->getEntityManager($input->getOption('em'), $input->getOption('shard'));
 
-        $databaseDriver = new DatabaseDriver($em->getConnection()->getSchemaManager());
+        $databaseDriver = $this->databaseDriverFactory->create($em->getConnection()->getSchemaManager());
         $em->getConfiguration()->setMetadataDriverImpl($databaseDriver);
 
         $emName = $input->getOption('em');

--- a/ORM/Mapping/Driver/DatabaseDriverFactory.php
+++ b/ORM/Mapping/Driver/DatabaseDriverFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\ORM\Mapping\Driver;
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+
+class DatabaseDriverFactory implements DatabaseDriverFactoryInterface
+{
+    public function create(AbstractSchemaManager $schemaManager): MappingDriver
+    {
+        return new DatabaseDriver($schemaManager);
+    }
+}

--- a/ORM/Mapping/Driver/DatabaseDriverFactoryInterface.php
+++ b/ORM/Mapping/Driver/DatabaseDriverFactoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\ORM\Mapping\Driver;
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+
+interface DatabaseDriverFactoryInterface
+{
+    public function create(AbstractSchemaManager $schemaManager): MappingDriver;
+}

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -223,8 +223,11 @@
             <tag name="console.command" command="doctrine:schema:validate" />
         </service>
 
+        <service id="doctrine.database_driver.factory" class="Doctrine\Bundle\DoctrineBundle\ORM\Mapping\Driver\DatabaseDriverFactory"/>
+
         <service id="doctrine.mapping_import_command" class="Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand">
             <argument type="service" id="doctrine" />
+            <argument type="service" id="doctrine.database_driver.factory"/>
             <argument>%kernel.bundles%</argument>
 
             <tag name="console.command" command="doctrine:mapping:import" />


### PR DESCRIPTION
Case

```
[Doctrine\ORM\Mapping\MappingException]                                             
  Property "d" in "Contract" was already declared, but it must be declared only once
```

- Need to reverse-engineer table with columns "D" and "_D" as result they are both are mapped to "D" field.
- Cannot call "setFieldNameForColumn" to add custom mapping
  