### PR TITLE
Allow resetting lazy managers on Symfony 6.2

### DIFF
--- a/Registry.php
+++ b/Registry.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Proxy\Proxy;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Component\VarExporter\LazyGhostObjectInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 use function array_keys;
@@ -75,7 +76,7 @@ class Registry extends ManagerRegistry implements ResetInterface
 
         assert($manager instanceof EntityManagerInterface);
 
-        if (! $manager instanceof LazyLoadingInterface || $manager->isOpen()) {
+        if ((! $manager instanceof LazyLoadingInterface && ! $manager instanceof LazyGhostObjectInterface) || $manager->isOpen()) {
             $manager->clear();
 
             return;

--- a/Tests/LazyGhostObjectEntityManagerInterface.php
+++ b/Tests/LazyGhostObjectEntityManagerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\VarExporter\LazyGhostObjectInterface;
+
+interface LazyGhostObjectEntityManagerInterface extends LazyGhostObjectInterface, EntityManagerInterface
+{
+}

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -176,19 +176,16 @@ class RegistryTest extends TestCase
             self::markTestSkipped('This test requires ORM and VarExporter 6.2+');
         }
 
+        /** @psalm-suppress MissingDependency https://github.com/vimeo/psalm/issues/8258 */
         $ghostManager = $this->createMock(LazyGhostObjectEntityManagerInterface::class);
-        $ghostManager->expects($this->once())
-             ->method('resetLazyGhostObject')
-             ->willReturn(true);
+        /** @psalm-suppress MissingDependency https://github.com/vimeo/psalm/issues/8258 */
+        $ghostManager->expects($this->once())->method('resetLazyGhostObject')->willReturn(true);
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
-        $container->expects($this->any())
-            ->method('initialized')
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('initialized')
             ->withConsecutive(['doctrine.orm.uninitialized_entity_manager'], ['doctrine.orm.ghost_entity_manager'])
             ->willReturnOnConsecutiveCalls(false, true, true);
-
-        $container->expects($this->any())
-            ->method('get')
+        $container->method('get')
             ->withConsecutive(['doctrine.orm.ghost_entity_manager'], ['doctrine.orm.ghost_entity_manager'], ['doctrine.orm.ghost_entity_manager'])
             ->willReturnOnConsecutiveCalls($ghostManager, $ghostManager, $ghostManager);
 
@@ -197,8 +194,7 @@ class RegistryTest extends TestCase
             'ghost' => 'doctrine.orm.ghost_entity_manager',
         ];
 
-        $registry = new Registry($container, [], $entityManagers, 'default', 'default');
-        $registry->reset();
+        (new Registry($container, [], $entityManagers, 'default', 'default'))->reset();
     }
 
     public function testIdentityMapsStayConsistentAfterReset(): void

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -43,6 +43,7 @@
             <errorLevel type="suppress">
                 <!-- We use the "Foo" namespace in unit tests. We are aware that those classes don't exist. -->
                 <referencedClass name="Foo\*"/>
+                <referencedClass name="Symfony\Component\VarExporter\LazyGhostObjectInterface"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedDocblockClass>


### PR DESCRIPTION
Sidekick of https://github.com/symfony/symfony/pull/46752