### PR TITLE
Add an Argument Resolver

### DIFF
--- a/ArgumentResolver/EntityValueResolver.php
+++ b/ArgumentResolver/EntityValueResolver.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\ArgumentResolver;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\Entity;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use LogicException;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use function array_combine;
+use function array_filter;
+use function array_merge;
+use function count;
+use function is_array;
+use function method_exists;
+use function sprintf;
+use function strstr;
+
+/**
+ * Yields the entity matching the criteria provided in the route
+ */
+final class EntityValueResolver implements ArgumentValueResolverInterface
+{
+    /** @var ManagerRegistry */
+    private $registry;
+    /** @var ExpressionLanguage|null */
+    private $language;
+    /** @var array<string, mixed> */
+    private $defaultOptions;
+
+    /** @param array<string, mixed> $defaultOptions */
+    public function __construct(ManagerRegistry $registry, ?ExpressionLanguage $expressionLanguage = null, array $defaultOptions = [])
+    {
+        $this->registry       = $registry;
+        $this->language       = $expressionLanguage;
+        $this->defaultOptions = array_merge([
+            'entity_manager' => null,
+            'expr' => null,
+            'auto_mapping' => true,
+            'mapping' => [],
+            'exclude' => [],
+            'strip_null' => false,
+            'id' => null,
+            'evict_cache' => false,
+        ], $defaultOptions);
+    }
+
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        if (count($this->registry->getManagerNames()) === 0) {
+            return false;
+        }
+
+        $options = $this->getOptions($argument);
+        if ($options['class'] === null) {
+            return false;
+        }
+
+        // Doctrine Entity?
+        $em = $this->getManager($options['entity_manager'], $options['class']);
+        if ($em === null) {
+            return false;
+        }
+
+        return ! $em->getMetadataFactory()->isTransient($options['class']);
+    }
+
+    /** @return object[] */
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        $options = $this->getOptions($argument);
+
+        $name  = $argument->getName();
+        $class = $options['class'];
+
+        $errorMessage = null;
+        if ($options['expr'] !== null) {
+            $object = $this->findViaExpression($class, $request, $options['expr'], $options);
+
+            if ($object === null) {
+                $errorMessage = sprintf('The expression "%s" returned null', $options['expr']);
+            }
+
+            // find by identifier?
+        } else {
+            $object = $this->find($class, $request, $options, $name);
+            if ($object === false) {
+                // find by criteria
+                $object = $this->findOneBy($class, $request, $options);
+                if ($object === false) {
+                    if (! $argument->isNullable()) {
+                        throw new LogicException(sprintf('Unable to guess how to get a Doctrine instance from the request information for parameter "%s".', $name));
+                    }
+
+                    $object = null;
+                }
+            }
+        }
+
+        if ($object === null && ! $argument->isNullable()) {
+            $message = sprintf('"%s" object not found by the "%s" Argument Resolver.', $class, self::class);
+            if ($errorMessage) {
+                $message .= ' ' . $errorMessage;
+            }
+
+            throw new NotFoundHttpException($message);
+        }
+
+        return [$object];
+    }
+
+    private function getManager(?string $name, string $class): ?ObjectManager
+    {
+        if ($name === null) {
+            return $this->registry->getManagerForClass($class);
+        }
+
+        return $this->registry->getManager($name);
+    }
+
+    /**
+     * @param array<string, string> $options
+     *
+     * @return false|object|null
+     */
+    private function find(string $class, Request $request, array $options, string $name)
+    {
+        if ($options['mapping'] || $options['exclude']) {
+            return false;
+        }
+
+        $id = $this->getIdentifier($request, $options, $name);
+        if ($id === false || $id === null) {
+            return false;
+        }
+
+        $om = $this->getManager($options['entity_manager'], $class);
+        if ($options['evict_cache'] && $om instanceof EntityManagerInterface) {
+            $cacheProvider = $om->getCache();
+            if ($cacheProvider && $cacheProvider->containsEntity($class, $id)) {
+                $cacheProvider->evictEntity($class, $id);
+            }
+        }
+
+        try {
+            return $om->getRepository($class)->find($id);
+        } catch (NoResultException | ConversionException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<string, string> $options
+     *
+     * @return false|mixed|mixed[]
+     */
+    private function getIdentifier(Request $request, array $options, string $name)
+    {
+        if ($options['id'] !== null) {
+            if (is_array($options['id'])) {
+                $id = [];
+                foreach ($options['id'] as $field) {
+                    // Convert "%s_uuid" to "foobar_uuid"
+                    if (strstr($field, '%s') !== false) {
+                        $field = sprintf($field, $name);
+                    }
+
+                    $id[$field] = $request->attributes->get($field);
+                }
+
+                return $id;
+            }
+
+            $name = $options['id'];
+        }
+
+        if ($request->attributes->has($name)) {
+            return $request->attributes->get($name);
+        }
+
+        if ($request->attributes->has('id') && ! $options['id']) {
+            return $request->attributes->get('id');
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, string> $options
+     *
+     * @return false|object|null
+     */
+    private function findOneBy(string $class, Request $request, array $options)
+    {
+        if (! $options['mapping']) {
+            if (! $options['auto_mapping']) {
+                return false;
+            }
+
+            $keys               = $request->attributes->keys();
+            $options['mapping'] = $keys ? array_combine($keys, $keys) : [];
+        }
+
+        foreach ($options['exclude'] as $exclude) {
+            unset($options['mapping'][$exclude]);
+        }
+
+        if (! $options['mapping']) {
+            return false;
+        }
+
+        // if a specific id has been defined in the options and there is no corresponding attribute
+        // return false in order to avoid a fallback to the id which might be of another object
+        if ($options['id'] && $request->attributes->get($options['id']) === null) {
+            return false;
+        }
+
+        $criteria = [];
+        $em       = $this->getManager($options['entity_manager'], $class);
+        $metadata = $em->getClassMetadata($class);
+
+        foreach ($options['mapping'] as $attribute => $field) {
+            if (! $metadata->hasField($field) && (! $metadata->hasAssociation($field) || ! $metadata->isSingleValuedAssociation($field))) {
+                continue;
+            }
+
+            $criteria[$field] = $request->attributes->get($attribute);
+        }
+
+        if ($options['strip_null']) {
+            $criteria = array_filter($criteria, static function ($value) {
+                return $value !== null;
+            });
+        }
+
+        if (! $criteria) {
+            return false;
+        }
+
+        try {
+            return $em->getRepository($class)->findOneBy($criteria);
+        } catch (NoResultException | ConversionException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<string, string> $options
+     *
+     * @return object|null
+     */
+    private function findViaExpression(string $class, Request $request, string $expression, array $options)
+    {
+        if ($this->language === null) {
+            throw new LogicException(sprintf('To use the "%s" Argument Resolver tag with the "expr" option, you need to install the ExpressionLanguage component.', self::class));
+        }
+
+        $repository = $this->getManager($options['entity_manager'], $class)->getRepository($class);
+        $variables  = array_merge($request->attributes->all(), ['repository' => $repository]);
+
+        try {
+            return $this->language->evaluate($expression, $variables);
+        } catch (NoResultException | ConversionException $e) {
+            return null;
+        } catch (SyntaxError $e) {
+            throw new LogicException(sprintf('Error parsing expression -- "%s" -- (%s).', $expression, $e->getMessage()), 0, $e);
+        }
+    }
+
+    /** @return array<string, string> */
+    private function getOptions(ArgumentMetadata $argument): array
+    {
+        /** @var ?Entity $configuration */
+        $configuration = method_exists($argument, 'getAttributes') ? $argument->getAttributes(Entity::class, ArgumentMetadata::IS_INSTANCEOF)[0] ?? null : null;
+
+        if ($configuration === null) {
+            return array_merge($this->defaultOptions, [
+                'class' => $argument->getType(),
+            ]);
+        }
+
+        return array_merge($this->defaultOptions, [
+            'class' => $configuration->getClass() ?? $argument->getType(),
+            'entity_manager' => $configuration->getEntityManager(),
+            'expr' => $configuration->getExpr(),
+            'mapping' => $configuration->getMapping(),
+            'exclude' => $configuration->getExclude(),
+            'strip_null' => $configuration->isStripNull(),
+            'id' => $configuration->getId(),
+            'evict_cache' => $configuration->isEvictCache(),
+        ]);
+    }
+}

--- a/Attribute/Entity.php
+++ b/Attribute/Entity.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Attribute;
+
+use Attribute;
+
+/**
+ * Indicates that a controller argument should receive an Entity.
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Entity
+{
+    /** @var string|null */
+    private $class;
+    /** @var string|null */
+    private $entityManager;
+    /** @var string|null */
+    private $expr;
+    /** @var array<string, string> */
+    private $mapping;
+    /** @var string[] */
+    private $exclude;
+    /** @var bool */
+    private $stripNull;
+    /** @var string[]|string|null */
+    private $id;
+    /** @var bool */
+    private $evictCache;
+
+    /**
+     * @param array<string, string> $mapping
+     * @param string[]              $exclude
+     * @param string[]|string|null  $id
+     */
+    public function __construct(
+        ?string $class = null,
+        ?string $entityManager = null,
+        ?string $expr = null,
+        array $mapping = [],
+        array $exclude = [],
+        bool $stripNull = false,
+        $id = null,
+        bool $evictCache = false
+    ) {
+        $this->class         = $class;
+        $this->entityManager = $entityManager;
+        $this->expr          = $expr;
+        $this->mapping       = $mapping;
+        $this->exclude       = $exclude;
+        $this->stripNull     = $stripNull;
+        $this->id            = $id;
+        $this->evictCache    = $evictCache;
+    }
+
+    public function getClass(): ?string
+    {
+        return $this->class;
+    }
+
+    public function getEntityManager(): ?string
+    {
+        return $this->entityManager;
+    }
+
+    public function getExpr(): ?string
+    {
+        return $this->expr;
+    }
+
+    /** @return array<string, string> */
+    public function getMapping(): array
+    {
+        return $this->mapping;
+    }
+
+    /** @return string[] */
+    public function getExclude(): array
+    {
+        return $this->exclude;
+    }
+
+    public function isStripNull(): bool
+    {
+        return $this->stripNull;
+    }
+
+    /** @return string|string[]|null */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function isEvictCache(): bool
+    {
+        return $this->evictCache;
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -383,6 +383,7 @@ class Configuration implements ConfigurationInterface
                             // Key that should not be rewritten to the connection config
                             $excludedKeys  = [
                                 'default_entity_manager' => true,
+                                'argument_resolver' => true,
                                 'auto_generate_proxy_classes' => true,
                                 'proxy_dir' => true,
                                 'proxy_namespace' => true,
@@ -440,6 +441,19 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/orm/Proxies')->end()
                         ->scalarNode('proxy_namespace')->defaultValue('Proxies')->end()
+                        ->arrayNode('argument_resolver')
+                            ->info('Find entities that match request\'t attributes and inject them in controller\'s request parameters.')
+                            ->canBeEnabled()
+                            ->children()
+                                ->booleanNode('auto_mapping')
+                                    ->info(
+                                        'Use all attributes in the request to build the findOneBy query.' .
+                                        ' When set to false, you have to provide a "mapping" or an "expr" to the annotation.'
+                                    )
+                                    ->defaultTrue()
+                                ->end()
+                            ->end()
+                        ->end()
                     ->end()
                     ->fixXmlConfig('entity_manager')
                     ->append($this->getOrmEntityManagersNode())

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -544,6 +544,16 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ->addTag('container.preload', [
                 'class' => Autoloader::class,
             ]);
+
+        if (! $config['argument_resolver']['enabled']) {
+            $container->removeDefinition('doctrine.entity_value_resolver');
+        } else {
+            $options = [
+                'auto_mapping' => $config['argument_resolver']['auto_mapping'],
+            ];
+            $container->getDefinition('doctrine.entity_value_resolver')
+                ->replaceArgument(2, $options);
+        }
     }
 
     /**

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -229,5 +229,16 @@
 
             <tag name="console.command" command="doctrine:mapping:import" />
         </service>
+
+        <!-- argument resolvers -->
+        <service id="doctrine.entity_value_resolver" class="Doctrine\Bundle\DoctrineBundle\ArgumentResolver\EntityValueResolver">
+            <argument type="service" id="doctrine" />
+            <argument type="service" on-invalid="null">
+                <service class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
+            </argument>
+            <argument type="collection"/>
+
+            <tag name="controller.argument_value_resolver" />
+        </service>
     </services>
 </container>

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -138,6 +138,7 @@
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="entity-manager" type="entity_manager" />
             <xsd:element name="resolve-target-entity" type="resolve_target_entity" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="argument-resolver" type="argument_resolver" minOccurs="0" maxOccurs="1" />
             <xsd:group ref="entity-manager-child-config" />
         </xsd:choice>
 
@@ -272,5 +273,10 @@
             <xsd:element name="numeric-function" type="named_scalar" />
             <xsd:element name="datetime-function" type="named_scalar" />
         </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:complexType name="argument_resolver">
+        <xsd:attribute name="enabled" type="xsd:boolean" default="false"/>
+        <xsd:attribute name="auto_mapping" type="xsd:boolean" default="true"/>
     </xsd:complexType>
 </xsd:schema>

--- a/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -1,0 +1,591 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver;
+
+use Doctrine\Bundle\DoctrineBundle\ArgumentResolver\EntityValueResolver;
+use Doctrine\Bundle\DoctrineBundle\Attribute\Entity;
+use Doctrine\DBAL\Types\ConversionException;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use function is_array;
+use function method_exists;
+
+class EntityValueResolverTest extends TestCase
+{
+    public function testApplyWithNoIdAndData()
+    {
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $this->expectException(LogicException::class);
+
+        $request  = new Request();
+        $argument = $this->createArgument(null, new Entity());
+
+        $converter->resolve($request, $argument);
+    }
+
+    public function testApplyWithNoIdAndDataOptional()
+    {
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $request  = new Request();
+        $argument = $this->createArgument(null, new Entity(), 'arg', true);
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertNull($this->toArray($ret)[0]);
+    }
+
+    public function testApplyWithStripNulls()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('arg', null);
+        $argument = $this->createArgument('stdClass', new Entity(null, null, null, ['arg' => 'arg'], [], true), 'arg', true);
+
+        $classMetadata = $this->getMockBuilder('Doctrine\Persistence\Mapping\ClassMetadata')->getMock();
+        $manager       = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $manager->expects($this->once())
+            ->method('getClassMetadata')
+            ->with('stdClass')
+            ->willReturn($classMetadata);
+
+        $manager->expects($this->never())
+            ->method('getRepository');
+
+        $registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->with('stdClass')
+            ->willReturn($manager);
+
+        $classMetadata->expects($this->once())
+            ->method('hasField')
+            ->with($this->equalTo('arg'))
+            ->willReturn(true);
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertNull($this->toArray($ret)[0]);
+    }
+
+    /**
+     * @param string|int $id
+     *
+     * @dataProvider idsProvider
+     */
+    public function testApplyWithId($id)
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('id', $id);
+
+        $argument = $this->createArgument('stdClass', new Entity(null, null, null, [], [], false, 'id'));
+
+        $manager          = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Persistence\ObjectRepository')->getMock();
+        $registry->expects($this->once())
+              ->method('getManagerForClass')
+              ->with('stdClass')
+              ->willReturn($manager);
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with('stdClass')
+            ->willReturn($objectRepository);
+
+        $objectRepository->expects($this->once())
+                      ->method('find')
+                      ->with($this->equalTo($id))
+                      ->willReturn($object = new stdClass());
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertSame($object, $this->toArray($ret)[0]);
+    }
+
+    public function testApplyWithConversionFailedException()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $request = new Request();
+        $request->attributes->set('id', 'test');
+
+        $argument = $this->createArgument('stdClass', new Entity(null, null, null, [], [], false, 'id'));
+
+        $manager          = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Persistence\ObjectRepository')->getMock();
+        $registry->expects($this->once())
+              ->method('getManagerForClass')
+              ->with('stdClass')
+              ->willReturn($manager);
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with('stdClass')
+            ->willReturn($objectRepository);
+
+        $objectRepository->expects($this->once())
+                      ->method('find')
+                      ->with($this->equalTo('test'))
+                      ->will($this->throwException(new ConversionException()));
+
+        $converter->resolve($request, $argument);
+    }
+
+    public function testUsedProperIdentifier()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('id', 1);
+        $request->attributes->set('entity_id', null);
+        $request->attributes->set('arg', null);
+
+        $argument = $this->createArgument('stdClass', new Entity(null, null, null, [], [], false, 'entity_id'), 'arg', true);
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertNull($this->toArray($ret)[0]);
+    }
+
+    /** @return array{0: int|string}[] */
+    public function idsProvider()
+    {
+        return [
+            [1],
+            [0],
+            ['foo'],
+        ];
+    }
+
+    public function testApplyGuessOptional()
+    {
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('arg', null);
+
+        $argument = $this->createArgument('stdClass', new Entity(), 'arg', true);
+
+        $classMetadata = $this->getMockBuilder('Doctrine\Persistence\Mapping\ClassMetadata')->getMock();
+        $manager       = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $manager->expects($this->once())
+            ->method('getClassMetadata')
+            ->with('stdClass')
+            ->willReturn($classMetadata);
+
+        $objectRepository = $this->getMockBuilder('Doctrine\Persistence\ObjectRepository')->getMock();
+        $registry->expects($this->once())
+              ->method('getManagerForClass')
+              ->with('stdClass')
+              ->willReturn($manager);
+
+        $manager->expects($this->never())->method('getRepository');
+
+        $objectRepository->expects($this->never())->method('find');
+        $objectRepository->expects($this->never())->method('findOneBy');
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertNull($this->toArray($ret)[0]);
+    }
+
+    public function testApplyWithMappingAndExclude()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('foo', 1);
+        $request->attributes->set('bar', 2);
+
+        $argument = $this->createArgument(
+            'stdClass',
+            new Entity(null, null, null, ['foo' => 'Foo'], ['bar'])
+        );
+
+        $manager    = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $metadata   = $this->getMockBuilder('Doctrine\Persistence\Mapping\ClassMetadata')->getMock();
+        $repository = $this->getMockBuilder('Doctrine\Persistence\ObjectRepository')->getMock();
+
+        $registry->expects($this->once())
+                ->method('getManagerForClass')
+                ->with('stdClass')
+                ->willReturn($manager);
+
+        $manager->expects($this->once())
+                ->method('getClassMetadata')
+                ->with('stdClass')
+                ->willReturn($metadata);
+        $manager->expects($this->once())
+                ->method('getRepository')
+                ->with('stdClass')
+                ->willReturn($repository);
+
+        $metadata->expects($this->once())
+                 ->method('hasField')
+                 ->with($this->equalTo('Foo'))
+                 ->willReturn(true);
+
+        $repository->expects($this->once())
+                      ->method('findOneBy')
+                      ->with($this->equalTo(['Foo' => 1]))
+                      ->willReturn($object = new stdClass());
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertSame($object, $this->toArray($ret)[0]);
+    }
+
+    public function testIgnoreMappingWhenAutoMappingDisabled()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry, null, ['auto_mapping' => false]);
+
+        $request = new Request();
+        $request->attributes->set('foo', 1);
+
+        $argument = $this->createArgument(
+            'stdClass',
+            new Entity()
+        );
+
+        $metadata = $this->getMockBuilder('Doctrine\Persistence\Mapping\ClassMetadata')->getMock();
+
+        $registry->expects($this->never())
+                ->method('getManagerForClass');
+
+        $metadata->expects($this->never())
+                 ->method('hasField');
+
+        $this->expectException(LogicException::class);
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertCount(0, $this->toArray($ret));
+    }
+
+    public function testSupports()
+    {
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $argument        = $this->createArgument('stdClass', new Entity());
+        $metadataFactory = $this->getMockBuilder('Doctrine\Persistence\Mapping\ClassMetadataFactory')->getMock();
+        $metadataFactory->expects($this->once())
+                        ->method('isTransient')
+                        ->with($this->equalTo('stdClass'))
+                        ->willReturn(false);
+
+        $objectManager = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectManager->expects($this->once())
+                      ->method('getMetadataFactory')
+                      ->willReturn($metadataFactory);
+
+        $registry->expects($this->any())
+                    ->method('getManagerNames')
+                    ->willReturn(['default']);
+
+        $registry->expects($this->once())
+                      ->method('getManagerForClass')
+                      ->with('stdClass')
+                      ->willReturn($objectManager);
+
+        $ret = $converter->supports(new Request(), $argument);
+
+        $this->assertTrue($ret, 'Should be supported');
+    }
+
+    public function testSupportsWithConfiguredEntityManager()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $argument        = $this->createArgument('stdClass', new Entity(null, 'foo'));
+        $metadataFactory = $this->getMockBuilder('Doctrine\Persistence\Mapping\ClassMetadataFactory')->getMock();
+        $metadataFactory->expects($this->once())
+                        ->method('isTransient')
+                        ->with($this->equalTo('stdClass'))
+                        ->willReturn(false);
+
+        $objectManager = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectManager->expects($this->once())
+                      ->method('getMetadataFactory')
+                      ->willReturn($metadataFactory);
+
+        $registry->expects($this->once())
+                    ->method('getManagerNames')
+                    ->willReturn(['default']);
+
+        $registry->expects($this->once())
+                      ->method('getManager')
+                      ->with('foo')
+                      ->willReturn($objectManager);
+
+        $ret = $converter->supports(new Request(), $argument);
+
+        $this->assertTrue($ret, 'Should be supported');
+    }
+
+    public function testSupportsWithDifferentConfiguration()
+    {
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $argument = $this->createArgument('DateTime');
+
+        $objectManager = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectManager->expects($this->never())
+                      ->method('getMetadataFactory');
+
+        $registry->expects($this->any())
+            ->method('getManagerNames')
+            ->willReturn(['default']);
+
+        $registry->expects($this->never())
+                      ->method('getManager');
+
+        $ret = $converter->supports(new Request(), $argument);
+
+        $this->assertFalse($ret, 'Should not be supported');
+    }
+
+    public function testExceptionWithExpressionIfNoLanguageAvailable()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry);
+
+        $this->expectException(LogicException::class);
+
+        $request  = new Request();
+        $argument = $this->createArgument(
+            'stdClass',
+            new Entity(null, null, 'repository.find(id)'),
+            'arg1'
+        );
+
+        $converter->resolve($request, $argument);
+    }
+
+    public function testExpressionFailureReturns404()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        $language = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ExpressionLanguage')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry, $language);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $request  = new Request();
+        $argument = $this->createArgument(
+            'stdClass',
+            new Entity(null, null, 'repository.someMethod()'),
+            'arg1'
+        );
+
+        $objectManager    = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Persistence\ObjectRepository')->getMock();
+
+        $objectManager->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($objectRepository);
+
+        // find should not be attempted on this repository as a fallback
+        $objectRepository->expects($this->never())
+            ->method('find');
+
+        $registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->willReturn($objectManager);
+
+        $language->expects($this->once())
+            ->method('evaluate')
+            ->willReturn(null);
+
+        $converter->resolve($request, $argument);
+    }
+
+    public function testExpressionMapsToArgument()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        $language = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ExpressionLanguage')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry, $language);
+
+        $request = new Request();
+        $request->attributes->set('id', 5);
+        $argument = $this->createArgument(
+            'stdClass',
+            new Entity(null, null, 'repository.findOneByCustomMethod(id)'),
+            'arg1'
+        );
+
+        $objectManager    = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Persistence\ObjectRepository')->getMock();
+
+        $objectManager->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($objectRepository);
+
+        // find should not be attempted on this repository as a fallback
+        $objectRepository->expects($this->never())
+            ->method('find');
+
+        $registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->willReturn($objectManager);
+
+        $language->expects($this->once())
+            ->method('evaluate')
+            ->with('repository.findOneByCustomMethod(id)', [
+                'repository' => $objectRepository,
+                'id' => 5,
+            ])
+            ->willReturn('new_mapped_value');
+
+        $ret = $converter->resolve($request, $argument);
+        $this->assertEquals('new_mapped_value', $this->toArray($ret)[0]);
+    }
+
+    public function testExpressionSyntaxErrorThrowsException()
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            $this->markTestSkipped('Options are only configurable with symfony 5.2');
+        }
+
+        $registry = $this->getMockBuilder('Doctrine\Persistence\ManagerRegistry')->getMock();
+        $language = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ExpressionLanguage')->getMock();
+        /** @psalm-suppress InvalidArgument */
+        $converter = new EntityValueResolver($registry, $language);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('syntax error message around position 10');
+
+        $request  = new Request();
+        $argument = $this->createArgument(
+            'stdClass',
+            new Entity(null, null, 'repository.findOneByCustomMethod(id)'),
+            'arg1'
+        );
+
+        $objectManager    = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')->getMock();
+        $objectRepository = $this->getMockBuilder('Doctrine\Persistence\ObjectRepository')->getMock();
+
+        $objectManager->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($objectRepository);
+
+        // find should not be attempted on this repository as a fallback
+        $objectRepository->expects($this->never())
+            ->method('find');
+
+        $registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->willReturn($objectManager);
+
+        $language->expects($this->once())
+            ->method('evaluate')
+            ->will($this->throwException(new SyntaxError('syntax error message', 10)));
+
+        $converter->resolve($request, $argument);
+    }
+
+    private function createArgument(?string $class = null, ?Entity $entity = null, string $name = 'arg', bool $isNullable = false): ArgumentMetadata
+    {
+        if (! method_exists(ArgumentMetadata::class, 'getAttributes')) {
+            return new ArgumentMetadata($name, $class ?? stdClass::class, false, false, null, $isNullable);
+        }
+
+        /** @psalm-suppress TooManyArguments */
+        return new ArgumentMetadata($name, $class ?? stdClass::class, false, false, null, $isNullable, $entity ? [$entity] : []);
+    }
+
+    /**
+     * @param object[] $it
+     *
+     * @return object[]
+     */
+    private function toArray(iterable $it): array
+    {
+        if (is_array($it)) {
+            return $it;
+        }
+
+        $ret = [];
+        foreach ($it as $k => $v) {
+            $ret[$k] = $v;
+        }
+
+        return $ret;
+    }
+}

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1376,6 +1376,31 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertFalse($collectorDefinition->getArguments()[1]);
     }
 
