### PR TITLE
[Doc] Fix some minor syntax issues

### DIFF
--- a/Resources/doc/entity-listeners.rst
+++ b/Resources/doc/entity-listeners.rst
@@ -11,7 +11,7 @@ Full example:
 
 .. configuration-block::
 
-    .. code-block:: annotation
+    .. code-block:: php-annotations
 
         <?php
         // User.php
@@ -28,7 +28,7 @@ Full example:
             // ....
         }
     
-    .. code-block:: attribute
+    .. code-block:: php-attributes
 
         <?php
         // User.php


### PR DESCRIPTION
Fixes the error reported in https://symfony.com/doc/build_errors#DoctrineBundle-2.7.x (this error doesn't happen in 2.6.x branch)