### PR TITLE
fix: propagate driverOptions to primary-replica connections

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -52,22 +52,15 @@ EOT
 
         $ifNotExists = $input->getOption('if-not-exists');
 
-        $driverOptions = [];
-        $params        = $connection->getParams();
-
-        if (isset($params['driverOptions'])) {
-            $driverOptions = $params['driverOptions'];
-        }
+        $params = $connection->getParams();
 
         // Since doctrine/dbal 2.11 master has been replaced by primary
         if (isset($params['primary'])) {
-            $params                  = $params['primary'];
-            $params['driverOptions'] = $driverOptions;
+            $params = $params['primary'];
         }
 
         if (isset($params['master'])) {
-            $params                  = $params['master'];
-            $params['driverOptions'] = $driverOptions;
+            $params = $params['master'];
         }
 
         // Cannot inject `shard` option in parent::getDoctrineConnection

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -63,22 +63,15 @@ EOT
 
         $ifExists = $input->getOption('if-exists');
 
-        $driverOptions = [];
-        $params        = $connection->getParams();
-
-        if (isset($params['driverOptions'])) {
-            $driverOptions = $params['driverOptions'];
-        }
+        $params = $connection->getParams();
 
         // Since doctrine/dbal 2.11 master has been replaced by primary
         if (isset($params['primary'])) {
-            $params                  = $params['primary'];
-            $params['driverOptions'] = $driverOptions;
+            $params = $params['primary'];
         }
 
         if (isset($params['master'])) {
-            $params                  = $params['master'];
-            $params['driverOptions'] = $driverOptions;
+            $params = $params['master'];
         }
 
         if (isset($params['shards'])) {

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -360,10 +360,21 @@ class DoctrineExtension extends AbstractDoctrineExtension
             throw new InvalidArgumentException('Sharding and master-slave connection cannot be used together');
         }
 
+        foreach (['shards', 'replica', 'slaves'] as $connectionKey) {
+            foreach (array_keys($options[$connectionKey]) as $name) {
+                $driverOptions       = $options[$connectionKey][$name]['driverOptions'] ?? [];
+                $parentDriverOptions = $options['driverOptions'] ?? [];
+                if ($driverOptions === [] && $parentDriverOptions === []) {
+                    continue;
+                }
+
+                $options[$connectionKey][$name]['driverOptions'] = $driverOptions + $parentDriverOptions;
+            }
+        }
+
         if (! empty($options['slaves']) || ! empty($options['replica'])) {
             $nonRewrittenKeys = [
                 'driver' => true,
-                'driverOptions' => true,
                 'driverClass' => true,
                 'wrapperClass' => true,
                 'keepSlave' => true,

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -361,8 +361,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         foreach (['shards', 'replica', 'slaves'] as $connectionKey) {
-            foreach (array_keys($options[$connectionKey]) as $name) {
-                $driverOptions       = $options[$connectionKey][$name]['driverOptions'] ?? [];
+            foreach ($options[$connectionKey] as $name => $value) {
+                $driverOptions       = $value['driverOptions'] ?? [];
                 $parentDriverOptions = $options['driverOptions'] ?? [];
                 if ($driverOptions === [] && $parentDriverOptions === []) {
                     continue;

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Generator;
 use InvalidArgumentException;
+use PDO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator;
@@ -199,6 +200,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'mysql_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
+                'driverOptions' => [PDO::ATTR_STRINGIFY_FETCHES => 1],
             ],
             $param['primary'] ?? $param['master'] // TODO: Remove 'master' support here when we require dbal >= 2.11
         );
@@ -210,6 +212,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'replica_db',
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld_replica.sock',
+                'driverOptions' => [PDO::ATTR_STRINGIFY_FETCHES => 1],
             ],
             $param['replica']['replica1']
         );

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_master_slave_connection.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_master_slave_connection.xml
@@ -10,6 +10,7 @@
         <dbal dbname="mysql_db" user="mysql_user" password="mysql_s3cr3t" unix-socket="/path/to/mysqld.sock" keep-replica="true">
             <replica name="replica1" dbname="replica_db" user="replica_user" password="replica_s3cr3t" unix-socket="/path/to/mysqld_replica.sock" />
             <default-table-option name="engine">InnoDB</default-table-option>
+            <option key="17" value="1" />
         </dbal>
     </config>
 </srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_master_slave_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_master_slave_connection.yml
@@ -7,6 +7,8 @@ doctrine:
         keep_replica: true
         default_table_options:
             engine: InnoDB
+        options:
+            !php/const:PDO::ATTR_STRINGIFY_FETCHES: 1
         replicas:
             replica1:
                 user: replica_user


### PR DESCRIPTION
_I kind of struggle to find out what's going on about propagating DriverOptions to primary-replica connections. Searching through issues it seems it was removed in https://github.com/doctrine/DoctrineBundle/pull/1253, then requested to be added in https://github.com/doctrine/DoctrineBundle/issues/1416 and that was closed as resolved even though there were no changes._

![me confused](https://cultofthepartyparrot.com/parrots/hd/confusedparrot.gif)

This PR does not break any tests so I consider it a fix that does not break anything 🤷🏾‍♀️.

[DBAL's PrimaryReadReplicaConnection::connectTo()](https://github.com/doctrine/dbal/blob/719663b15983278227669c8595151586a2ff3327/src/Connections/PrimaryReadReplicaConnection.php#L244) method calls `chooseConnectionConfiguration()` which creates params for PDO in my case.

The problem is that `primary` entry already does not have the `driverOptions` entry. `driverOptions` is in top level only. So `$connectionParams` does not contain it, it gets stripped.

<details>
<summary>Values</summary>

`$params`:

```php
array (
  'driver' => 'pdo_mysql',
  'driverOptions' => 
  array (
    17 => 1,
  ),
  'keepReplica' => true,
  'replica' => 
  array (
    'r1' => 
    array (
      'url' => 'mysql://root:root@127.0.0.1:3307/__tests_1649508676_a0a89602',
      'host' => '127.0.0.1',
      'port' => 3307,
      'user' => 'root',
      'password' => 'root',
      'driver' => 'pdo_mysql',
      'dbname' => '__tests_1649506773_2e8ed0d5',
    ),
  ),
  'primary' => 
  array (
    'charset' => 'utf8',
    'url' => 'mysql://root:root@127.0.0.1:3307/__tests_1649508676_a0a89602',
    'host' => '127.0.0.1',
    'port' => 3307,
    'user' => 'root',
    'password' => 'root',
    'driver' => 'pdo_mysql',
    'dbname' => '__tests_1649508676_a0a89602',
  ),
)
```

`$connectionParams`:
```php
array (
  'charset' => 'utf8',
  'url' => 'mysql://root:root@127.0.0.1:3307/__tests_1649508676_a0a89602',
  'host' => '127.0.0.1',
  'port' => 3307,
  'user' => 'root',
  'password' => 'root',
  'driver' => 'pdo_mysql',
  'dbname' => '__tests_1649508676_a0a89602',
)
```
</details>

Since those are passed into `$this->_driver->connect($connectionParams)` which bubbles that into [Driver, the new PDO instance is created without it so DriverOptions are effectively ignored](https://github.com/doctrine/dbal/blob/719663b15983278227669c8595151586a2ff3327/src/Driver/PDO/MySQL/Driver.php#L18).

