### PR TITLE
Configure Query and ResultCache as PSR6

### DIFF
--- a/DependencyInjection/Compiler/CacheCompatibilityPass.php
+++ b/DependencyInjection/Compiler/CacheCompatibilityPass.php
@@ -14,17 +14,18 @@ use Symfony\Component\DependencyInjection\Reference;
 
 use function array_keys;
 use function assert;
+use function in_array;
 use function is_a;
 use function trigger_deprecation;
 
 /** @internal  */
 final class CacheCompatibilityPass implements CompilerPassInterface
 {
-    private const CONFIGURATION_TAG              = 'doctrine.orm.configuration';
-    private const CACHE_METHODS_PSR6_SUPPORT_MAP = [
-        'setMetadataCache' => true,
-        'setQueryCacheImpl' => false,
-        'setResultCacheImpl' => false,
+    private const CONFIGURATION_TAG          = 'doctrine.orm.configuration';
+    private const CACHE_METHODS_PSR6_SUPPORT = [
+        'setMetadataCache',
+        'setQueryCache',
+        'setResultCache',
     ];
 
     public function process(ContainerBuilder $container): void
@@ -36,15 +37,14 @@ final class CacheCompatibilityPass implements CompilerPassInterface
                     continue;
                 }
 
-                if (! isset(self::CACHE_METHODS_PSR6_SUPPORT_MAP[$methodCall[0]])) {
+                if (! in_array($methodCall[0], self::CACHE_METHODS_PSR6_SUPPORT, true)) {
                     continue;
                 }
 
                 $aliasId      = (string) $methodCall[1][0];
                 $definitionId = (string) $container->getAlias($aliasId);
-                $shouldBePsr6 = self::CACHE_METHODS_PSR6_SUPPORT_MAP[$methodCall[0]];
 
-                $this->wrapIfNecessary($container, $aliasId, $definitionId, $shouldBePsr6);
+                $this->wrapIfNecessary($container, $aliasId, $definitionId, true);
             }
         }
     }

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -580,8 +580,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $methods = [
             'setMetadataCache' => new Reference(sprintf('doctrine.orm.%s_metadata_cache', $entityManager['name'])),
-            'setQueryCacheImpl' => new Reference(sprintf('doctrine.orm.%s_query_cache', $entityManager['name'])),
-            'setResultCacheImpl' => new Reference(sprintf('doctrine.orm.%s_result_cache', $entityManager['name'])),
+            'setQueryCache' => new Reference(sprintf('doctrine.orm.%s_query_cache', $entityManager['name'])),
+            'setResultCache' => new Reference(sprintf('doctrine.orm.%s_result_cache', $entityManager['name'])),
             'setMetadataDriverImpl' => new Reference('doctrine.orm.' . $entityManager['name'] . '_metadata_driver'),
             'setProxyDir' => '%doctrine.orm.proxy_dir%',
             'setProxyNamespace' => '%doctrine.orm.proxy_namespace%',

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -6,7 +6,6 @@ use Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\DbalTestKernel;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration as DBALConfiguration;
 use Doctrine\DBAL\Connection;
@@ -24,6 +23,7 @@ use Symfony\Bridge\Doctrine\Logger\DbalLogger;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 use function class_exists;
@@ -65,8 +65,8 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(Configuration::class, $container->get('doctrine.orm.default_configuration'));
         $this->assertInstanceOf(MappingDriverChain::class, $container->get('doctrine.orm.default_metadata_driver'));
         $this->assertInstanceOf(PhpArrayAdapter::class, $container->get('doctrine.orm.default_metadata_cache'));
-        $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_query_cache'));
-        $this->assertInstanceOf(DoctrineProvider::class, $container->get('doctrine.orm.default_result_cache'));
+        $this->assertInstanceOf(ArrayAdapter::class, $container->get('doctrine.orm.default_query_cache'));
+        $this->assertInstanceOf(ArrayAdapter::class, $container->get('doctrine.orm.default_result_cache'));
         $this->assertInstanceOf(EntityManager::class, $container->get('doctrine.orm.default_entity_manager'));
         $this->assertInstanceOf(Connection::class, $container->get('database_connection'));
         $this->assertInstanceOf(EntityManager::class, $container->get('doctrine.orm.entity_manager'));

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -433,18 +433,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals(PhpArrayAdapter::class, $definition->getClass());
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_query_cache'));
-        $this->assertEquals(CacheProvider::class, $definition->getClass());
-        $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
-        $arguments = $definition->getArguments();
-        $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertEquals('cache.doctrine.orm.em1.query', (string) $arguments[0]);
+        $this->assertSame(ArrayAdapter::class, $definition->getClass());
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.em1_result_cache'));
-        $this->assertEquals(CacheProvider::class, $definition->getClass());
-        $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
-        $arguments = $definition->getArguments();
-        $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertEquals('cache.doctrine.orm.em1.result', (string) $arguments[0]);
+        $this->assertSame(ArrayAdapter::class, $definition->getClass());
     }
 
     public function testLoadLogging(): void

--- a/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -63,9 +63,7 @@ class CacheCompatibilityPassTest extends TestCase
                     $containerBuilder->register($this->regionClass, $this->regionClass);
                     $containerBuilder->setDefinition(
                         'custom_cache_service',
-                        (new Definition(DoctrineProvider::class))
-                            ->setArguments([new Definition(ArrayAdapter::class)])
-                            ->setFactory([DoctrineProvider::class, 'wrap'])
+                        new Definition(ArrayAdapter::class)
                     );
                 });
             }

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -10,7 +10,6 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\Php8EntityListener;
 use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Sharding\PoolingShardManager;
@@ -482,18 +481,10 @@ class DoctrineExtensionTest extends TestCase
         $this->assertSame(ArrayAdapter::class, $wrappedDefinition->getClass());
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_query_cache'));
-        $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
-        $arguments = $definition->getArguments();
-        $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertEquals('cache.doctrine.orm.default.query', (string) $arguments[0]);
-        $this->assertSame(ArrayAdapter::class, $container->getDefinition((string) $arguments[0])->getClass());
+        $this->assertSame(ArrayAdapter::class, $definition->getClass());
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_result_cache'));
-        $this->assertEquals([DoctrineProvider::class, 'wrap'], $definition->getFactory());
-        $arguments = $definition->getArguments();
-        $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertEquals('cache.doctrine.orm.default.result', (string) $arguments[0]);
-        $this->assertSame(ArrayAdapter::class, $container->getDefinition((string) $arguments[0])->getClass());
+        $this->assertSame(ArrayAdapter::class, $definition->getClass());
     }
 
     public function testUseSavePointsAddMethodCallToAddSavepointsToTheConnection(): void

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",
-        "doctrine/orm": "^2.9 || ^3.0",
+        "doctrine/orm": "^2.10 || ^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.3 || ^10.0",
         "psalm/plugin-phpunit": "^0.16.1",
@@ -66,7 +66,7 @@
         }
     },
     "conflict": {
-        "doctrine/orm": "<2.9",
+        "doctrine/orm": "<2.10",
         "twig/twig": "<1.34|>=2.0,<2.4"
     },
     "suggest": {


### PR DESCRIPTION
Since https://github.com/doctrine/orm/pull/9002 also the Query and ResultCache can and should be configured as PSR6.