### PR TITLE
Remove unknown branch 2.9.x

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,12 +4,6 @@
   "slug": "doctrine-bundle",
   "versions": [
     {
-      "name": "2.9",
-      "branchName": "2.9.x",
-      "slug": "latest",
-      "upcoming": true
-    },
-    {
       "name": "2.8",
       "branchName": "2.8.x",
       "slug": "2.8",


### PR DESCRIPTION
The website build is failing because of either a missing branch 2.9.x or a remnant entry in .doctrine-project.json