### PR TITLE
Allow userland middlewares

### DIFF
--- a/Attribute/AsMiddleware.php
+++ b/Attribute/AsMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class AsMiddleware
+{
+    /** @param string[] $connections */
+    public function __construct(
+        public array $connections = [],
+    ) {
+    }
+}

--- a/DependencyInjection/Compiler/MiddlewaresPass.php
+++ b/DependencyInjection/Compiler/MiddlewaresPass.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\Middleware\ConnectionNameAwareInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+use function array_keys;
+use function in_array;
+use function is_subclass_of;
+use function sprintf;
+
+final class MiddlewaresPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $middlewareAbstractDefs = [];
+        $middlewareConnections  = [];
+        foreach ($container->findTaggedServiceIds('doctrine.middleware') as $id => $tags) {
+            $middlewareAbstractDefs[$id] = $container->getDefinition($id);
+            // When a def has doctrine.middleware tags with connection attributes equal to connection names
+            // registration of this middleware is limited to the connections with these names
+            foreach ($tags as $tag) {
+                if (! isset($tag['connection'])) {
+                    continue;
+                }
+
+                $middlewareConnections[$id][] = $tag['connection'];
+            }
+        }
+
+        foreach (array_keys($container->getParameter('doctrine.connections')) as $name) {
+            $middlewareDefs = [];
+            foreach ($middlewareAbstractDefs as $id => $abstractDef) {
+                if (isset($middlewareConnections[$id]) && ! in_array($name, $middlewareConnections[$id], true)) {
+                    continue;
+                }
+
+                $middlewareDefs[] = $childDef = $container->setDefinition(
+                    sprintf('%s.%s', $id, $name),
+                    new ChildDefinition($id)
+                );
+
+                if (! is_subclass_of($abstractDef->getClass(), ConnectionNameAwareInterface::class)) {
+                    continue;
+                }
+
+                $childDef->addMethodCall('setConnectionName', [$name]);
+            }
+
+            $container
+                ->getDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name))
+                ->addMethodCall('setMiddlewares', [$middlewareDefs]);
+        }
+    }
+}

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -7,10 +7,12 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubsc
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\MiddlewaresPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RemoveProfilerControllerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\WellKnownSchemaFilterPass;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Autoloader;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
@@ -26,6 +28,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use function assert;
 use function class_exists;
 use function clearstatcache;
+use function interface_exists;
 use function spl_autoload_unregister;
 
 class DoctrineBundle extends Bundle
@@ -59,6 +62,11 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new DbalSchemaFilterPass());
         $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
         $container->addCompilerPass(new RemoveProfilerControllerPass());
