### PR TITLE
Fix error in tests: The parameter "debug.file_link_format" has a dependency on a non-existent parameter "env(default::SYMFONY_IDE)"

### DIFF
--- a/Tests/CacheSchemaSubscriberTest.php
+++ b/Tests/CacheSchemaSubscriberTest.php
@@ -46,6 +46,7 @@ class CacheSchemaSubscriberTest extends TestCase
             'kernel.container_class' => ContainerBuilder::class,
             'kernel.secret' => 'test',
             'env(base64:default::SYMFONY_DECRYPTION_SECRET)' => 'foo',
+            'debug.file_link_format' => null,
         ]));
 
         $extension = new FrameworkExtension();

--- a/Tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
@@ -48,6 +48,7 @@ class IdGeneratorPassTest extends TestCase
             'kernel.secret' => 'test',
             'container.build_id' => uniqid(),
             'env(base64:default::SYMFONY_DECRYPTION_SECRET)' => 'foo',
+            'debug.file_link_format' => null,
         ]));
         $container->set('annotation_reader', new AnnotationReader());
 

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -52,6 +52,7 @@ class ServiceRepositoryTest extends TestCase
             'kernel.secret' => 'test',
             'container.build_id' => uniqid(),
             'env(base64:default::SYMFONY_DECRYPTION_SECRET)' => 'foo',
+            'debug.file_link_format' => null,
         ]));
         $container->set('annotation_reader', new AnnotationReader());
 


### PR DESCRIPTION
The failing tests using the `ContainerBuilder` without `RegisterEnvVarProcessorsPass`. `%env()%` is not interpreted.

Caused by https://github.com/symfony/symfony/pull/44575#issuecomment-997348440
<details>
  <summary>Failing tests</summary>

```
1) Doctrine\Bundle\DoctrineBundle\Tests\CacheSchemaSubscriberTest::testSchemaSubscriberWiring with data set #0 ('cache.adapter.doctrine_dbal', 'doctrine.orm.listeners.doctri...criber', 'Symfony\Bridge\Doctrine\Schem...criber')
Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException: The parameter "debug.file_link_format" has a dependency on a non-existent parameter "env(default::SYMFONY_IDE)".

/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:93
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:198
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:172
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:135
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/Compiler/ResolveParameterPlaceHoldersPass.php:58
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ContainerBuilder.php:716
/home/runner/work/DoctrineBundle/DoctrineBundle/Tests/CacheSchemaSubscriberTest.php:82

2) Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler\IdGeneratorPassTest::testRepositoryServiceWiring
Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException: The parameter "debug.file_link_format" has a dependency on a non-existent parameter "env(default::SYMFONY_IDE)".

/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:93
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:198
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:172
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:135
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/Compiler/ResolveParameterPlaceHoldersPass.php:58
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ContainerBuilder.php:716
/home/runner/work/DoctrineBundle/DoctrineBundle/Tests/DependencyInjection/Compiler/IdGeneratorPassTest.php:84

3) Doctrine\Bundle\DoctrineBundle\Tests\ServiceRepositoryTest::testRepositoryServiceWiring
Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException: The parameter "debug.file_link_format" has a dependency on a non-existent parameter "env(default::SYMFONY_IDE)".

/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:93
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:198
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:172
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:135
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/Compiler/ResolveParameterPlaceHoldersPass.php:58
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/home/runner/work/DoctrineBundle/DoctrineBundle/vendor/symfony/dependency-injection/ContainerBuilder.php:716
/home/runner/work/DoctrineBundle/DoctrineBundle/Tests/ServiceRepositoryTest.php:92
```

</details>