### PR TITLE
Rename AsEventListener to AsDoctrineListener

### DIFF
--- a/Attribute/AsDoctrineListener.php
+++ b/Attribute/AsDoctrineListener.php
@@ -8,7 +8,7 @@ use Attribute;
  * Service tag to autoconfigure event listeners.
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-class AsEventListener
+class AsDoctrineListener
 {
     public function __construct(
         public string $event,

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
-use Doctrine\Bundle\DoctrineBundle\Attribute\AsEventListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsMiddleware;
 use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
 use Doctrine\Bundle\DoctrineBundle\Dbal\ManagerRegistryAwareConnectionProvider;
@@ -505,7 +505,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'entity'         => $attribute->entity,
             ]);
         });
-        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute) {
+        $container->registerAttributeForAutoconfiguration(AsDoctrineListener::class, static function (ChildDefinition $definition, AsDoctrineListener $attribute) {
             $definition->addTag('doctrine.event_listener', [
                 'event'      => $attribute->event,
                 'priority'   => $attribute->priority,

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -3,8 +3,8 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Closure;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
-use Doctrine\Bundle\DoctrineBundle\Attribute\AsEventListener;
 use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheCompatibilityPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
@@ -1113,7 +1113,7 @@ class DoctrineExtensionTest extends TestCase
     }
 
     /** @requires PHP 8 */
-    public function testAsEventListenerAttribute()
+    public function testAsDoctrineListenerAttribute()
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -1126,14 +1126,14 @@ class DoctrineExtensionTest extends TestCase
         $extension->load([$config], $container);
 
         $attributes = $container->getAutoconfiguredAttributes();
-        $this->assertInstanceOf(Closure::class, $attributes[AsEventListener::class]);
+        $this->assertInstanceOf(Closure::class, $attributes[AsDoctrineListener::class]);
 
         $reflector  = new ReflectionClass(Php8EventListener::class);
         $definition = new ChildDefinition('');
         /** @psalm-suppress UndefinedMethod */
-        $attribute = $reflector->getAttributes(AsEventListener::class)[0]->newInstance();
+        $attribute = $reflector->getAttributes(AsDoctrineListener::class)[0]->newInstance();
 
-        $attributes[AsEventListener::class]($definition, $attribute);
+        $attributes[AsDoctrineListener::class]($definition, $attribute);
 
         $expected = [
             'event'      => Events::postFlush,

--- a/Tests/DependencyInjection/Fixtures/Php8EventListener.php
+++ b/Tests/DependencyInjection/Fixtures/Php8EventListener.php
@@ -2,10 +2,10 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
 
-use Doctrine\Bundle\DoctrineBundle\Attribute\AsEventListener;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Events;
 
-#[AsEventListener(Events::postFlush)]
+#[AsDoctrineListener(Events::postFlush)]
 final class Php8EventListener
 {
     public function postFlush(): void


### PR DESCRIPTION
As discussed in https://github.com/doctrine/DoctrineBundle/pull/1583, I think introducing at attribute with the same name as the one used in Symfony is going to create needless confusion.

I therefor propose to rename the attribute to `AsDoctrineListener`.