### PR TITLE
Ensure a lazy *value holder* proxy is always generated with proxy-manager-bridge

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -100,6 +100,7 @@
 
         <service id="doctrine.orm.entity_manager.abstract" class="%doctrine.orm.entity_manager.class%" abstract="true" lazy="true">
             <factory class="%doctrine.orm.entity_manager.class%" method="create" />
+            <tag name="proxy" interface="%doctrine.orm.entity_manager.class%" />
         </service>
 
         <service id="doctrine.orm.container_repository_factory" class="Doctrine\Bundle\DoctrineBundle\Repository\ContainerRepositoryFactory" public="false">

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -509,6 +509,9 @@ class DoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition((string) $container->getAlias('doctrine.orm.default_result_cache'));
         $this->assertSame(ArrayAdapter::class, $definition->getClass());
+
+        $definition = $container->getDefinition('doctrine.orm.entity_manager.abstract');
+        $this->assertSame([['interface' => '%doctrine.orm.entity_manager.class%']], $definition->getTag('proxy'));
     }
 
     public function testUseSavePointsAddMethodCallToAddSavepointsToTheConnection(): void


### PR DESCRIPTION
While working on https://github.com/symfony/symfony/issues/35345, I figured out that we need to ensure that the entity manager will continue to use a value-holder proxy (and not a ghost-object proxy, at least not until https://github.com/doctrine/orm/issues/5933 is solved.)

This is the way to do so.

See also https://github.com/symfony/symfony/issues/35345#issuecomment-1136017356