### PR TITLE
Fix fatal when installing with php8

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -870,7 +870,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         return 'Entity';
     }
 
-    protected function getMappingResourceConfigDirectory(string $bundleDir = null): string
+    protected function getMappingResourceConfigDirectory(?string $bundleDir = null): string
     {
         return 'Resources/config/doctrine';
     }

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -870,7 +870,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         return 'Entity';
     }
 
-    protected function getMappingResourceConfigDirectory(): string
+    protected function getMappingResourceConfigDirectory(string $bundleDir = null): string
     {
         return 'Resources/config/doctrine';
     }


### PR DESCRIPTION
Allow installation on a new symfony/skeleton project with php8.
Without that fix the following error will occour:

`PHP Fatal error:  Declaration of Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension::getMappingResourceConfigDirectory(): string must be compatible with Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension::getMappingResourceConfigDirectory(?string $bundleDir = null): string in /vendor/doctrine/doctrine-bundle/DependencyInjection/DoctrineExtension.php on line 873`