### PR TITLE
fix issue `The ignoreFile "./tests/baseline-ignore" does not exist`

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     </testsuites>
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./tests/baseline-ignore"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./Tests/baseline-ignore"/>
     </php>
 
     <filter>


### PR DESCRIPTION
```
Doctrine\Bundle\DoctrineBundle\Tests\Twig\DoctrineExtensionTest::testItHighlightsSqlQueriesUsingCssClasses
InvalidArgumentException: The ignoreFile "./tests/baseline-ignore" does not exist.

/var/www/DoctrineBundle/vendor/symfony/deprecation-contracts/function.php:25
/var/www/DoctrineBundle/Twig/DoctrineExtension.php:153
/var/www/DoctrineBundle/Tests/Twig/DoctrineExtensionTest.php:112
/var/www/DoctrineBundle/vendor/phpunit/phpunit/src/Framework/TestResult.php:728
/var/www/DoctrineBundle/vendor/phpunit/phpunit/src/Framework/TestSuite.php:673
/var/www/DoctrineBundle/vendor/phpunit/phpunit/src/Framework/TestSuite.php:673
/var/www/DoctrineBundle/vendor/phpunit/phpunit/src/Framework/TestSuite.php:673
/var/www/DoctrineBundle/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:661