### PR TITLE
Lowering the EntityValueResolver to be lower than the #[CurrentUser]

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -175,7 +175,7 @@
         <service id="doctrine.orm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">
             <argument type="service" id="doctrine" />
             <argument type="service" id="doctrine.orm.entity_value_resolver.expression_language" on-invalid="ignore" />
-            <tag name="controller.argument_value_resolver" priority="110" />
+            <tag name="controller.argument_value_resolver" priority="30" />
         </service>
 
         <service id="doctrine.orm.entity_value_resolver.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />


### PR DESCRIPTION
Hi!

Currently, this, unfortunately, doesn't work:

```php
#[Route('/products/edit/{id}', name: 'product_edit')]
public function foo(Product $product, #[CurrentUser] User $user)
```

The `EntityValueResolver` runs before the `#[CurrentUser]` system and so it will try to query for `User`. This changes the priority to be lower than that system so that `#[CurrentUser]` runs first.

The trade-off is that this situation won't work: https://github.com/doctrine/DoctrineBundle/pull/1554#discussion_r949478887

However, because this is a new feature, we can choose which use-cases we want to support and not support. Querying from a `Foo` entity whose property is called `foo` looks weird to me.

ALSO, Symfony could implement some sort of two-pass system to allow for "conflicting" entity resolvers to be handled more intelligently. So, for right now, the decision, I think, is to decide which use-case is more important to support today.

Cheers!