### PR TITLE
Enable attaching an entity listener without specifying an event

### DIFF
--- a/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/DependencyInjection/Compiler/EntityListenerPass.php
@@ -53,7 +53,7 @@ class EntityListenerPass implements CompilerPassInterface
                 $resolver = $container->findDefinition($resolverId);
                 $resolver->setPublic(true);
 
-                if (isset($attributes['entity']) && isset($attributes['event'])) {
+                if (isset($attributes['entity'])) {
                     $this->attachToListener($container, $name, $this->getConcreteDefinitionClass($container->findDefinition($id), $container, $id), $attributes);
                 }
 
@@ -94,7 +94,7 @@ class EntityListenerPass implements CompilerPassInterface
         }
     }
 
-    /** @param array{entity: class-string, event: string} $attributes */
+    /** @param array{entity: class-string, event?: ?string} $attributes */
     private function attachToListener(ContainerBuilder $container, string $name, string $class, array $attributes): void
     {
         $listenerId = sprintf('doctrine.orm.%s_listeners.attach_entity_listeners', $name);
@@ -106,12 +106,12 @@ class EntityListenerPass implements CompilerPassInterface
         $args = [
             $attributes['entity'],
             $class,
-            $attributes['event'],
+            $attributes['event'] ?? null,
         ];
 
         if (isset($attributes['method'])) {
             $args[] = $attributes['method'];
-        } elseif (! method_exists($class, $attributes['event']) && method_exists($class, '__invoke')) {
+        } elseif (isset($attributes['event']) && ! method_exists($class, $attributes['event']) && method_exists($class, '__invoke')) {
             $args[] = '__invoke';
         }
 

--- a/Tests/DependencyInjection/Compiler/EntityListenerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/EntityListenerPassTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
+use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Tools\AttachEntityListenersListener;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+use function interface_exists;
+
+class EntityListenerPassTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
+    /** @dataProvider provideEvents */
+    public function testEntityListenersAreRegistered(?string $event, ?string $method, ?string $expectedMethod): void
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new EntityListenerPass());
+
+        $container->setParameter('doctrine.default_entity_manager', 'default');
+        $container->register('doctrine.orm.default_entity_manager', EntityManager::class);
+        $container->register('doctrine.orm.default_entity_listener_resolver', ContainerEntityListenerResolver::class);
+        $container->register('doctrine.orm.default_listeners.attach_entity_listeners', AttachEntityListenersListener::class)
+            ->setPublic(true);
+
+        $tagAttributes = [
+            'entity' => stdClass::class,
+            'event' => $event,
+            'method' => $method,
+        ];
+        $container->register(TestListener::class)->addTag('doctrine.orm.entity_listener', $tagAttributes);
+
+        $container->compile();
+
+        $definition = $container->getDefinition('doctrine.orm.default_listeners.attach_entity_listeners');
+
+        $methodCalls = $definition->getMethodCalls();
+        self::assertSame('addEntityListener', $methodCalls[0][0]);
+        self::assertSame(stdClass::class, $methodCalls[0][1][0]);
+        self::assertSame(TestListener::class, $methodCalls[0][1][1]);
+        self::assertSame($event, $methodCalls[0][1][2]);
+        self::assertSame($expectedMethod, $methodCalls[0][1][3] ?? null);
+    }
+
+    /** @return iterable<array{0: ?string, 1: ?string, 2: ?string}> */
+    public function provideEvents(): iterable
+    {
+        yield 'With event and matching method' => [Events::prePersist, null, null];
+        yield 'Without event' => [null, null, null];
+        yield 'With event and custom method' => [Events::postLoad, 'postLoadHandler', 'postLoadHandler'];
+        yield 'With event and no matching method' => [Events::postLoad, null, '__invoke'];
+    }
+}
+
+class TestListener
+{
+    public function prePersist(): void
+    {
+    }
+
+    public function postPersist(): void
+    {
+    }
+
+    public function postLoadHandler(): void
+    {
+    }
+
+    public function __invoke(): void
+    {
+    }
+}


### PR DESCRIPTION
Requires https://github.com/doctrine/orm/pull/10122

Currently, when registering an entity listener the event name needs to be specified, eg:

```php
use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
use Doctrine\ORM\Events;

#[AsEntityListener(event: Events::prePersist, entity: MyEntity::class)]
final class MyEntityListener
{}
```

If the event is not specified, it's not registered. This is because of the following check:
https://github.com/doctrine/DoctrineBundle/blob/23c23c79a0a0ddeb695854ee57a79198a8bca56a/DependencyInjection/Compiler/EntityListenerPass.php#L56-L58

However, when the `EntityListeners` attribute is used the events get read from the listener class by matching the method names to the names of possible events, eg:

```php
use Doctrine\ORM\Mapping as ORM;

#[ORM\Entity]
#[ORM\EntityListeners([MyEntityListener::class])]
class MyEntity
{}
```

The following code is triggers this behavior:

https://github.com/doctrine/orm/blob/06c77cebb5aa7ee3cb57f8cc0d2224538de154d7/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php#L527-L529

The problem with this approach is that it's not very intuitive since the configuration is split across multiple files making it hard to use.

With this PR, the events will attempt to be auto-mapped in the `AttachEntityListenersListener` if `null` is passed as the event name (see https://github.com/doctrine/orm/pull/10122), eg:

```php
use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;

#[AsEntityListener(entity: MyEntity::class)]
final class MyEntityListener
{}
```