### PR TITLE
Add generics types on ServiceEntityRepository using the LazyServiceEntityRepository

### DIFF
--- a/Repository/ServiceEntityRepository.php
+++ b/Repository/ServiceEntityRepository.php
@@ -11,6 +11,10 @@ use function sprintf;
 use function trait_exists;
 
 if (trait_exists(LazyGhostTrait::class)) {
+    /**
+     * @template T of object
+     * @template-extends LazyServiceEntityRepository<T>
+     */
     class ServiceEntityRepository extends LazyServiceEntityRepository
     {
     }


### PR DESCRIPTION
https://github.com/doctrine/DoctrineBundle/pull/1599 has introduced a new `ServiceEntityRepository` definition using the `LazyServiceEntityRepository`.

This new definition doesn't declare the generic type that cause problems for static analysis when this service implementation is used.