### PR TITLE
fix: Doctrine ORM 3 support

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -19,6 +19,8 @@ use Doctrine\DBAL\Tools\Console\ConnectionProvider;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Proxy\Autoloader;
+use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand;
+use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
 use Doctrine\ORM\UnitOfWork;
 use LogicException;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
@@ -458,6 +460,15 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (! class_exists(UuidGenerator::class)) {
             $container->removeDefinition('doctrine.uuid_generator');
+        }
+
+        // not available in Doctrine ORM 3.0 and higher
+        if (! class_exists(ConvertMappingCommand::class)) {
+            $container->removeDefinition('doctrine.mapping_convert_command');
+        }
+
+        if (! class_exists(EnsureProductionSettingsCommand::class)) {
+            $container->removeDefinition('doctrine.ensure_production_settings_command');
         }
 
         $entityManagers = [];

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand;
 use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
+use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\ORM\UnitOfWork;
 use LogicException;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
@@ -469,6 +470,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (! class_exists(EnsureProductionSettingsCommand::class)) {
             $container->removeDefinition('doctrine.ensure_production_settings_command');
+        }
+
+        if (! class_exists(ClassMetadataExporter::class)) {
+            $container->removeDefinition('doctrine.mapping_import_command');
         }
 
         $entityManagers = [];

--- a/Tests/Command/ImportMappingDoctrineCommandTest.php
+++ b/Tests/Command/ImportMappingDoctrineCommandTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+use function class_exists;
 use function file_get_contents;
 use function interface_exists;
 use function sys_get_temp_dir;
@@ -26,11 +28,11 @@ class ImportMappingDoctrineCommandTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        if (interface_exists(EntityManagerInterface::class)) {
+        if (interface_exists(EntityManagerInterface::class) && class_exists(ClassMetadataExporter::class)) {
             return;
         }
 
-        self::markTestSkipped('This test requires ORM');
+        self::markTestSkipped('This test requires ORM version 2');
     }
 
     protected function setup(): void

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",
-        "doctrine/orm": "^2.9",
+        "doctrine/orm": "^2.9 || ^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.3 || ^10.0",
         "psalm/plugin-phpunit": "^0.16.1",
@@ -59,7 +59,11 @@
         "vimeo/psalm": "^4.7"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "conflict": {
         "doctrine/orm": "<2.9",


### PR DESCRIPTION
`doctrine:mapping:convert`, `doctrine:ensure-production-settings` and `doctrine:mapping:import` have been removed from Doctrine 3. Registering the proxy classes prevent the container to build properly.