+
+        /** @psalm-suppress UndefinedClass */
+        if (interface_exists(Middleware::class)) {
+            $container->addCompilerPass(new MiddlewaresPass());
+        }
 
         if (! class_exists(RegisterUidTypePass::class)) {
             return;

--- a/Middleware/ConnectionNameAwareInterface.php
+++ b/Middleware/ConnectionNameAwareInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Middleware;
+
+interface ConnectionNameAwareInterface
+{
+    public function setConnectionName(string $name): void;
+}

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -36,9 +36,6 @@
             <argument type="service" id="debug.stopwatch" on-invalid="null" />
         </service>
 
-        <service id="doctrine.dbal.logging_middleware" class="Doctrine\DBAL\Logging\Middleware" abstract="true">
-        </service>
-
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
             <tag name="data_collector" template="@Doctrine/Collector/db.html.twig" id="db" priority="250" />
             <argument type="service" id="doctrine" />

--- a/Resources/config/middlewares.xml
+++ b/Resources/config/middlewares.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="doctrine.dbal.logging_middleware" class="Doctrine\DBAL\Logging\Middleware" abstract="true">
+            <argument type="service" id="logger" on-invalid="null" />
+            <tag name="monolog.logger" channel="doctrine" />
+            <tag name="doctrine.middleware" />
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/Compiler/MiddlewarePassTest.php
+++ b/Tests/DependencyInjection/Compiler/MiddlewarePassTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsMiddleware;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\MiddlewaresPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Doctrine\Bundle\DoctrineBundle\Middleware\ConnectionNameAwareInterface;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+use function interface_exists;
+use function method_exists;
+use function sprintf;
+
+use const PHP_VERSION_ID;
+
+class MiddlewarePassTest extends TestCase
+{
+    /** @return array<string, array{0: class-string, 1: bool}> */
+    public function provideAddMiddleware(): array
+    {
+        return [
+            'not connection name aware' => [PHP7Middleware::class, false],
+            'connection name aware' => [ConnectionAwarePHP7Middleware::class, true],
+        ];
+    }
+
+    /** @dataProvider provideAddMiddleware */
+    public function testAddMiddlewareWithExplicitTag(string $middlewareClass, bool $connectionNameAware): void
+    {
+        /** @psalm-suppress UndefinedClass */
+        if (! interface_exists(Middleware::class)) {
+            $this->markTestSkipped(sprintf('%s needed to run this test', Middleware::class));
+        }
+
+        $container = $this->createContainer(static function (ContainerBuilder $container) use ($middlewareClass) {
+            $container
+                ->register('middleware', $middlewareClass)
+                ->setAbstract(true)
+                ->addTag('doctrine.middleware');
+
+            $container
+                ->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+
+            $container
+                ->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+        });
+
+        $this->assertMiddlewareInjected($container, 'conn1', $middlewareClass, $connectionNameAware);
+        $this->assertMiddlewareInjected($container, 'conn2', $middlewareClass, $connectionNameAware);
+    }
+
+    public function testAddMiddlewareWithExplicitTagsOnSpecificConnections(): void
+    {
+        /** @psalm-suppress UndefinedClass */
+        if (! interface_exists(Middleware::class)) {
+            $this->markTestSkipped(sprintf('%s needed to run this test', Middleware::class));
+        }
+
+        $container = $this->createContainer(static function (ContainerBuilder $container) {
+            $container
+                ->register('middleware', PHP7Middleware::class)
+                ->setAbstract(true)
+                ->addTag('doctrine.middleware', ['connection' => 'conn1']);
+
+            $container
+                ->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+
+            $container
+                ->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+        });
+
+        $this->assertMiddlewareInjected($container, 'conn1', PHP7Middleware::class);
+        $this->assertMiddlewareNotInjected($container, 'conn2', PHP7Middleware::class);
+    }
+
+    public function testAddMiddlewareWithAutoconfigure(): void
+    {
+        /** @psalm-suppress UndefinedClass */
+        if (! interface_exists(Middleware::class)) {
+            $this->markTestSkipped(sprintf('%s needed to run this test', Middleware::class));
+        }
+
+        $container = $this->createContainer(static function (ContainerBuilder $container) {
+            /** @psalm-suppress UndefinedClass */
+            $container
+                ->register('middleware', AutoconfiguredPHP7Middleware::class)
+                ->setAutoconfigured(true);
+
+            $container
+                ->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+
+            $container
+                ->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+        });
+
+        /** @psalm-suppress UndefinedClass */
+        $this->assertMiddlewareInjected($container, 'conn1', AutoconfiguredPHP7Middleware::class);
+        /** @psalm-suppress UndefinedClass */
+        $this->assertMiddlewareInjected($container, 'conn2', AutoconfiguredPHP7Middleware::class);
+    }
+
+    /** @return array<string, array{0: class-string, 1: bool}> */
+    public function provideAddMiddlewareWithAttributeForAutoconfiguration(): array
+    {
+        /** @psalm-suppress UndefinedClass */
+        return [
+            'without specifying connection' => [AutoconfiguredMiddleware::class, true],
+            'specifying connection' => [AutoconfiguredMiddlewareWithConnection::class, false],
+        ];
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider provideAddMiddlewareWithAttributeForAutoconfiguration
+     */
+    public function testAddMiddlewareWithAttributeForAutoconfiguration(string $className, bool $registeredOnConn1): void
+    {
+        /** @psalm-suppress UndefinedClass */
+        if (! interface_exists(Middleware::class)) {
+            $this->markTestSkipped(sprintf('%s needed to run this test', Middleware::class));
+        }
+
+        if (PHP_VERSION_ID < 80000 || ! method_exists(ContainerBuilder::class, 'registerAttributeForAutoconfiguration')) {
+            $this->markTestSkipped(sprintf(
+                'Testing attribute for autoconfiguration requires PHP 8 and %s::registerAttributeForAutoconfiguration',
+                ContainerBuilder::class
+            ));
+        }
+
+        $container = $this->createContainer(static function (ContainerBuilder $container) use ($className) {
+            /** @psalm-suppress UndefinedClass */
+            $container
+                ->register('middleware', $className)
+                ->setAutoconfigured(true);
+
+            $container
+                ->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+
+            $container
+                ->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')
+                ->setPublic(true); // Avoid removal and inlining
+        });
+
+        if ($registeredOnConn1) {
+            /** @psalm-suppress UndefinedClass */
+            $this->assertMiddlewareInjected($container, 'conn1', $className);
+        } else {
+            $this->assertMiddlewareNotInjected($container, 'conn1', $className);
+        }
+
+        /** @psalm-suppress UndefinedClass */
+        $this->assertMiddlewareInjected($container, 'conn2', $className);
+    }
+
+    private function createContainer(callable $func): ContainerBuilder
+    {
+        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => false]));
+
+        $container->registerExtension(new DoctrineExtension());
+        $container->loadFromExtension('doctrine', [
+            'dbal' => [
+                'connections' => [
+                    'conn1' => ['url' => 'mysql://user:pass@server1.tld:3306/db1'],
+                    'conn2' => ['url' => 'mysql://user:pass@server2.tld:3306/db2'],
+                ],
+            ],
+        ]);
+
+        $container->addCompilerPass(new MiddlewaresPass());
+
+        $func($container);
+
+        $container->compile();
+
+        return $container;
+    }
+
+    private function assertMiddlewareInjected(
+        ContainerBuilder $container,
+        string $connName,
+        string $middlewareClass,
+        bool $connectionNameAware = false
+    ): void {
+        $middlewareFound = $this->getMiddlewaresForConn($container, $connName, $middlewareClass);
+
+        $this->assertCount(1, $middlewareFound, sprintf(
+            'Middleware %s not injected in doctrine.dbal.%s_connection.configuration',
+            $middlewareClass,
+            $connName
+        ));
+
+        $callsFound = [];
+        foreach ($middlewareFound[0]->getMethodCalls() as $call) {
+            if ($call[0] !== 'setConnectionName') {
+                continue;
+            }
+
+            $callsFound[] = $call;
+        }
+
+        if ($connectionNameAware) {
+            $this->assertCount(1, $callsFound);
+            $this->assertSame($callsFound[0][1][0] ?? null, $connName);
+        } else {
+            $this->assertCount(0, $callsFound);
+        }
+    }
+
+    private function assertMiddlewareNotInjected(
+        ContainerBuilder $container,
+        string $connName,
+        string $middlewareClass
+    ): void {
+        $middlewareFound = $this->getMiddlewaresForConn($container, $connName, $middlewareClass);
+
+        $this->assertCount(0, $middlewareFound, sprintf(
+            'Middleware %s injected in doctrine.dbal.%s_connection.configuration',
+            $middlewareClass,
+            $connName
+        ));
+    }
+
+    /** @return Definition[] */
+    private function getMiddlewaresForConn(ContainerBuilder $container, string $connName, string $middlewareClass): array
+    {
+        $calls            = $container->getDefinition('conf_' . $connName)->getMethodCalls();
+        $middlewaresFound = [];
+        foreach ($calls as $call) {
+            if ($call[0] !== 'setMiddlewares' || ! isset($call[1][0])) {
+                continue;
+            }
+
+            foreach ($call[1][0] as $middlewareDef) {
+                if ($middlewareDef->getClass() !== $middlewareClass) {
+                    continue;
+                }
+
+                $middlewaresFound[] = $middlewareDef;
+            }
+        }
+
+        return $middlewaresFound;
+    }
+}
+
+class PHP7Middleware
+{
+}
+
+class ConnectionAwarePHP7Middleware implements ConnectionNameAwareInterface
+{
+    public function setConnectionName(string $name): void
+    {
+    }
+}
+
+/** @psalm-suppress UndefinedClass */
+if (interface_exists(Middleware::class)) {
+    class AutoconfiguredPHP7Middleware implements Middleware
+    {
+        public function wrap(Driver $driver): Driver
+        {
+            return $driver;
+        }
+    }
+
+    if (PHP_VERSION_ID >= 80000) {
+        #[AsMiddleware]
+        class AutoconfiguredMiddleware
+        {
+        }
+
+        #[AsMiddleware(connections: ['conn2'])]
+        class AutoconfiguredMiddlewareWithConnection
+        {
+        }
+    }
+}


### PR DESCRIPTION
Related to the needs to replace SQLLogger by Middlewares, this implementations allows to easily inject middleware via a `doctrine.middleware` tag.