### PR TITLE
Call clear() when trying to reset ghost object proxies

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Proxy\Proxy;
+use ProxyManager\Proxy\GhostObjectInterface;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
@@ -75,7 +76,7 @@ class Registry extends ManagerRegistry implements ResetInterface
 
         assert($manager instanceof EntityManagerInterface);
 
-        if (! $manager instanceof LazyLoadingInterface || $manager->isOpen()) {
+        if (! $manager instanceof LazyLoadingInterface || $manager instanceof GhostObjectInterface || $manager->isOpen()) {
             $manager->clear();
 
             return;

--- a/Tests/GhostObjectEntityManagerInterface.php
+++ b/Tests/GhostObjectEntityManagerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests;
+
+use Doctrine\ORM\EntityManagerInterface;
+use ProxyManager\Proxy\GhostObjectInterface;
+
+interface GhostObjectEntityManagerInterface extends GhostObjectInterface, EntityManagerInterface
+{
+}

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -143,6 +143,10 @@ class RegistryTest extends TestCase
         $noProxyManager->expects($this->once())
             ->method('clear');
 
+        $ghostProxyManager = $this->getMockBuilder(GhostObjectEntityManagerInterface::class)->getMock();
+        $ghostProxyManager->expects($this->once())
+            ->method('clear');
+
         $proxyManager = $this->createMock(LazyLoadingEntityManagerInterface::class);
         $proxyManager->expects($this->once())
             ->method('setProxyInitializer')
@@ -151,17 +155,18 @@ class RegistryTest extends TestCase
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $container->expects($this->any())
             ->method('initialized')
-            ->withConsecutive(['doctrine.orm.uninitialized_entity_manager'], ['doctrine.orm.noproxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'])
-            ->willReturnOnConsecutiveCalls(false, true, true, true);
+            ->withConsecutive(['doctrine.orm.uninitialized_entity_manager'], ['doctrine.orm.noproxy_entity_manager'], ['doctrine.orm.ghost_proxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'])
+            ->willReturnOnConsecutiveCalls(false, true, true, true, true);
 
         $container->expects($this->any())
             ->method('get')
-            ->withConsecutive(['doctrine.orm.noproxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'])
-            ->willReturnOnConsecutiveCalls($noProxyManager, $proxyManager, $proxyManager, $proxyManager);
+            ->withConsecutive(['doctrine.orm.noproxy_entity_manager'], ['doctrine.orm.ghost_proxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'], ['doctrine.orm.proxy_entity_manager'])
+            ->willReturnOnConsecutiveCalls($noProxyManager, $ghostProxyManager, $proxyManager, $proxyManager, $proxyManager);
 
         $entityManagers = [
             'uninitialized' => 'doctrine.orm.uninitialized_entity_manager',
             'noproxy' => 'doctrine.orm.noproxy_entity_manager',
+            'ghost_proxy' => 'doctrine.orm.ghost_proxy_entity_manager',
             'proxy' => 'doctrine.orm.proxy_entity_manager',
         ];
 


### PR DESCRIPTION
Similar to https://github.com/symfony/symfony/pull/46443
Builds on https://github.com/doctrine/DoctrineBundle/pull/1118