### PR TITLE
Clear second level cache stats after data collected

### DIFF
--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -180,6 +180,8 @@ class DoctrineDataCollector extends BaseCollector
 
                 $caches['regions']['misses'][$key] += $value;
             }
+
+            $cacheLoggerStats->clearStats();
         }
 
         $this->data['entities'] = $entities;


### PR DESCRIPTION
I am writing a Symfony application which integrated with Swoole.
I found that when request finished, the profiler page will not clear the counter in profiler page.
After some research, I think the problem is that DoctrineBundle froget to reset the stat data after profiler data collected.
This PR also fix a small OOM problem in long-run runtime.