### PR TITLE
Stop giving charset examples

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -27,7 +27,10 @@ Configuration Reference
                         port:                 ~
                         user:                 root
                         password:             ~
-                        charset:              "UTF8"
+
+                        # RDBMS specific; Refer to the manual of your RDBMS for more information
+                        charset:              ~
+
                         dbname_suffix:        ~
 
                         # SQLite specific
@@ -132,8 +135,8 @@ Configuration Reference
                         default_table_options:
                             # Affects schema-tool. If absent, DBAL chooses defaults
                             # based on the platform. Examples here are for MySQL.
-                            # charset:      utf8
-                            # collate:      utf8_unicode_ci
+                            # charset:      utf8mb4
+                            # collate:      utf8mb4_unicode_ci
                             # engine:       InnoDB
 
                         replicas:
@@ -443,7 +446,7 @@ Configuration Reference
                         port="null"
                         user="root"
                         password="null"
-                        charset="UTF8"
+                        charset="null"
                         path=""
                         memory=""
                         unix-socket=""
@@ -485,8 +488,8 @@ Configuration Reference
                         <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
 
                         <!-- example -->
-                        <doctrine:default-table-option name="charset">utf8</doctrine:default-table-option>
-                        <doctrine:default-table-option name="collate">utf8_unicode_ci</doctrine:default-table-option>
+                        <doctrine:default-table-option name="charset">utf8mb4</doctrine:default-table-option>
+                        <doctrine:default-table-option name="collate">utf8mb4_unicode_ci</doctrine:default-table-option>
                         <doctrine:default-table-option name="engine">InnoDB</doctrine:default-table-option>
 
                         <!-- example -->
@@ -959,7 +962,7 @@ can configure. The following block shows all possible configuration keys:
                 sslkey:                   postgresql-key.pem  # PostgreSQL specific (LIBPQ-CONNECT-SSLKEY)
                 sslcrl:                   postgresql.crl      # PostgreSQL specific (LIBPQ-CONNECT-SSLCRL)
                 wrapper_class:            MyDoctrineDbalConnectionWrapper
-                charset:                  UTF8
+                charset:                  ~                   # RDBMS-specific. Refer to the manual of your RDBMS for more information.
                 logging:                  "%kernel.debug%"
                 platform_service:         MyOwnDatabasePlatformService
                 auto_commit:              false
@@ -970,9 +973,10 @@ can configure. The following block shows all possible configuration keys:
                     custom: Acme\HelloBundle\MyCustomType
                 default_table_options:
                     # Affects schema-tool. If absent, DBAL chooses defaults
-                    # based on the platform.
-                    charset:              utf8
-                    collate:              utf8_unicode_ci
+                    # based on the platform. These defaults might be
+                    # sub-optimal for backward compatibility reasons.
+                    charset:              utf8mb4
+                    collate:              utf8mb4_unicode_ci
                     engine:               InnoDB
 
     .. code-block:: xml
@@ -1048,7 +1052,7 @@ can configure. The following block shows all possible configuration keys:
                     sslkey="postgresql-key.pem"
                     sslcrl="postgresql.crl"
                     wrapper-class="MyDoctrineDbalConnectionWrapper"
-                    charset="UTF8"
+                    charset=""
                     logging="%kernel.debug%"
                     platform-service="MyOwnDatabasePlatformService"
                     auto-commit="false"
@@ -1056,8 +1060,8 @@ can configure. The following block shows all possible configuration keys:
                 >
                     <doctrine:option key="foo">bar</doctrine:option>
                     <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
-                    <doctrine:default-table-option name="charset">utf8</doctrine:default-table-option>
-                    <doctrine:default-table-option name="collate">utf8_unicode_ci</doctrine:default-table-option>
+                    <doctrine:default-table-option name="charset">utf8mb4</doctrine:default-table-option>
+                    <doctrine:default-table-option name="collate">utf8mb4_unicode_ci</doctrine:default-table-option>
                     <doctrine:default-table-option name="engine">InnoDB</doctrine:default-table-option>
                     <doctrine:type name="custom">Acme\HelloBundle\MyCustomType</doctrine:type>
                 </doctrine:dbal>


### PR DESCRIPTION
On PostgreSQL, `UTF8` is a good recommendation. On MySQL though, it will
result in the usage of a deprecated charset, and using uppercase like in
the example is known to cause bugs when diffing schemas.