### PR TITLE
Moves ProfilerController service definition to dbal.xml

### DIFF
--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -104,5 +104,13 @@
             <tag name="console.command" command="dbal:run-sql" />
         </service>
 
+        <service id="Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController">
+            <argument type="service" id="twig" />
+            <argument type="service" id="doctrine" />
+            <argument type="service" id="profiler" />
+
+            <tag name="controller.service_arguments" />
+        </service>
+
     </services>
 </container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -233,13 +233,5 @@
 
             <tag name="console.command" command="doctrine:mapping:import" />
         </service>
-
-        <service id="Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController">
-            <argument type="service" id="twig" />
-            <argument type="service" id="doctrine" />
-            <argument type="service" id="profiler" />
-
-            <tag name="controller.service_arguments" />
-        </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
+use Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController;
 use Doctrine\Bundle\DoctrineBundle\Dbal\BlacklistSchemaAssetFilter;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheCompatibilityPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
@@ -447,6 +448,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     public function testLoadLogging(): void
     {
         $container = $this->loadContainer('dbal_logging');
+
+        $this->assertTrue($container->hasDefinition(ProfilerController::class), 'ProfilerController should be available even when not using the ORM.');
 
         $definition = $container->getDefinition('doctrine.dbal.log_connection.configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setSQLLogger', [new Reference('doctrine.dbal.logger')]);


### PR DESCRIPTION
This makes the profiler controller available even when not using the ORM.

See issue #1530 