### PR TITLE
Allow to specify `EntityValueResolver` as `ValueResolver`

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -183,7 +183,7 @@
         <service id="doctrine.orm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">
             <argument type="service" id="doctrine" />
             <argument type="service" id="doctrine.orm.entity_value_resolver.expression_language" on-invalid="ignore" />
-            <tag name="controller.argument_value_resolver" priority="110" />
+            <tag name="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver" priority="110">controller.argument_value_resolver</tag>
         </service>
 
         <service id="doctrine.orm.entity_value_resolver.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />


### PR DESCRIPTION
Follow-up of https://github.com/symfony/symfony/pull/48992: a new `ValueResolver` attribute can be attached to a parameter to specify which resolver will yield its value. This PR will allow to write

```php
#[ValueResolver(EntityValueResolver::class)]
```

(The used syntax allowing to add a `name` attribute to a tag has been introduced in `symfony/dependency-injection` 5.1 by https://github.com/symfony/symfony/pull/36586. This is not a problem since we require `^5.4 || ^6.0`.)