### PR TITLE
Allow $profiler to be null in ProfilerController constructor

### DIFF
--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -28,10 +28,10 @@ class ProfilerController
     private $twig;
     /** @var Registry */
     private $registry;
-    /** @var Profiler */
+    /** @var Profiler|null */
     private $profiler;
 
-    public function __construct(Environment $twig, Registry $registry, Profiler $profiler)
+    public function __construct(Environment $twig, Registry $registry, ?Profiler $profiler)
     {
         $this->twig     = $twig;
         $this->registry = $registry;
@@ -49,6 +49,7 @@ class ProfilerController
      */
     public function explainAction($token, $connectionName, $query)
     {
+        assert($this->profiler instanceof Profiler);
         $this->profiler->disable();
 
         $profile   = $this->profiler->loadProfile($token);


### PR DESCRIPTION
When a project did not require symfony/web-profiler-bundle the symfony command lint:container failed with this error: 
```
 [ERROR] Invalid definition for service "Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController": argument 3 of
         "Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController::__construct()" accepts
         "Symfony\Component\HttpKernel\Profiler\Profiler", "null" passed.
```

This PR propose to allow nullable $profiler in ProfilerController constructor and use assert() to check $profiler is not null like it was done in previous version 2.5.2 when profiler was retrieved from container.

closes #1457 