### PR TITLE
Add types to private properties

### DIFF
--- a/CacheWarmer/DoctrineMetadataCacheWarmer.php
+++ b/CacheWarmer/DoctrineMetadataCacheWarmer.php
@@ -12,11 +12,8 @@ use function is_file;
 
 class DoctrineMetadataCacheWarmer extends AbstractPhpFileCacheWarmer
 {
-    /** @var EntityManagerInterface */
-    private $entityManager;
-
-    /** @var string */
-    private $phpArrayFile;
+    private EntityManagerInterface $entityManager;
+    private string $phpArrayFile;
 
     public function __construct(EntityManagerInterface $entityManager, string $phpArrayFile)
     {

--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -16,8 +16,7 @@ use Symfony\Component\Console\Command\Command;
  */
 abstract class DoctrineCommand extends Command
 {
-    /** @var ManagerRegistry */
-    private $doctrine;
+    private ManagerRegistry $doctrine;
 
     public function __construct(ManagerRegistry $doctrine)
     {

--- a/Command/ImportMappingDoctrineCommand.php
+++ b/Command/ImportMappingDoctrineCommand.php
@@ -31,7 +31,7 @@ use function str_replace;
 class ImportMappingDoctrineCommand extends DoctrineCommand
 {
     /** @var string[] */
-    private $bundles;
+    private array $bundles;
 
     /** @param string[] $bundles */
     public function __construct(ManagerRegistry $doctrine, array $bundles)

--- a/Command/Proxy/OrmProxyCommand.php
+++ b/Command/Proxy/OrmProxyCommand.php
@@ -9,8 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /** @internal */
 trait OrmProxyCommand
 {
-    /** @var EntityManagerProvider|null */
-    private $entityManagerProvider;
+    private ?EntityManagerProvider $entityManagerProvider;
 
     public function __construct(?EntityManagerProvider $entityManagerProvider = null)
     {

--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -23,10 +23,9 @@ use const PHP_EOL;
 class ConnectionFactory
 {
     /** @var mixed[][] */
-    private $typesConfig = [];
+    private array $typesConfig = [];
 
-    /** @var bool */
-    private $initialized = false;
+    private bool $initialized = false;
 
     /** @param mixed[][] $typesConfig */
     public function __construct(array $typesConfig)

--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -20,12 +20,9 @@ use function assert;
 /** @internal */
 class ProfilerController
 {
-    /** @var Environment */
-    private $twig;
-    /** @var Registry */
-    private $registry;
-    /** @var Profiler */
-    private $profiler;
+    private Environment $twig;
+    private Registry $registry;
+    private Profiler $profiler;
 
     public function __construct(Environment $twig, Registry $registry, Profiler $profiler)
     {

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -50,20 +50,16 @@ use function usort;
  */
 class DoctrineDataCollector extends BaseCollector
 {
-    /** @var ManagerRegistry */
-    private $registry;
-
-    /** @var int|null */
-    private $invalidEntityCount;
+    private ManagerRegistry $registry;
+    private ?int $invalidEntityCount = null;
 
     /**
-     * @var mixed[][]
+     * @var mixed[][]|null
      * @psalm-var ?array<string, list<QueryType&array{count: int, index: int, executionPercent: float}>>
      */
-    private $groupedQueries;
+    private ?array $groupedQueries = null;
 
-    /** @var bool */
-    private $shouldValidateSchema;
+    private bool $shouldValidateSchema;
 
     /** @psalm-suppress UndefinedClass */
     public function __construct(ManagerRegistry $registry, bool $shouldValidateSchema = true, ?DebugDataHolder $debugDataHolder = null)
@@ -242,11 +238,7 @@ class DoctrineDataCollector extends BaseCollector
     /** @return int */
     public function getInvalidEntityCount()
     {
-        if ($this->invalidEntityCount === null) {
-            $this->invalidEntityCount = array_sum(array_map('count', $this->data['errors']));
-        }
-
-        return $this->invalidEntityCount;
+        return $this->invalidEntityCount ??= array_sum(array_map('count', $this->data['errors']));
     }
 
     /**

--- a/Dbal/BlacklistSchemaAssetFilter.php
+++ b/Dbal/BlacklistSchemaAssetFilter.php
@@ -10,7 +10,7 @@ use function in_array;
 class BlacklistSchemaAssetFilter
 {
     /** @var string[] */
-    private $blacklist;
+    private array $blacklist;
 
     /** @param string[] $blacklist */
     public function __construct(array $blacklist)

--- a/Dbal/ManagerRegistryAwareConnectionProvider.php
+++ b/Dbal/ManagerRegistryAwareConnectionProvider.php
@@ -8,8 +8,7 @@ use Doctrine\Persistence\AbstractManagerRegistry;
 
 class ManagerRegistryAwareConnectionProvider implements ConnectionProvider
 {
-    /** @var AbstractManagerRegistry */
-    private $managerRegistry;
+    private AbstractManagerRegistry $managerRegistry;
 
     public function __construct(AbstractManagerRegistry $managerRegistry)
     {

--- a/Dbal/RegexSchemaAssetFilter.php
+++ b/Dbal/RegexSchemaAssetFilter.php
@@ -8,8 +8,7 @@ use function preg_match;
 
 class RegexSchemaAssetFilter
 {
-    /** @var string */
-    private $filterExpression;
+    private string $filterExpression;
 
     public function __construct(string $filterExpression)
     {

--- a/Dbal/SchemaAssetsFilterManager.php
+++ b/Dbal/SchemaAssetsFilterManager.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Schema\AbstractAsset;
 class SchemaAssetsFilterManager
 {
     /** @var callable[] */
-    private $schemaAssetFilters;
+    private array $schemaAssetFilters;
 
     /** @param callable[] $schemaAssetFilters */
     public function __construct(array $schemaAssetFilters)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,8 +47,7 @@ use function trigger_deprecation;
  */
 class Configuration implements ConfigurationInterface
 {
-    /** @var bool */
-    private $debug;
+    private bool $debug;
 
     /** @param bool $debug Whether to use the debug mode */
     public function __construct(bool $debug)

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -73,8 +73,7 @@ use const PHP_VERSION_ID;
  */
 class DoctrineExtension extends AbstractDoctrineExtension
 {
-    /** @var string */
-    private $defaultConnection;
+    private string $defaultConnection;
 
     /**
      * {@inheritDoc}

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
+use Closure;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheCompatibilityPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubscriberPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
@@ -32,8 +33,7 @@ use function spl_autoload_unregister;
 
 class DoctrineBundle extends Bundle
 {
-    /** @var callable|null */
-    private $autoloader;
+    private ?Closure $autoloader = null;
 
     /**
      * {@inheritDoc}

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -11,10 +11,10 @@ use Doctrine\ORM\Query\Filter\SQLFilter;
 class ManagerConfigurator
 {
     /** @var string[] */
-    private $enabledFilters = [];
+    private array $enabledFilters = [];
 
     /** @var array<string,array<string,string>> */
-    private $filtersParameters = [];
+    private array $filtersParameters = [];
 
     /**
      * @param string[]                           $enabledFilters

--- a/Mapping/ClassMetadataCollection.php
+++ b/Mapping/ClassMetadataCollection.php
@@ -6,14 +6,11 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 
 class ClassMetadataCollection
 {
-    /** @var string */
-    private $path;
-
-    /** @var string */
-    private $namespace;
+    private ?string $path      = null;
+    private ?string $namespace = null;
 
     /** @var ClassMetadata[] */
-    private $metadata;
+    private array $metadata;
 
     /** @param ClassMetadata[] $metadata */
     public function __construct(array $metadata)
@@ -33,7 +30,7 @@ class ClassMetadataCollection
         $this->path = $path;
     }
 
-    /** @return string */
+    /** @return string|null */
     public function getPath()
     {
         return $this->path;
@@ -45,7 +42,7 @@ class ClassMetadataCollection
         $this->namespace = $namespace;
     }
 
-    /** @return string */
+    /** @return string|null */
     public function getNamespace()
     {
         return $this->namespace;

--- a/Mapping/ContainerEntityListenerResolver.php
+++ b/Mapping/ContainerEntityListenerResolver.php
@@ -15,14 +15,13 @@ use function trim;
 /** @final */
 class ContainerEntityListenerResolver implements EntityListenerServiceResolver
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     /** @var object[] Map to store entity listener instances. */
-    private $instances = [];
+    private array $instances = [];
 
     /** @var string[] Map to store registered service ids */
-    private $serviceIds = [];
+    private array $serviceIds = [];
 
     /** @param ContainerInterface $container a service locator for listeners */
     public function __construct(ContainerInterface $container)

--- a/Mapping/DisconnectedMetadataFactory.php
+++ b/Mapping/DisconnectedMetadataFactory.php
@@ -25,10 +25,8 @@ use function strpos;
  */
 class DisconnectedMetadataFactory
 {
-    /** @var ManagerRegistry */
-    private $registry;
+    private ManagerRegistry $registry;
 
-    /** @param ManagerRegistry $registry A ManagerRegistry instance */
     public function __construct(ManagerRegistry $registry)
     {
         $this->registry = $registry;

--- a/Mapping/MappingDriver.php
+++ b/Mapping/MappingDriver.php
@@ -9,11 +9,8 @@ use Psr\Container\ContainerInterface;
 
 class MappingDriver implements MappingDriverInterface
 {
-    /** @var MappingDriverInterface */
-    private $driver;
-
-    /** @var ContainerInterface */
-    private $idGeneratorLocator;
+    private MappingDriverInterface $driver;
+    private ContainerInterface $idGeneratorLocator;
 
     public function __construct(MappingDriverInterface $driver, ContainerInterface $idGeneratorLocator)
     {

--- a/Middleware/BacktraceDebugDataHolder.php
+++ b/Middleware/BacktraceDebugDataHolder.php
@@ -15,10 +15,10 @@ use const DEBUG_BACKTRACE_IGNORE_ARGS;
 class BacktraceDebugDataHolder extends DebugDataHolder
 {
     /** @var string[] */
-    private $connWithBacktraces;
+    private array $connWithBacktraces;
 
     /** @var array<string, array<string, mixed>[]> */
-    private $backtraces = [];
+    private array $backtraces = [];
 
     /** @param string[] $connWithBacktraces */
     public function __construct(array $connWithBacktraces)

--- a/Middleware/DebugMiddleware.php
+++ b/Middleware/DebugMiddleware.php
@@ -10,14 +10,9 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 class DebugMiddleware implements Middleware, ConnectionNameAwareInterface
 {
-    /** @var DebugDataHolder */
-    private $debugDataHolder;
-
-    /** @var Stopwatch|null */
-    private $stopwatch;
-
-    /** @var string */
-    private $connectionName = 'default';
+    private DebugDataHolder $debugDataHolder;
+    private ?Stopwatch $stopwatch;
+    private string $connectionName = 'default';
 
     public function __construct(DebugDataHolder $debugDataHolder, ?Stopwatch $stopwatch)
     {

--- a/Orm/ManagerRegistryAwareEntityManagerProvider.php
+++ b/Orm/ManagerRegistryAwareEntityManagerProvider.php
@@ -12,8 +12,7 @@ use function sprintf;
 
 final class ManagerRegistryAwareEntityManagerProvider implements EntityManagerProvider
 {
-    /** @var ManagerRegistry */
-    private $managerRegistry;
+    private ManagerRegistry $managerRegistry;
 
     public function __construct(ManagerRegistry $managerRegistry)
     {

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -21,10 +21,9 @@ use function sprintf;
 final class ContainerRepositoryFactory implements RepositoryFactory
 {
     /** @var array<string, ObjectRepository> */
-    private $managedRepositories = [];
+    private array $managedRepositories = [];
 
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     /** @param ContainerInterface $container A service locator containing the repositories */
     public function __construct(ContainerInterface $container)

--- a/Tests/Builder/BundleConfigurationBuilder.php
+++ b/Tests/Builder/BundleConfigurationBuilder.php
@@ -5,7 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\Builder;
 class BundleConfigurationBuilder
 {
     /** @var array<string, mixed> */
-    private $configuration;
+    private array $configuration = [];
 
     public static function createBuilder(): self
     {

--- a/Tests/Command/ImportMappingDoctrineCommandTest.php
+++ b/Tests/Command/ImportMappingDoctrineCommandTest.php
@@ -20,11 +20,8 @@ use function sys_get_temp_dir;
 /** @group legacy */
 class ImportMappingDoctrineCommandTest extends TestCase
 {
-    /** @var TestKernel|null */
-    private $kernel;
-
-    /** @var CommandTester|null */
-    private $commandTester;
+    private TestKernel $kernel;
+    private CommandTester $commandTester;
 
     public static function setUpBeforeClass(): void
     {
@@ -61,13 +58,12 @@ class ImportMappingDoctrineCommandTest extends TestCase
     protected function tearDown(): void
     {
         $fs = new Filesystem();
-        if ($this->kernel !== null) {
+        if (isset($this->kernel)) {
             $fs->remove($this->kernel->getCacheDir());
         }
 
         $fs->remove(sys_get_temp_dir() . '/import_mapping_bundle');
-        $this->kernel        = null;
-        $this->commandTester = null;
+        unset($this->kernel, $this->commandTester);
     }
 
     public function testExecuteXmlWithBundle(): void

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1540,8 +1540,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
 class DummySchemaAssetsFilter
 {
-    /** @var string */
-    private $tableToIgnore;
+    private string $tableToIgnore;
 
     public function __construct(string $tableToIgnore)
     {

--- a/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -23,8 +23,7 @@ class CacheCompatibilityPassTest extends TestCase
         $customRegionClass = get_class($this->createMock(Region::class));
 
         (new class ($customRegionClass) extends TestKernel {
-            /** @var string */
-            private $regionClass;
+            private string $regionClass;
 
             public function __construct(string $regionClass)
             {

--- a/Tests/DependencyInjection/Fixtures/CustomEntityListenerServiceResolver.php
+++ b/Tests/DependencyInjection/Fixtures/CustomEntityListenerServiceResolver.php
@@ -6,8 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\Mapping\EntityListenerServiceResolver;
 
 class CustomEntityListenerServiceResolver implements EntityListenerServiceResolver
 {
-    /** @var EntityListenerServiceResolver */
-    private $resolver;
+    private EntityListenerServiceResolver $resolver;
 
     public function __construct(EntityListenerServiceResolver $resolver)
     {

--- a/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
@@ -18,10 +18,9 @@ use function sys_get_temp_dir;
 class DbalTestKernel extends Kernel
 {
     /** @var array<string, mixed> */
-    private $dbalConfig;
+    private array $dbalConfig;
 
-    /** @var string|null */
-    private $projectDir;
+    private ?string $projectDir = null;
 
     /** @param array<string, mixed> $dbalConfig */
     public function __construct(array $dbalConfig = ['driver' => 'pdo_sqlite'])
@@ -59,11 +58,7 @@ class DbalTestKernel extends Kernel
 
     public function getProjectDir(): string
     {
-        if ($this->projectDir === null) {
-            $this->projectDir = sys_get_temp_dir() . '/sf_kernel_' . md5((string) mt_rand());
-        }
-
-        return $this->projectDir;
+        return $this->projectDir ??= sys_get_temp_dir() . '/sf_kernel_' . md5((string) mt_rand());
     }
 
     public function getRootDir(): string

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -16,8 +16,7 @@ use function sys_get_temp_dir;
 
 class TestKernel extends Kernel
 {
-    /** @var string|null */
-    private $projectDir;
+    private ?string $projectDir = null;
 
     public function __construct(bool $debug = true)
     {
@@ -59,11 +58,7 @@ class TestKernel extends Kernel
 
     public function getProjectDir(): string
     {
-        if ($this->projectDir === null) {
-            $this->projectDir = sys_get_temp_dir() . '/sf_kernel_' . md5((string) mt_rand());
-        }
-
-        return $this->projectDir;
+        return $this->projectDir ??= sys_get_temp_dir() . '/sf_kernel_' . md5((string) mt_rand());
     }
 
     public function getRootDir(): string

--- a/Tests/Mapping/ContainerEntityListenerResolverTest.php
+++ b/Tests/Mapping/ContainerEntityListenerResolverTest.php
@@ -14,11 +14,10 @@ use function interface_exists;
 
 class ContainerEntityListenerResolverTest extends TestCase
 {
-    /** @var ContainerEntityListenerResolver */
-    private $resolver;
+    private ContainerEntityListenerResolver $resolver;
 
     /** @var ContainerInterface&MockObject */
-    private $container;
+    private ContainerInterface $container;
 
     public static function setUpBeforeClass(): void
     {

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -30,14 +30,9 @@ use function str_replace;
 
 class ProfilerTest extends BaseTestCase
 {
-    /** @var DebugStack */
-    private $logger;
-
-    /** @var Environment */
-    private $twig;
-
-    /** @var DoctrineDataCollector */
-    private $collector;
+    private DebugStack $logger;
+    private Environment $twig;
+    private DoctrineDataCollector $collector;
 
     public function setUp(): void
     {

--- a/Twig/DoctrineExtension.php
+++ b/Twig/DoctrineExtension.php
@@ -30,8 +30,7 @@ use function trigger_deprecation;
  */
 class DoctrineExtension extends AbstractExtension
 {
-    /** @var SqlFormatter */
-    private $sqlFormatter;
+    private SqlFormatter $sqlFormatter;
 
     /**
      * Define our functions

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,6 +39,12 @@
                 <file name="Tests/ConnectionFactoryTest.php"/>
             </errorLevel>
         </InvalidArrayOffset>
+        <RedundantPropertyInitializationCheck>
+            <errorLevel type="suppress">
+                <!-- Properties can be uninitialized in tests if setUp() fails. -->
+                <directory name="Tests"/>
+            </errorLevel>
+        </RedundantPropertyInitializationCheck>
         <UndefinedClass>
             <errorLevel type="suppress">
                 <!-- We use the "Foo" namespace in unit tests. We are aware that those classes don't exist. -->


### PR DESCRIPTION
Now that we've bumped to PHP 7.4, we can use property types. In this PR, I've added them to all private properties which should be safe.