### PR TITLE
Allow Annotations 2, add attribute support to testing fixtures and test with attributes when able, allow the Annotations package to be an optional dependency

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -12,6 +12,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
+use Doctrine\Common\Annotations\Annotation;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
@@ -374,6 +375,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (class_exists(AbstractType::class)) {
             $container->getDefinition('form.type.entity')->addTag('kernel.reset', ['method' => 'reset']);
+        }
+
+        if (! class_exists(Annotation::class)) {
+            $container->removeAlias('doctrine.orm.metadata.annotation_reader');
         }
 
         // available in Symfony 5.1 and up to Symfony 5.4 (deprecated)

--- a/Tests/Command/ImportMappingDoctrineCommandTest.php
+++ b/Tests/Command/ImportMappingDoctrineCommandTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use InvalidArgumentException;
@@ -17,6 +18,8 @@ use function file_get_contents;
 use function interface_exists;
 use function sys_get_temp_dir;
 
+use const PHP_VERSION_ID;
+
 /** @group legacy */
 class ImportMappingDoctrineCommandTest extends TestCase
 {
@@ -25,6 +28,10 @@ class ImportMappingDoctrineCommandTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (PHP_VERSION_ID < 80000 && ! class_exists(AnnotationReader::class)) {
+            self::markTestSkipped('This test requires Annotations when run on PHP 7');
+        }
+
         if (interface_exists(EntityManagerInterface::class) && class_exists(ClassMetadataExporter::class)) {
             return;
         }

--- a/Tests/Command/Proxy/InfoDoctrineCommandTest.php
+++ b/Tests/Command/Proxy/InfoDoctrineCommandTest.php
@@ -4,11 +4,31 @@ namespace Command\Proxy;
 
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCase;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function class_exists;
+use function interface_exists;
+
+use const PHP_VERSION_ID;
+
 class InfoDoctrineCommandTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        if (PHP_VERSION_ID < 80000 && ! class_exists(AnnotationReader::class)) {
+            self::markTestSkipped('This test requires Annotations when run on PHP 7');
+        }
+
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
     public function testExecute(): void
     {
         $kernel = new TestKernel();

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -35,11 +35,15 @@ class ContainerTest extends TestCase
 
         $container = $this->createXmlBundleTestContainer();
 
+        /** @psalm-suppress UndefinedClass */
+        if (interface_exists(Reader::class)) {
+            $this->assertInstanceOf(Reader::class, $container->get('doctrine.orm.metadata.annotation_reader'));
+        }
+
         $this->assertInstanceOf(DoctrineDataCollector::class, $container->get('data_collector.doctrine'));
         $this->assertInstanceOf(DBALConfiguration::class, $container->get('doctrine.dbal.default_connection.configuration'));
         $this->assertInstanceOf(EventManager::class, $container->get('doctrine.dbal.default_connection.event_manager'));
         $this->assertInstanceOf(Connection::class, $container->get('doctrine.dbal.default_connection'));
-        $this->assertInstanceOf(Reader::class, $container->get('doctrine.orm.metadata.annotation_reader'));
         $this->assertInstanceOf(Configuration::class, $container->get('doctrine.orm.default_configuration'));
         $this->assertInstanceOf(MappingDriverChain::class, $container->get('doctrine.orm.default_metadata_driver'));
         $this->assertInstanceOf(PhpArrayAdapter::class, $container->get('doctrine.orm.default_metadata_cache'));

--- a/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -4,19 +4,38 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
 
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCase;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Cache\Region;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
+use function class_exists;
 use function get_class;
+use function interface_exists;
+
+use const PHP_VERSION_ID;
 
 class CacheCompatibilityPassTest extends TestCase
 {
     use ExpectDeprecationTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (PHP_VERSION_ID < 80000 && ! class_exists(AnnotationReader::class)) {
+            self::markTestSkipped('This test requires Annotations when run on PHP 7');
+        }
+
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
 
     public function testCacheConfigUsingServiceDefinedByApplication(): void
     {

--- a/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Entity/TestCustomIdGeneratorEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Entity/TestCustomIdGeneratorEntity.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Fixtures\Bundles\AttributesBundle\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class TestCustomIdGeneratorEntity
+{
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'CUSTOM'), ORM\CustomIdGenerator('my_id_generator'), ORM\Column(type: Types::INTEGER)]
+    public ?int $id = null;
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomClassRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomClassRepoEntity.php
@@ -2,9 +2,12 @@
 
 namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository;
 
 /** @ORM\Entity(repositoryClass="Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository") */
+#[ORM\Entity(repositoryClass: TestCustomClassRepoRepository::class)]
 class TestCustomClassRepoEntity
 {
     /**
@@ -12,5 +15,6 @@ class TestCustomClassRepoEntity
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'AUTO'), ORM\Column(type: Types::INTEGER)]
     private ?int $id = null;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomServiceRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestCustomServiceRepoEntity.php
@@ -2,9 +2,12 @@
 
 namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoRepository;
 
 /** @ORM\Entity(repositoryClass="Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoRepository") */
+#[ORM\Entity(repositoryClass: TestCustomServiceRepoRepository::class)]
 class TestCustomServiceRepoEntity
 {
     /**
@@ -12,5 +15,6 @@ class TestCustomServiceRepoEntity
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'AUTO'), ORM\Column(type: Types::INTEGER)]
     private ?int $id = null;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Entity/TestDefaultRepoEntity.php
@@ -2,9 +2,11 @@
 
 namespace Fixtures\Bundles\RepositoryServiceBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /** @ORM\Entity */
+#[ORM\Entity]
 class TestDefaultRepoEntity
 {
     /**
@@ -12,5 +14,6 @@ class TestDefaultRepoEntity
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'AUTO'), ORM\Column(type: Types::INTEGER)]
     private ?int $id = null;
 }

--- a/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/DbalTestKernel.php
@@ -4,6 +4,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCaseAllPublicCompilerPass;
+use Doctrine\Common\Annotations\Annotation;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -11,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
+use function class_exists;
 use function md5;
 use function mt_rand;
 use function sys_get_temp_dir;
@@ -42,7 +44,13 @@ class DbalTestKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(function (ContainerBuilder $container): void {
-            $container->loadFromExtension('framework', ['secret' => 'F00', 'http_method_override' => false]);
+            $container->loadFromExtension('framework', [
+                'secret' => 'F00',
+                'http_method_override' => false,
+                'annotations' => [
+                    'enabled' => class_exists(Annotation::class),
+                ],
+            ]);
 
             $container->loadFromExtension('doctrine', [
                 'dbal' => $this->dbalConfig,

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Common\Annotations\Annotation;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -10,9 +11,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
+use function class_exists;
 use function md5;
 use function mt_rand;
 use function sys_get_temp_dir;
+
+use const PHP_VERSION_ID;
 
 class TestKernel extends Kernel
 {
@@ -35,7 +39,13 @@ class TestKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
-            $container->loadFromExtension('framework', ['secret' => 'F00', 'http_method_override' => false]);
+            $container->loadFromExtension('framework', [
+                'secret' => 'F00',
+                'http_method_override' => false,
+                'annotations' => [
+                    'enabled' => class_exists(Annotation::class),
+                ],
+            ]);
 
             $container->loadFromExtension('doctrine', [
                 'dbal' => ['driver' => 'pdo_sqlite'],
@@ -43,7 +53,7 @@ class TestKernel extends Kernel
                     'auto_generate_proxy_classes' => true,
                     'mappings' => [
                         'RepositoryServiceBundle' => [
-                            'type' => 'annotation',
+                            'type' => PHP_VERSION_ID >= 80000 ? 'attribute' : 'annotation',
                             'dir' => __DIR__ . '/Bundles/RepositoryServiceBundle/Entity',
                             'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Entity',
                         ],

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 use Closure;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Fixtures\Bundles\RepositoryServiceBundle\Entity\TestCustomClassRepoEntity;
@@ -16,7 +17,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 
 use function assert;
+use function class_exists;
 use function interface_exists;
+
+use const PHP_VERSION_ID;
 
 class RegistryTest extends TestCase
 {
@@ -199,6 +203,10 @@ class RegistryTest extends TestCase
 
     public function testIdentityMapsStayConsistentAfterReset(): void
     {
+        if (PHP_VERSION_ID < 80000 && ! class_exists(AnnotationReader::class)) {
+            self::markTestSkipped('This test requires Annotations when run on PHP 7');
+        }
+
         if (! interface_exists(EntityManagerInterface::class)) {
             self::markTestSkipped('This test requires ORM');
         }

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+use function class_exists;
 use function sys_get_temp_dir;
 use function uniqid;
 
@@ -37,7 +38,10 @@ class TestCase extends BaseTestCase
             'kernel.bundles_metadata' => [],
             'container.build_id' => uniqid(),
         ]));
-        $container->set('annotation_reader', new AnnotationReader());
+
+        if (class_exists(AnnotationReader::class)) {
+            $container->set('annotation_reader', new AnnotationReader());
+        }
 
         $extension = new DoctrineExtension();
         $container->registerExtension($extension);

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/annotations": "^1",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/dbal": "^3.4.0",
         "doctrine/persistence": "^2.2 || ^3",
@@ -45,6 +44,7 @@
         "symfony/service-contracts": "^1.1.1 || ^2.0 || ^3"
     },
     "require-dev": {
+        "doctrine/annotations": "^1 || ^2",
         "doctrine/coding-standard": "^9.0",
         "doctrine/orm": "^2.11 || ^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
@@ -64,6 +64,7 @@
         "vimeo/psalm": "^4.30"
     },
     "conflict": {
+        "doctrine/annotations": ">=3.0",
         "doctrine/orm": "<2.11 || >=3.0",
         "twig/twig": "<1.34 || >=2.0,<2.4"
     },


### PR DESCRIPTION
This can supersede #1596

This PR will:

- Allow `doctrine/annotations` 2.x to be installed
- Makes the Annotations package optional by moving it to `require-dev` and unloading the `doctrine.orm.metadata.annotation_reader` service alias if not installed
- Explicitly configures whether annotation support should be enabled in test fixtures instead of relying on feature detection in the FrameworkBundle (which relies on the package existing in someone's `require` list)
- Adds attributes to the `RepositoryServiceBundle` test fixture bundle that is loaded by `Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel`
- Configures resources using the `RepositoryServiceBundle` test fixture bundle to use attributes when run on PHP 8 and annotations on PHP 7
- Skips tests if run on PHP 7 and the Annotations package isn't installed