### PR TITLE
New feature: "waiting for db" command

### DIFF
--- a/Command/WaitForDatabaseCommand.php
+++ b/Command/WaitForDatabaseCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Command;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class WaitForDatabaseCommand
+{
+    protected static $defaultName = 'doctrine:database:wait';
+
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->addOption(
+            'timeout',
+            't',
+            InputOption::VALUE_OPTIONAL,
+            'Timeout (in seconds)',
+            120
+        );
+
+        $this->setDescription('This command tries to call the database and fails in the timeout is reached');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $failure = true;
+        $attempts = 0;
+        $lastError = 'unknown';
+
+        while($failure) {
+            try {
+                $this->connection->executeQuery('SELECT 1');
+                $failure = false;
+            } catch (\Exception $e) {
+                $lastError = $e->getMessage();
+                $output->writeln("<error>$lastError</error>", OutputInterface::VERBOSITY_VERBOSE);
+            }
+
+            if ($failure && $attempts > 120) { // 120 = 2 min
+
+                $output->writeln("\n", OutputInterface::VERBOSITY_VERBOSE);
+                $output->writeln("<error>Last error: $lastError</error>", OutputInterface::VERBOSITY_NORMAL);
+                return self::FAILURE;
+            }
+
+            sleep(1);
+            $attempts++;
+        }
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
Hello,

Context: while writing test suite or deploying infrastructures with docker, we often need to wait for the database to be ready. Since `docker-compose` version 3 we cannot add a health check into docker, and the official way to go is [to use a tweak](https://docs.docker.com/compose/startup-order/). It never work as expected and finally the best option to make it simple is often to make a `sleep 120`. Even the command `pg_wait` provided in the docker image does not work properly for this use case (??!).

I'm getting bored of those tweaks and maintaining weak scripts even for a little project. So here is some code working for me. If you like the idea, do not hesitate to suggest improvements, and I will surely add a test and fix cs.

With the hope of helping people! :)

_(sorry no idea how to make it a draft)_