### PR TITLE
Allow Doctrine Annotations 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/annotations": "^1",
+        "doctrine/annotations": "^1|^2",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/dbal": "^3.4.0",
         "doctrine/persistence": "^2.2 || ^3",


### PR DESCRIPTION
The bundle itself should be compatible with Annotations 2 right away.

However, I wonder if the Annotations package should remain a mandatory dependency. If we use the bundle to configure the DBAL without the ORM, requiring Annotations feels pointless. Moreover, in a PHP 8 project with native attributes, we don't necessarily need Annotations for the ORM either.