### PR TITLE
Profiler: Linkify classes in entities mapping section

### DIFF
--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -12,8 +12,6 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
-use ReflectionClass;
-use ReflectionException;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector as BaseCollector;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Symfony\Component\HttpFoundation\Request;
@@ -117,21 +115,13 @@ class DoctrineDataCollector extends BaseCollector
                         continue;
                     }
 
-                    $classErrors = $validator->validateClass($class);
-                    try {
-                        $r                                  = new ReflectionClass($class->getName());
-                        $entities[$name][$class->getName()] = [
-                            'class' => $class->getName(),
-                            'file' => $r->getFileName(),
-                            'line' => $r->getStartLine(),
-                        ];
-                    } catch (ReflectionException $e) {
-                        $entities[$name][$class->getName()] = [
-                            'class' => $class->getName(),
-                            'file' => 'n/a',
-                            'line' => 'n/a',
-                        ];
-                    }
+                    $classErrors                        = $validator->validateClass($class);
+                    $r                                  = $class->getReflectionClass();
+                    $entities[$name][$class->getName()] = [
+                        'class' => $class->getName(),
+                        'file' => $r->getFileName(),
+                        'line' => $r->getStartLine(),
+                    ];
 
                     if (empty($classErrors)) {
                         continue;

--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -12,6 +12,8 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
+use ReflectionClass;
+use ReflectionException;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector as BaseCollector;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Symfony\Component\HttpFoundation\Request;
@@ -115,8 +117,21 @@ class DoctrineDataCollector extends BaseCollector
                         continue;
                     }
 
-                    $classErrors                        = $validator->validateClass($class);
-                    $entities[$name][$class->getName()] = $class->getName();
+                    $classErrors = $validator->validateClass($class);
+                    try {
+                        $r                                  = new ReflectionClass($class->getName());
+                        $entities[$name][$class->getName()] = [
+                            'class' => $class->getName(),
+                            'file' => $r->getFileName(),
+                            'line' => $r->getStartLine(),
+                        ];
+                    } catch (ReflectionException $e) {
+                        $entities[$name][$class->getName()] = [
+                            'class' => $class->getName(),
+                            'file' => 'n/a',
+                            'line' => 'n/a',
+                        ];
+                    }
 
                     if (empty($classErrors)) {
                         continue;

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -367,10 +367,7 @@
                         {% set contains_errors = collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class.class] is defined %}
                         <tr class="{{ contains_errors ? 'status-error' }}">
                             <td>
-                                {%- set link = class.file|file_link(class.line) %}
-                                {%- if link %}<a href="{{ link }}" title="{{ class.class }}">{% else %}<span title="{{ class.class }}">{% endif %}
-                                    {{ class.class }}
-                                {%- if link %}</a>{% else %}</span>{% endif %}
+                                <a href="{{ class.file|file_link(class.line) }}">{{ class. class}}</a>
                             </td>
                             <td class="font-normal">
                                 {% if contains_errors %}

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -363,19 +363,19 @@
                     </tr>
                     </thead>
                     <tbody>
-                    {% for class in classes|keys %}
-                        {% set contains_errors = collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class] is defined %}
+                    {% for class in classes %}
+                        {% set contains_errors = collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class.class] is defined %}
                         <tr class="{{ contains_errors ? 'status-error' }}">
                             <td>
-                                {%- set link = classes[class].file|file_link(classes[class].line) %}
-                                {%- if link %}<a href="{{ link }}" title="{{ class }}">{% else %}<span title="{{ class }}">{% endif %}
-                                    {{ class }}
+                                {%- set link = class.file|file_link(class.line) %}
+                                {%- if link %}<a href="{{ link }}" title="{{ class.class }}">{% else %}<span title="{{ class.class }}">{% endif %}
+                                    {{ class.class }}
                                 {%- if link %}</a>{% else %}</span>{% endif %}
                             </td>
                             <td class="font-normal">
                                 {% if contains_errors %}
                                     <ul>
-                                        {% for error in collector.mappingErrors[manager][class] %}
+                                        {% for error in collector.mappingErrors[manager][class.class] %}
                                             <li>{{ error }}</li>
                                         {% endfor %}
                                     </ul>

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -363,10 +363,15 @@
                     </tr>
                     </thead>
                     <tbody>
-                    {% for class in classes %}
+                    {% for class in classes|keys %}
                         {% set contains_errors = collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class] is defined %}
                         <tr class="{{ contains_errors ? 'status-error' }}">
-                            <td>{{ class }}</td>
+                            <td>
+                                {%- set link = classes[class].file|file_link(classes[class].line) %}
+                                {%- if link %}<a href="{{ link }}" title="{{ class }}">{% else %}<span title="{{ class }}">{% endif %}
+                                    {{ class }}
+                                {%- if link %}</a>{% else %}</span>{% endif %}
+                            </td>
                             <td class="font-normal">
                                 {% if contains_errors %}
                                     <ul>


### PR DESCRIPTION
While working on #1607 I noticed entity classes are not clickable to your IDE unlike most other things in the profiler, so I added support for it. It's based on how the RequestDataCollector from Symfony's HttpKernel does it.

Screenshot:
<img width="837" alt="image" src="https://user-images.githubusercontent.com/550145/210863051-17437fce-a76c-4c91-be9b-f996173366f4.png">
