### PR TITLE
* DoctrineExtension.php - bugfix

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -870,7 +870,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         return 'Entity';
     }
 
-    protected function getMappingResourceConfigDirectory(): string
+    protected function getMappingResourceConfigDirectory(string $bundleDir = null): string
     {
         return 'Resources/config/doctrine';
     }


### PR DESCRIPTION
SF 6.0 issue fix

```
Fatal error: Declaration of Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension::getMappingResourceConfigDirectory(): string must be compatible with Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension::getMappingResourceConfigDirectory(?string $bundleDir = null): string in /var/www/project/vendor/doctrine/doctrine-bundle/DependencyInjection/DoctrineExtension.php on line 873
```