### PR TITLE
Add AsEventListener attribute

### DIFF
--- a/Attribute/AsEventListener.php
+++ b/Attribute/AsEventListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Attribute;
+
+use Attribute;
+
+/**
+ * Service tag to autoconfigure event listeners.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class AsEventListener
+{
+    public function __construct(
+        public string $event,
+        public ?int $priority = null,
+        public ?string $connection = null,
+    ) {
+    }
+}

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEventListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsMiddleware;
 use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand;
@@ -650,6 +651,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
                     'lazy'           => $attribute->lazy,
                     'entity_manager' => $attribute->entityManager,
                     'entity'         => $attribute->entity,
+                ]);
+            });
+            $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute) {
+                $definition->addTag('doctrine.event_listener', [
+                    'event'      => $attribute->event,
+                    'priority'   => $attribute->priority,
+                    'connection' => $attribute->connection,
                 ]);
             });
         }

--- a/Tests/DependencyInjection/Fixtures/Php8EventListener.php
+++ b/Tests/DependencyInjection/Fixtures/Php8EventListener.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEventListener;
+use Doctrine\ORM\Events;
+
+#[AsEventListener(Events::postFlush)]
+final class Php8EventListener
+{
+    public function postFlush(): void
+    {
+    }
+}


### PR DESCRIPTION
Similar to #1345 allows replacing configs such as:

```yaml
App\EventListener\MyListener:
    tags:
        - { name: 'doctrine.event_listener', event: 'preFlush' }
        - { name: 'doctrine.event_listener', event: 'postFlush' }
```
with attributes:
```php
use Doctrine\Bundle\DoctrineBundle\Attribute\AsEventListener;
use Doctrine\ORM\Events;

#[AsEventListener(Events::preFlush)]
#[AsEventListener(Events::postFlush)]
class MyListener
{
// ...
}
```