### PR TITLE
 CVE-2021-43608 - DBAL 3 SQL Injection Security Vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^7.1 || ^8.0",
         "doctrine/annotations": "^1",
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/dbal": "^2.9.0|^3.0",
+        "doctrine/dbal": "^2.9.0|^3.1.14",
         "doctrine/persistence": "^1.3.3|^2.0",
         "doctrine/sql-formatter": "^1.0.1",
         "symfony/cache": "^4.3.3|^5.0|^6.0",


### PR DESCRIPTION
Patch minimum version of Doctrine/DBAL to 3.1.14 to prevent SQL where clause injection.

https://github.com/doctrine/dbal/security/advisories/GHSA-r7cj-8hjg-x622