### PR TITLE
add conflict with doctrine/orm < 2.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         }
     },
     "conflict": {
-        "doctrine/orm": "<2.10|>=3.0",
+        "doctrine/orm": "<2.11|>=3.0",
         "twig/twig": "<1.34|>=2.0,<2.4"
     },
     "suggest": {


### PR DESCRIPTION
Fixes https://github.com/doctrine/DoctrineBundle/issues/1536

Also thought about conditionally checking for existence of `Doctrine\ORM\Configuration::setSchemaIgnoreClasses()` but bumping the orm requirement seems better here.