### PR TITLE
Fix default MySQL charset with doctrine/dbal > 2

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -5,11 +5,9 @@ namespace Doctrine\Bundle\DoctrineBundle;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DriverException;
-use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
@@ -72,7 +74,9 @@ class ConnectionFactory
             $driver     = $connection->getDriver();
 
             if (! isset($params['charset'])) {
-                if ($driver->getDatabasePlatform()->getName() === 'mysql') {
+                if ($driver->getDatabasePlatform() instanceof AbstractMySQLPlatform
+                    || $driver->getDatabasePlatform() instanceof MySqlPlatform
+                ) {
                     $params['charset'] = 'utf8mb4';
 
                     /* PARAM_ASCII_STR_ARRAY is defined since doctrine/dbal 3.3

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -41,6 +41,7 @@ class ConnectionFactory
      * @param mixed[]               $params
      * @param array<string, string> $mappingTypes
      * @psalm-param Params $params
+     * @psalm-suppress UndefinedClass
      *
      * @return Connection
      */

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
@@ -73,7 +74,7 @@ class ConnectionFactory
             $driver     = $connection->getDriver();
 
             if (! isset($params['charset'])) {
-                if ($driver instanceof AbstractMySQLDriver) {
+                if ($driver->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
                     $params['charset'] = 'utf8mb4';
 
                     /* PARAM_ASCII_STR_ARRAY is defined since doctrine/dbal 3.3

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -74,7 +74,7 @@ class ConnectionFactory
             $driver     = $connection->getDriver();
 
             if (! isset($params['charset'])) {
-                if ($driver->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+                if ($driver->getDatabasePlatform()->getName() === 'mysql') {
                     $params['charset'] = 'utf8mb4';
 
                     /* PARAM_ASCII_STR_ARRAY is defined since doctrine/dbal 3.3

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -9,8 +9,8 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Types\Type;
 
 use function array_merge;
@@ -41,7 +41,6 @@ class ConnectionFactory
      * @param mixed[]               $params
      * @param array<string, string> $mappingTypes
      * @psalm-param Params $params
-     * @psalm-suppress UndefinedClass
      *
      * @return Connection
      */
@@ -73,11 +72,11 @@ class ConnectionFactory
             $connection = DriverManager::getConnection($params, $config, $eventManager);
             $params     = $this->addDatabaseSuffix(array_merge($connection->getParams(), $overriddenOptions));
             $driver     = $connection->getDriver();
+            $platform   = $driver->getDatabasePlatform();
 
             if (! isset($params['charset'])) {
-                if ($driver->getDatabasePlatform() instanceof AbstractMySQLPlatform
-                    || $driver->getDatabasePlatform() instanceof MySqlPlatform
-                ) {
+                /** @psalm-suppress UndefinedClass AbstractMySQLPlatform exists since DBAL 3.x only */
+                if ($platform instanceof AbstractMySQLPlatform || $platform instanceof MySqlPlatform) {
                     $params['charset'] = 'utf8mb4';
 
                     /* PARAM_ASCII_STR_ARRAY is defined since doctrine/dbal 3.3

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -51,7 +51,7 @@ class ConnectionFactoryTest extends TestCase
         try {
             $factory->createConnection($params, $config, $eventManager, $mappingTypes);
         } catch (Throwable $e) {
-            $this->assertStringContainsString($e->getMessage(), 'can circumvent this by setting');
+            $this->assertStringContainsString('can circumvent this by setting', $e->getMessage());
 
             throw $e;
         } finally {

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Exception;
 use Throwable;
@@ -31,7 +32,9 @@ class ConnectionFactoryTest extends TestCase
     {
         $typesConfig  = [];
         $factory      = new ConnectionFactory($typesConfig);
-        $params       = ['driverClass' => FakeDriver::class];
+        $params       = [
+            'driverClass' => FakeDriver::class,
+        ];
         $config       = null;
         $eventManager = null;
         $mappingTypes = ['' => ''];
@@ -48,7 +51,7 @@ class ConnectionFactoryTest extends TestCase
         try {
             $factory->createConnection($params, $config, $eventManager, $mappingTypes);
         } catch (Throwable $e) {
-            $this->assertTrue(strpos($e->getMessage(), 'can circumvent this by setting') > 0);
+            $this->assertStringContainsString($e->getMessage(), 'can circumvent this by setting');
 
             throw $e;
         } finally {

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -68,7 +68,7 @@ class ConnectionFactoryTest extends TestCase
         $connection    = $factory->createConnection($params);
 
         $this->assertInstanceof(FakeConnection::class, $connection);
-        $this->assertSame('utf8', $connection->getParams()['charset']);
+        $this->assertSame('utf8mb4', $connection->getParams()['charset']);
         $this->assertSame(1 + $creationCount, FakeConnection::$creationCount);
     }
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -45,5 +45,13 @@
                 <file name="Tests/ConnectionFactoryTest.php"/>
             </errorLevel>
         </InvalidArrayOffset>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <!-- https://github.com/symfony/symfony/issues/45609 -->
+                <referencedClass name="UnitEnum" />
+                <directory name="DependencyInjection"/>
+                <directory name="Tests/DependencyInjection"/>
+            </errorLevel>
+        </UndefinedDocblockClass>
     </issueHandlers>
 </psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,6 +15,7 @@
             <!-- Deprecated classes, not worth fixing -->
             <file name="Command/ImportMappingDoctrineCommand.php"/>
             <file name="DependencyInjection/Compiler/WellKnownSchemaFilterPass.php"/>
+            <file name="Tests/ConnectionFactoryTest.php"/>
         </ignoreFiles>
         <directory name="CacheWarmer"/>
         <directory name="Command"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,7 +15,7 @@
             <!-- Deprecated classes, not worth fixing -->
             <file name="Command/ImportMappingDoctrineCommand.php"/>
             <file name="DependencyInjection/Compiler/WellKnownSchemaFilterPass.php"/>
-            <file name="Tests/ConnectionFactoryTest.php"/>
+            <file name="ConnectionFactory.php"/>
         </ignoreFiles>
         <directory name="CacheWarmer"/>
         <directory name="Command"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,7 +15,6 @@
             <!-- Deprecated classes, not worth fixing -->
             <file name="Command/ImportMappingDoctrineCommand.php"/>
             <file name="DependencyInjection/Compiler/WellKnownSchemaFilterPass.php"/>
-            <file name="ConnectionFactory.php"/>
         </ignoreFiles>
         <directory name="CacheWarmer"/>
         <directory name="Command"/>


### PR DESCRIPTION
The `$driver` variable can return `Doctrine\DBAL\Logging\Driver` which is not instance of `AbstractMySQLDriver`. So it need to be via the platform.

Sadly `AbstractMySQLDriver` is not available on prefer lowest so we need to check on the deprecated `getName` method on the platform.

fixes #1480