### PR TITLE
Logging: allow disabling logging for all connections

### DIFF
--- a/Resources/config/middlewares.xml
+++ b/Resources/config/middlewares.xml
@@ -8,7 +8,6 @@
         <service id="doctrine.dbal.logging_middleware" class="Doctrine\DBAL\Logging\Middleware" abstract="true">
             <argument type="service" id="logger" />
             <tag name="monolog.logger" channel="doctrine" />
-            <tag name="doctrine.middleware" />
         </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1223,6 +1223,35 @@ class DoctrineExtensionTest extends TestCase
         $this->assertFalse(in_array(['connection' => 'conn2'], $middleWareTagAttributes, true), 'Tag with connection conn2 found');
     }
 
+    public function testDefinitionsToLogQueriesLoggingFalse(): void
+    {
+        /** @psalm-suppress UndefinedClass */
+        if (! class_exists(Middleware::class)) {
+            $this->markTestSkipped(sprintf('%s needs %s to not exist', __METHOD__, Middleware::class));
+        }
+
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $config = BundleConfigurationBuilder::createBuilderWithBaseValues()
+            ->addConnection([
+                'connections' => [
+                    'conn' => [
+                        'password' => 'foo',
+                        'logging' => false,
+                    ],
+                ],
+            ])
+            ->addBaseEntityManager()
+            ->build();
+
+        $extension->load([$config], $container);
+
+        $this->assertTrue($container->hasDefinition('doctrine.dbal.logging_middleware'));
+        $abstractMiddlewareDefTags = $container->getDefinition('doctrine.dbal.logging_middleware')->getTags();
+        $this->assertArrayNotHasKey('doctrine.middleware', $abstractMiddlewareDefTags);
+    }
+
     // phpcs:enable
 
     /** @param list<string> $bundles */


### PR DESCRIPTION
Having one or multiple connections set up and all of them `logging: false` configured, activates logging via Middleware for all connection.

Sample configuration:
```
doctrine:
    dbal:
        connections:
            default:
                driver: 'pdo_pgsql'
                url: '%env(DATABASE_URL)%'
                logging: false
```

The `middlewares.xml` defines a `doctrine.middleware` tag by default for `Doctrine\DBAL\Logging\Middleware`, which the `MiddlewaresPass` then applies to all connections. Having one or more connections with `logging: true` will overwrite the tag and set `connections` to an array of connections, which then only enables logging for those configured connections. That second part is working as expected.