### PR TITLE
Added naming_strategy option to config reference defaults

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -758,6 +758,7 @@ the ORM resolves to:
             metadata_cache_driver: ~
             query_cache_driver: ~
             result_cache_driver: ~
+            naming_strategy: doctrine.orm.naming_strategy.default
 
 There are lots of other configuration options that you can use to overwrite
 certain classes, but those are for very advanced use-cases only.


### PR DESCRIPTION
The `namong_strategy` option of the configuration reference is currenty missing from the ORM defaults section. So I have added it together with its default value.