### PR TITLE
add priority argument to AsEntityListener attribute

### DIFF
--- a/Attribute/AsEntityListener.php
+++ b/Attribute/AsEntityListener.php
@@ -12,6 +12,7 @@ class AsEntityListener
 {
     public function __construct(
         public ?string $event = null,
+        public ?int $priority = null,
         public ?string $method = null,
         public ?bool $lazy = null,
         public ?string $entityManager = null,

--- a/Attribute/AsEntityListener.php
+++ b/Attribute/AsEntityListener.php
@@ -12,11 +12,11 @@ class AsEntityListener
 {
     public function __construct(
         public ?string $event = null,
-        public ?int $priority = null,
         public ?string $method = null,
         public ?bool $lazy = null,
         public ?string $entityManager = null,
         public ?string $entity = null,
+        public ?int $priority = null,
     ) {
     }
 }

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -535,6 +535,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $container->registerAttributeForAutoconfiguration(AsEntityListener::class, static function (ChildDefinition $definition, AsEntityListener $attribute) {
             $definition->addTag('doctrine.orm.entity_listener', [
                 'event'          => $attribute->event,
+                'priority'       => $attribute->priority,
                 'method'         => $attribute->method,
                 'lazy'           => $attribute->lazy,
                 'entity_manager' => $attribute->entityManager,

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -535,11 +535,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $container->registerAttributeForAutoconfiguration(AsEntityListener::class, static function (ChildDefinition $definition, AsEntityListener $attribute) {
             $definition->addTag('doctrine.orm.entity_listener', [
                 'event'          => $attribute->event,
-                'priority'       => $attribute->priority,
                 'method'         => $attribute->method,
                 'lazy'           => $attribute->lazy,
                 'entity_manager' => $attribute->entityManager,
                 'entity'         => $attribute->entity,
+                'priority'       => $attribute->priority,
             ]);
         });
         $container->registerAttributeForAutoconfiguration(AsDoctrineListener::class, static function (ChildDefinition $definition, AsDoctrineListener $attribute) {

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1159,11 +1159,11 @@ class DoctrineExtensionTest extends TestCase
 
         $expected = [
             'event'          => null,
-            'priority'       => null,
             'method'         => null,
             'lazy'           => null,
             'entity_manager' => null,
             'entity'         => null,
+            'priority'       => null,
         ];
         $this->assertSame([$expected], $definition->getTag('doctrine.orm.entity_listener'));
     }

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1159,6 +1159,7 @@ class DoctrineExtensionTest extends TestCase
 
         $expected = [
             'event'          => null,
+            'priority'       => null,
             'method'         => null,
             'lazy'           => null,
             'entity_manager' => null,


### PR DESCRIPTION
The `doctrine.orm.entity_listener` tag has optional `priority` attribute which is missing from `AsEntityListener`.