### PR TITLE
Remap collate to collation when appropriate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^7.1 || ^8.0",
         "doctrine/annotations": "^1",
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/dbal": "^2.13.1|^3.1",
+        "doctrine/dbal": "^2.13.1|^3.3.2",
         "doctrine/persistence": "^2.2",
         "doctrine/sql-formatter": "^1.0.1",
         "symfony/cache": "^4.3.3|^5.0|^6.0",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,5 +39,11 @@
                 <file name="Repository/ServiceEntityRepository.php"/>
             </errorLevel>
         </TooManyTemplateParams>
+        <InvalidArrayOffset>
+            <errorLevel type="suppress">
+                <!-- requires a release of https://github.com/doctrine/dbal/pull/5261 -->
+                <file name="Tests/ConnectionFactoryTest.php"/>
+            </errorLevel>
+        </InvalidArrayOffset>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
`collate` was never supposed to be supported and used in the first place,
and DBAL 3.3.2 fixed that.
Here, we avoid the situation where a user willing to use the correct
option ends up with both `collate` and `collation` defined, and we remap
`collate` to `collation` when DBAL 3.3 is detected. DBAL 3.3.0 and 3.3.1 are
avoided thanks to a composer version constraint.

Might fix #1468 , might also fix https://github.com/doctrine/migrations/issues/1240, and might also fix https://github.com/doctrine/DoctrineMigrationsBundle/issues/470

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/DoctrineBundle
composer require doctrine/doctrine-bundle "dev-collation as 2.5.5"
```