### PR TITLE
Allow symfony/service-contracts 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/doctrine-bridge": "^4.4.22|^5.2.7|^6.0",
         "symfony/framework-bundle": "^3.4.30|^4.3.3|^5.0|^6.0",
-        "symfony/service-contracts": "^1.1.1|^2.0"
+        "symfony/service-contracts": "^1.1.1|^2.0|^3"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",


### PR DESCRIPTION
In PR #1434 was allowed deprecation-contracts 3 but now fresh symfony 6 installation need also service-contracts 3
```
Problem 1
    - doctrine/doctrine-bundle 2.5.0 requires symfony/deprecation-contracts ^2.1 -> found symfony/deprecation-contracts[v2.1.0, ..., v2.5.0] but the package is fixed to v3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - doctrine/doctrine-bundle 2.5.1 requires symfony/service-contracts ^1.1.1|^2.0 -> found symfony/service-contracts[v1.1.1, ..., v1.1.11, v2.0.0, ..., v2.5.0] but the package is fixed to v3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```