### PR TITLE
Remove unknown branch name from doctrine-website config

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,12 +4,6 @@
   "slug": "doctrine-bundle",
   "versions": [
     {
-      "name": "2.6",
-      "branchName": "2.6.x",
-      "slug": "latest",
-      "upcoming": true
-    },
-    {
       "name": "2.5",
       "branchName": "2.5.x",
       "slug": "2.4",


### PR DESCRIPTION
The branch 2.6.x doesn't exist and breaks the website build.