### PR TITLE
Register DBAL cache adapter for Symfony 5.4+

### DIFF
--- a/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
+++ b/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
@@ -2,13 +2,14 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Injects PdoAdapter into its schema subscriber.
+ * Injects Doctrine DBAL and legacy PDO adapters into their schema subscribers.
  *
  * Must be run later after ResolveChildDefinitionsPass.
  */
@@ -19,11 +20,20 @@ class CacheSchemaSubscriberPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $subscriberId = 'doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber';
+        // available in Symfony 5.4 and higher
+        $this->injectAdapters($container, 'doctrine.orm.listeners.doctrine_dbal_cache_adapter_schema_subscriber', DoctrineDbalAdapter::class);
 
+        // available in Symfony 5.1 and up to Symfony 5.4 (deprecated)
+        $this->injectAdapters($container, 'doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber', PdoAdapter::class);
+    }
+
+    private function injectAdapters(ContainerBuilder $container, string $subscriberId, string $class)
+    {
         if (! $container->hasDefinition($subscriberId)) {
             return;
         }
+
+        $subscriber = $container->getDefinition($subscriberId);
 
         $cacheAdaptersReferences = [];
         foreach ($container->getDefinitions() as $id => $definition) {
@@ -31,14 +41,13 @@ class CacheSchemaSubscriberPass implements CompilerPassInterface
                 continue;
             }
 
-            if ($definition->getClass() !== PdoAdapter::class) {
+            if ($definition->getClass() !== $class) {
                 continue;
             }
 
             $cacheAdaptersReferences[] = new Reference($id);
         }
 
-        $container->getDefinition($subscriberId)
-            ->replaceArgument(0, $cacheAdaptersReferences);
+        $subscriber->replaceArgument(0, $cacheAdaptersReferences);
     }
 }

--- a/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
+++ b/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
@@ -21,6 +21,7 @@ class CacheSchemaSubscriberPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         // available in Symfony 5.4 and higher
+        /** @psalm-suppress UndefinedClass */
         $this->injectAdapters($container, 'doctrine.orm.listeners.doctrine_dbal_cache_adapter_schema_subscriber', DoctrineDbalAdapter::class);
 
         // available in Symfony 5.1 and up to Symfony 5.4 (deprecated)

--- a/DependencyInjection/Compiler/WellKnownSchemaFilterPass.php
+++ b/DependencyInjection/Compiler/WellKnownSchemaFilterPass.php
@@ -2,10 +2,12 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+use Symfony\Component\Lock\Store\DoctrineDbalStore;
 use Symfony\Component\Lock\Store\PdoStore;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
 use Symfony\Component\Messenger\Transport\Doctrine\Connection as LegacyConnection;
@@ -32,6 +34,7 @@ class WellKnownSchemaFilterPass implements CompilerPassInterface
             }
 
             switch ($definition->getClass()) {
+                case DoctrineDbalAdapter::class:
                 case PdoAdapter::class:
                     $blacklist[] = $definition->getArguments()[3]['db_table'] ?? 'cache_items';
                     break;
@@ -40,6 +43,7 @@ class WellKnownSchemaFilterPass implements CompilerPassInterface
                     $blacklist[] = $definition->getArguments()[1]['db_table'] ?? 'sessions';
                     break;
 
+                case DoctrineDbalStore::class:
                 case PdoStore::class:
                     $blacklist[] = $definition->getArguments()[1]['db_table'] ?? 'lock_keys';
                     break;

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -27,6 +27,7 @@ use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaSubscriber;
 use Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaSubscriber;
 use Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber;
 use Symfony\Bridge\Doctrine\SchemaListener\RememberMeTokenProviderDoctrineSchemaSubscriber;
@@ -436,7 +437,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $container->getDefinition('form.type.entity')->addTag('kernel.reset', ['method' => 'reset']);
         }
 
-        // available in Symfony 5.1 and higher
+        // available in Symfony 5.4 and higher
+        if (! class_exists(DoctrineDbalCacheAdapterSchemaSubscriber::class)) {
+            $container->removeDefinition('doctrine.orm.listeners.doctrine_dbal_cache_adapter_schema_subscriber');
+        }
+
+        // available in Symfony 5.1 and up to Symfony 5.4 (deprecated)
         if (! class_exists(PdoCacheAdapterDoctrineSchemaSubscriber::class)) {
             $container->removeDefinition('doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber');
         }

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -134,6 +134,10 @@
 
         <!-- listeners -->
         <service id="doctrine.orm.listeners.resolve_target_entity" class="%doctrine.orm.listeners.resolve_target_entity.class%" public="false" />
+        <service id="doctrine.orm.listeners.doctrine_dbal_cache_adapter_schema_subscriber" class="Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaSubscriber">
+            <argument type="collection" /> <!-- DoctrineDbalAdapter instances -->
+            <tag name="doctrine.event_subscriber" />
+        </service>
         <service id="doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber" class="Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber">
             <argument type="collection" /> <!-- PdoAdapter instances -->
             <tag name="doctrine.event_subscriber" />

