### PR TITLE
Raise PHPCS language level to PHP 7.4

### DIFF
--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -135,8 +135,7 @@ class ConnectionFactoryTest extends TestCase
 
 class FakeConnection extends Connection
 {
-    /** @var int */
-    public static $creationCount = 0;
+    public static int $creationCount = 0;
 
     /**
      * {@inheritdoc}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -20,6 +20,7 @@ class ConfigurationTest extends TestCase
      * testGetConfigTreeBuilderDoNotUseDoctrineCommon that is run in separate process.
      *
      * @var bool
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      */
     protected $preserveGlobalState = false;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/TestCustomIdGeneratorEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity/TestCustomIdGeneratorEntity.php
@@ -12,8 +12,6 @@ class TestCustomIdGeneratorEntity
      * @ORM\GeneratedValue(strategy="CUSTOM")
      * @ORM\CustomIdGenerator("my_id_generator")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    public $id;
+    public ?int $id = null;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomClassRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomClassRepoEntity.php
@@ -11,8 +11,6 @@ class TestCustomClassRepoEntity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    private $id;
+    private ?int $id = null;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomServiceRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomServiceRepoEntity.php
@@ -11,8 +11,6 @@ class TestCustomServiceRepoEntity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    private $id;
+    private ?int $id = null;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
@@ -11,8 +11,6 @@ class TestDefaultRepoEntity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    private $id;
+    private ?int $id = null;
 }

--- a/Tests/Twig/DoctrineExtensionTest.php
+++ b/Tests/Twig/DoctrineExtensionTest.php
@@ -157,8 +157,7 @@ class DoctrineExtensionTest extends TestCase
 
 class DummyClass
 {
-    /** @var string */
-    protected $str;
+    protected string $str;
 
     public function __construct(string $str)
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,7 @@
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
 
-    <config name="php_version" value="70100"/>
+    <config name="php_version" value="70400"/>
 
     <file>.</file>
     <exclude-pattern>vendor/*</exclude-pattern>


### PR DESCRIPTION
PHPCS currently analyzes our code for PHP 7.1. I've change that to PHP 7.4 and fixed the remaining errors (tests only).