### PR TITLE
Revert "Lowering the EntityValueResolver to be lower than the #[CurrentUser] feature"

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -175,7 +175,7 @@
         <service id="doctrine.orm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">
             <argument type="service" id="doctrine" />
             <argument type="service" id="doctrine.orm.entity_value_resolver.expression_language" on-invalid="ignore" />
-            <tag name="controller.argument_value_resolver" priority="30" />
+            <tag name="controller.argument_value_resolver" priority="110" />
         </service>
 
         <service id="doctrine.orm.entity_value_resolver.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />


### PR DESCRIPTION
As discussed in #1574.

We should merge https://github.com/symfony/symfony/pull/48032 instead.