--- a/Tests/CacheSchemaSubscriberTest.php
+++ b/Tests/CacheSchemaSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubscriberPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\ORM\EntityManagerInterface;
+use Generator;
 use Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaSubscriber;
 use Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
@@ -85,12 +86,20 @@ class CacheSchemaSubscriberTest extends TestCase
         $this->assertEquals([new Reference('my_cache_adapter')], $definition->getArgument(0));
     }
 
-    public function getSchemaSubscribers(): iterable
+    public function getSchemaSubscribers(): Generator
     {
-        // available in Symfony 5.4 and higher
+        /**
+         * available in Symfony 5.4 and higher
+         *
+         * @psalm-suppress UndefinedClass
+         */
         yield ['cache.adapter.doctrine_dbal', 'doctrine.orm.listeners.doctrine_dbal_cache_adapter_schema_subscriber', DoctrineDbalCacheAdapterSchemaSubscriber::class];
 
-        // available in Symfony 5.1 and up to Symfony 5.4 (deprecated)
+        /**
+         * available in Symfony 5.1 and up to Symfony 5.4 (deprecated)
+         *
+         * @psalm-suppress UndefinedClass
+         */
         yield ['cache.adapter.pdo', 'doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber', PdoCacheAdapterDoctrineSchemaSubscriber::class];
     }
 }

--- a/Tests/CacheSchemaSubscriberTest.php
+++ b/Tests/CacheSchemaSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubscriberPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaSubscriber;
 use Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\Alias;
@@ -19,10 +20,11 @@ use function sys_get_temp_dir;
 
 class CacheSchemaSubscriberTest extends TestCase
 {
-    public function testSchemaSubscriberWiring(): void
+    /** @dataProvider getSchemaSubscribers */
+    public function testSchemaSubscriberWiring(string $adapterId, string $subscriberId, string $class): void
     {
-        if (! class_exists(PdoCacheAdapterDoctrineSchemaSubscriber::class)) {
-            $this->markTestSkipped('This test requires Symfony 5.1 or higher');
+        if (! class_exists($class)) {
+            self::markTestSkipped('symfony/doctrine-bridge version not supported');
         }
 
         if (! interface_exists(EntityManagerInterface::class)) {
@@ -51,11 +53,15 @@ class CacheSchemaSubscriberTest extends TestCase
             'framework' => [
                 'cache' => [
                     'pools' => [
-                        'my_cache_adapter' => ['adapter' => 'cache.adapter.pdo'],
+                        'my_cache_adapter' => ['adapter' => $adapterId],
                     ],
                 ],
             ],
         ], $container);
+
+        if (! $container->has($adapterId)) {
+            self::markTestSkipped('symfony/framework-bundle version not supported');
+        }
 
         $extension = new DoctrineExtension();
         $container->registerExtension($extension);
@@ -66,7 +72,7 @@ class CacheSchemaSubscriberTest extends TestCase
             ],
         ], $container);
 
-        $container->setAlias('test_subscriber_alias', new Alias('doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber', true));
+        $container->setAlias('test_subscriber_alias', new Alias($subscriberId, true));
         // prevent my_cache_apapter from inlining
         $container->register('uses_my_cache_adapter', 'stdClass')
             ->addArgument(new Reference('my_cache_adapter'))
@@ -77,5 +83,14 @@ class CacheSchemaSubscriberTest extends TestCase
         // check that PdoAdapter service is injected as an argument
         $definition = $container->findDefinition('test_subscriber_alias');
         $this->assertEquals([new Reference('my_cache_adapter')], $definition->getArgument(0));
+    }
+
+    public function getSchemaSubscribers(): iterable
+    {
+        // available in Symfony 5.4 and higher
+        yield ['cache.adapter.doctrine_dbal', 'doctrine.orm.listeners.doctrine_dbal_cache_adapter_schema_subscriber', DoctrineDbalCacheAdapterSchemaSubscriber::class];
+
+        // available in Symfony 5.1 and up to Symfony 5.4 (deprecated)
+        yield ['cache.adapter.pdo', 'doctrine.orm.listeners.pdo_cache_adapter_doctrine_schema_subscriber', PdoCacheAdapterDoctrineSchemaSubscriber::class];
     }
 }


### PR DESCRIPTION
Fix and replace https://github.com/doctrine/DoctrineBundle/pull/1417
Requires https://github.com/symfony/symfony/pull/44065 (merged)

In Symfony 5.4, `PdoAdapter` support for DBAL connection is deprecated and the new class `DoctrineDbalAdapter` must be used (https://github.com/symfony/symfony/pull/43362). Both have a related `*SchemaSubscriber` class. In Symfony 5.4 the legacy `PdoCacheAdapterDoctrineSchemaSubscriber` needs to be called to preserve backward compatibility ; in Symfony 6.0, it is removed (https://github.com/symfony/symfony/pull/43584).