+    public function testArgumentResolverEnabled(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->loadContainer('orm_argument_resolver_enabled');
+
+        $this->assertTrue($container->has('doctrine.entity_value_resolver'));
+        $options = $container->getDefinition('doctrine.entity_value_resolver')->getArgument(2);
+        $this->assertArrayHasKey('auto_mapping', $options);
+        $this->assertFalse($options['auto_mapping']);
+    }
+
+    public function testArgumentResolverDisabled(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->loadContainer('orm_argument_resolver_disabled');
+
+        $this->assertFalse($container->has('doctrine.entity_value_resolver'));
+    }
+
     /** @param list<string> $bundles */
     private function loadContainer(
         string $fixture,

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_argument_resolver_disabled.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_argument_resolver_disabled.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm>
+            <argument-resolver enabled="false" />
+        </orm>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_argument_resolver_enabled.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_argument_resolver_enabled.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm>
+            <argument-resolver enabled="true" auto_mapping="false" />
+        </orm>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_argument_resolver_disabled.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_argument_resolver_disabled.yml
@@ -1,0 +1,10 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        argument_resolver:
+            enabled: false

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_argument_resolver_enabled.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_argument_resolver_enabled.yml
@@ -1,0 +1,11 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        argument_resolver:
+            enabled: true
+            auto_mapping: false

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.3",
         "psalm/plugin-phpunit": "^0.15.1",
         "psalm/plugin-symfony": "^2.3.0",
+        "symfony/expression-language": "^4.3.3|^5.0|^6.0",
         "symfony/phpunit-bridge": "^5.2|^6.0",
         "symfony/property-info": "^4.3.3|^5.0|^6.0",
         "symfony/proxy-manager-bridge": "^3.4|^4.3.3|^5.0|^6.0",


### PR DESCRIPTION
This PR migrates the SensioFrameworkExtraBundle's Doctrine ParamsConverter to Argument Resolver.

Moving away from ParamConverter would fix https://github.com/symfony/symfony/issues/40333

usage:
enabled the behavior
```
doctrine:
    dbal:
        default_connection: default
        connections:
            default:
                dbname: db

    orm:
        argument_resolver: true
```


The default configuration works out of the box. The entity is fetch using `$repo->find()` using the route's attribute.
```
#[Route('/blog/{id}')]
public function show(Post $post)
{
}
```

Options can be configured with a new Attribute
```
use Doctrine\Bundle\DoctrineBundle\Attribute\Entity;

#[Route('/blog/{id}')]
public function show(
  #[Entity(entityManager: 'foo', expr: 'repository.findNotDeletedById(id)')]
  Post $post
)
{
}
```

note: the business logic and tests are copy/pasted from the [original repo](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/src/Request/ParamConverter/DoctrineParamConverter.php). Tell me if you think some options are not needed anymore.