### PR TITLE
deprecate all ORM proxy commands

### DIFF
--- a/Command/Proxy/ClearMetadataCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearMetadataCacheDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to clear the metadata cache of the various cache drivers.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand instead
  */
 class ClearMetadataCacheDoctrineCommand extends MetadataCommand
 {

--- a/Command/Proxy/ClearQueryCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearQueryCacheDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to clear the query cache of the various cache drivers.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand instead
  */
 class ClearQueryCacheDoctrineCommand extends QueryCommand
 {

--- a/Command/Proxy/ClearResultCacheDoctrineCommand.php
+++ b/Command/Proxy/ClearResultCacheDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to clear the result cache of the various cache drivers.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand instead
  */
 class ClearResultCacheDoctrineCommand extends ResultCommand
 {

--- a/Command/Proxy/CollectionRegionDoctrineCommand.php
+++ b/Command/Proxy/CollectionRegionDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to clear a collection cache region.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ClearCache\CollectionRegionCommand instead
  */
 class CollectionRegionDoctrineCommand extends CollectionRegionCommand
 {

--- a/Command/Proxy/ConvertMappingDoctrineCommand.php
+++ b/Command/Proxy/ConvertMappingDoctrineCommand.php
@@ -13,6 +13,8 @@ use function assert;
 /**
  * Convert Doctrine ORM metadata mapping information between the various supported
  * formats.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand instead
  */
 class ConvertMappingDoctrineCommand extends ConvertMappingCommand
 {

--- a/Command/Proxy/CreateSchemaDoctrineCommand.php
+++ b/Command/Proxy/CreateSchemaDoctrineCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Input\InputOption;
 /**
  * Command to execute the SQL needed to generate the database schema for
  * a given entity manager.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand instead
  */
 class CreateSchemaDoctrineCommand extends CreateCommand
 {

--- a/Command/Proxy/DropSchemaDoctrineCommand.php
+++ b/Command/Proxy/DropSchemaDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to drop the database schema for a set of classes based on their mappings.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand instead
  */
 class DropSchemaDoctrineCommand extends DropCommand
 {

--- a/Command/Proxy/EnsureProductionSettingsDoctrineCommand.php
+++ b/Command/Proxy/EnsureProductionSettingsDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Ensure the Doctrine ORM is configured properly for a production environment.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand instead
  */
 class EnsureProductionSettingsDoctrineCommand extends EnsureProductionSettingsCommand
 {

--- a/Command/Proxy/EntityRegionCacheDoctrineCommand.php
+++ b/Command/Proxy/EntityRegionCacheDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to clear a entity cache region.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ClearCache\EntityRegionCommand instead
  */
 class EntityRegionCacheDoctrineCommand extends EntityRegionCommand
 {

--- a/Command/Proxy/InfoDoctrineCommand.php
+++ b/Command/Proxy/InfoDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Show information about mapped entities
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\InfoCommand instead
  */
 class InfoDoctrineCommand extends InfoCommand
 {

--- a/Command/Proxy/OrmProxyCommand.php
+++ b/Command/Proxy/OrmProxyCommand.php
@@ -6,7 +6,12 @@ use Doctrine\ORM\Tools\Console\EntityManagerProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/** @internal */
+use function trigger_deprecation;
+
+/**
+ * @internal
+ * @deprecated
+ */
 trait OrmProxyCommand
 {
     private ?EntityManagerProvider $entityManagerProvider;
@@ -15,6 +20,14 @@ trait OrmProxyCommand
     {
         parent::__construct($entityManagerProvider);
         $this->entityManagerProvider = $entityManagerProvider;
+
+        trigger_deprecation(
+            'doctrine/doctrine-bundle',
+            '2.8',
+            'Class "%s" is deprecated. Use "%s" instead.',
+            self::class,
+            parent::class
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/Command/Proxy/QueryRegionCacheDoctrineCommand.php
+++ b/Command/Proxy/QueryRegionCacheDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to clear a query cache region.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryRegionCommand instead
  */
 class QueryRegionCacheDoctrineCommand extends QueryRegionCommand
 {

--- a/Command/Proxy/RunDqlDoctrineCommand.php
+++ b/Command/Proxy/RunDqlDoctrineCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Execute a Doctrine DQL query and output the results.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\RunDqlCommand instead
  */
 class RunDqlDoctrineCommand extends RunDqlCommand
 {

--- a/Command/Proxy/UpdateSchemaDoctrineCommand.php
+++ b/Command/Proxy/UpdateSchemaDoctrineCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Input\InputOption;
 /**
  * Command to generate the SQL needed to update the database schema to match
  * the current mapping information.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand instead
  */
 class UpdateSchemaDoctrineCommand extends UpdateCommand
 {

--- a/Command/Proxy/ValidateSchemaCommand.php
+++ b/Command/Proxy/ValidateSchemaCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Command to run Doctrine ValidateSchema() on the current mappings.
+ *
+ * @deprecated use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand instead
  */
 class ValidateSchemaCommand extends DoctrineValidateSchemaCommand
 {

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -181,72 +181,72 @@
         <service id="doctrine.orm.entity_value_resolver.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
 
         <!-- commands -->
-        <service id="doctrine.cache_clear_metadata_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearMetadataCacheDoctrineCommand">
+        <service id="doctrine.cache_clear_metadata_command" class="Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:cache:clear-metadata" />
         </service>
 
-        <service id="doctrine.cache_clear_query_cache_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearQueryCacheDoctrineCommand">
+        <service id="doctrine.cache_clear_query_cache_command" class="Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:cache:clear-query" />
         </service>
 
-        <service id="doctrine.cache_clear_result_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ClearResultCacheDoctrineCommand">
+        <service id="doctrine.cache_clear_result_command" class="Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:cache:clear-result" />
         </service>
 
-        <service id="doctrine.cache_collection_region_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CollectionRegionDoctrineCommand">
+        <service id="doctrine.cache_collection_region_command" class="Doctrine\ORM\Tools\Console\Command\ClearCache\CollectionRegionCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:cache:clear-collection-region" />
         </service>
 
-        <service id="doctrine.mapping_convert_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ConvertMappingDoctrineCommand">
+        <service id="doctrine.mapping_convert_command" class="Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:mapping:convert" />
         </service>
 
-        <service id="doctrine.schema_create_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\CreateSchemaDoctrineCommand">
+        <service id="doctrine.schema_create_command" class="Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:schema:create" />
         </service>
 
-        <service id="doctrine.schema_drop_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\DropSchemaDoctrineCommand">
+        <service id="doctrine.schema_drop_command" class="Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:schema:drop" />
         </service>
 
-        <service id="doctrine.ensure_production_settings_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EnsureProductionSettingsDoctrineCommand">
+        <service id="doctrine.ensure_production_settings_command" class="Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:ensure-production-settings" />
         </service>
 
-        <service id="doctrine.clear_entity_region_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\EntityRegionCacheDoctrineCommand">
+        <service id="doctrine.clear_entity_region_command" class="Doctrine\ORM\Tools\Console\Command\ClearCache\EntityRegionCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:cache:clear-entity-region" />
         </service>
 
-        <service id="doctrine.mapping_info_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand">
+        <service id="doctrine.mapping_info_command" class="Doctrine\ORM\Tools\Console\Command\InfoCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:mapping:info" />
         </service>
 
-        <service id="doctrine.clear_query_region_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\QueryRegionCacheDoctrineCommand">
+        <service id="doctrine.clear_query_region_command" class="Doctrine\ORM\Tools\Console\Command\ClearCache\QueryRegionCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:cache:clear-query-region" />
         </service>
 
-        <service id="doctrine.query_dql_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunDqlDoctrineCommand">
+        <service id="doctrine.query_dql_command" class="Doctrine\ORM\Tools\Console\Command\RunDqlCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:query:dql" />
         </service>
 
-        <service id="doctrine.schema_update_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand">
+        <service id="doctrine.schema_update_command" class="Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:schema:update" />
         </service>
 
-        <service id="doctrine.schema_validate_command" class="Doctrine\Bundle\DoctrineBundle\Command\Proxy\ValidateSchemaCommand">
+        <service id="doctrine.schema_validate_command" class="Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:schema:validate" />
         </service>

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\InfoDoctrineCommand;
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Orm\ManagerRegistryAwareEntityManagerProvider;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventManager;
@@ -13,6 +11,8 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Console\Command\InfoCommand;
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer;
@@ -61,8 +61,8 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ProxyCacheWarmer::class, $container->get('doctrine.orm.proxy_cache_warmer'));
         $this->assertInstanceOf(ManagerRegistry::class, $container->get('doctrine'));
         $this->assertInstanceOf(UniqueEntityValidator::class, $container->get('doctrine.orm.validator.unique'));
-        $this->assertInstanceOf(InfoDoctrineCommand::class, $container->get('doctrine.mapping_info_command'));
-        $this->assertInstanceOf(UpdateSchemaDoctrineCommand::class, $container->get('doctrine.schema_update_command'));
+        $this->assertInstanceOf(InfoCommand::class, $container->get('doctrine.mapping_info_command'));
+        $this->assertInstanceOf(UpdateCommand::class, $container->get('doctrine.schema_update_command'));
 
         $this->assertSame($container->get('my.platform'), $container->get('doctrine.dbal.default_connection')->getDatabasePlatform());
 

--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -8,10 +8,11 @@ Dependencies
 
 Commands
 --------
- * Support for using Shards has been removed from `\Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand` as it's not supported using DBAL 3.
- * Support for using Shards has been removed from `\Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand` as it's not supported using DBAL 3.
- * Support for using Shards has been removed from `\Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand` as it's not supported using DBAL 3.
- * The `\Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand` command has been removed as it's not supported using DBAL 3.
+ * Support for using Shards has been removed from `Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand` as it's not supported using DBAL 3.
+ * Support for using Shards has been removed from `Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand` as it's not supported using DBAL 3.
+ * Support for using Shards has been removed from `Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand` as it's not supported using DBAL 3.
+ * The `Doctrine\Bundle\DoctrineBundle\Command\Proxy\ImportDoctrineCommand` command has been removed as it's not supported using DBAL 3.
+ * All ORM proxy commands in the namespace `Doctrine\Bundle\DoctrineBundle\Command\Proxy\` have been deprecated. Use their corresponding ORM command class directly instead.
 
 Configuration
 --------

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -14,6 +14,7 @@
             <directory name="vendor"/>
             <!-- Deprecated classes, not worth fixing -->
             <file name="Command/ImportMappingDoctrineCommand.php"/>
+            <file name="Command/Proxy/OrmProxyCommand.php"/>
             <file name="DependencyInjection/Compiler/WellKnownSchemaFilterPass.php"/>
         </ignoreFiles>
         <directory name="CacheWarmer"/>


### PR DESCRIPTION
Closes https://github.com/doctrine/DoctrineBundle/issues/1524

List of all doctrine commands from this bundle as tested on one of my apps using this branch:

```
      doctrine:database:create                  Creates the configured database                                                                                    
      doctrine:database:drop                    Drops the configured database                                                                                      
      doctrine:query:sql                        Executes arbitrary SQL directly from the command line.                                                             
      doctrine:cache:clear-metadata             Clear all metadata cache of the various cache drivers                                                              
      doctrine:cache:clear-query                Clear all query cache of the various cache drivers                                                                 
      doctrine:cache:clear-result               Clear all result cache of the various cache drivers                                                                
      doctrine:cache:clear-collection-region    Clear a second-level cache collection region                                                                       
      doctrine:mapping:convert                  Convert mapping information between supported formats                                                              
      doctrine:schema:create                    Processes the schema and either create it directly on EntityManager Storage Connection or generate the SQL output  
      doctrine:schema:drop                      Drop the complete database schema of EntityManager Storage Connection or generate the corresponding SQL output     
      doctrine:ensure-production-settings       Verify that Doctrine is properly configured for a production environment                                           
      doctrine:cache:clear-entity-region        Clear a second-level cache entity region                                                                           
      doctrine:mapping:info                     Show basic information about all mapped entities                                                                   
      doctrine:cache:clear-query-region         Clear a second-level cache query region                                                                            
      doctrine:query:dql                        Executes arbitrary DQL directly from the command line                                                              
      doctrine:schema:update                    Executes (or dumps) the SQL needed to update the database schema to match the current mapping metadata             
      doctrine:schema:validate                  Validate the mapping files                                                                                         
      doctrine:mapping:import                   Imports mapping information from an existing database     
``` 