### PR TITLE
show doctrine deprecations with phpunit bridge

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       SYMFONY_REQUIRE: ${{matrix.symfony-require}}
-      SYMFONY_DEPRECATIONS_HELPER: ${{matrix.symfony-deprecations-helper}}
+      #SYMFONY_DEPRECATIONS_HELPER: ${{matrix.symfony-deprecations-helper}}
 
     strategy:
       fail-fast: false
@@ -37,25 +37,25 @@ jobs:
           - dependencies: "lowest"
             stability: "stable"
             php-version: "7.4"
-            symfony-deprecations-helper: "weak"
+            #symfony-deprecations-helper: "weak"
 
           # Test LTS
           - symfony-require: "5.4.*"
             dependencies: "highest"
             php-version: "8.0"
-            symfony-deprecations-helper: "weak"
+            #symfony-deprecations-helper: "weak"
 
           # Test last supported minor version
           - symfony-require: "6.*"
             dependencies: "highest"
             php-version: "8.1"
-            symfony-deprecations-helper: "weak"
+            #symfony-deprecations-helper: "weak"
 
           # Bleeding edge
           - php-version: "8.1"
             dependencies: "highest"
             stability: "dev"
-            symfony-deprecations-helper: "weak"
+            #symfony-deprecations-helper: "weak"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       SYMFONY_REQUIRE: ${{matrix.symfony-require}}
-      #SYMFONY_DEPRECATIONS_HELPER: ${{matrix.symfony-deprecations-helper}}
 
     strategy:
       fail-fast: false
@@ -37,25 +36,21 @@ jobs:
           - dependencies: "lowest"
             stability: "stable"
             php-version: "7.4"
-            #symfony-deprecations-helper: "weak"
 
           # Test LTS
           - symfony-require: "5.4.*"
             dependencies: "highest"
             php-version: "8.0"
-            #symfony-deprecations-helper: "weak"
 
           # Test last supported minor version
           - symfony-require: "6.*"
             dependencies: "highest"
             php-version: "8.1"
-            #symfony-deprecations-helper: "weak"
 
           # Bleeding edge
           - php-version: "8.1"
             dependencies: "highest"
             stability: "dev"
-            #symfony-deprecations-helper: "weak"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       SYMFONY_REQUIRE: ${{matrix.symfony-require}}
+      SYMFONY_DEPRECATIONS_HELPER: weak
 
     strategy:
       fail-fast: false
@@ -28,8 +29,6 @@ jobs:
         stability:
           - "stable"
         symfony-require:
-          - ""
-        symfony-deprecations-helper:
           - ""
         include:
           # Tests the lowest set of dependencies

--- a/.github/workflows/test-dev-stability.yml
+++ b/.github/workflows/test-dev-stability.yml
@@ -52,4 +52,4 @@ jobs:
           composer-options: "--prefer-dist"
 
       - name: "Run PHPUnit"
-        run: "SYMFONY_DEPRECATIONS_HELPER=${{env.GITHUB_WORKSPACE}}/tests/baseline-ignore vendor/bin/phpunit"
+        run: "vendor/bin/phpunit"

--- a/.github/workflows/test-dev-stability.yml
+++ b/.github/workflows/test-dev-stability.yml
@@ -52,4 +52,4 @@ jobs:
           composer-options: "--prefer-dist"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit"
+        run: "SYMFONY_DEPRECATIONS_HELPER=${{env.GITHUB_WORKSPACE}}/tests/baseline-ignore vendor/bin/phpunit"

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -52,6 +52,7 @@ class ConnectionFactoryTest extends TestCase
         );
     }
 
+    /** @group legacy */
     public function testCollateMapsToCollationForMySql(): void
     {
         $factory = new ConnectionFactory([]);

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+use Doctrine\Deprecations\Deprecation;
+
+require_once 'vendor/autoload.php';
+
+if (class_exists(Deprecation::class)) {
+    Deprecation::enableWithTriggerError();
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -4,6 +4,4 @@ use Doctrine\Deprecations\Deprecation;
 
 require_once 'vendor/autoload.php';
 
-if (class_exists(Deprecation::class)) {
-    Deprecation::enableWithTriggerError();
-}
+Deprecation::enableWithTriggerError();

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "require-dev": {
         "doctrine/annotations": "^1 || ^2",
         "doctrine/coding-standard": "^9.0",
+        "doctrine/deprecations": "^1.0",
         "doctrine/orm": "^2.11 || ^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "phpunit/phpunit": "^9.5.26 || ^10.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit colors="true" bootstrap="Tests/bootstrap.php">
     <testsuites>
         <testsuite name="DoctrineBundle for the Symfony Framework">
             <directory>./Tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     </testsuites>
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;ignoreFile=./Tests/baseline-ignore"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0&amp;max[indirect]=99&amp;ignoreFile=./Tests/baseline-ignore"/>
     </php>
 
     <filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     </testsuites>
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./Tests/baseline-ignore"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;ignoreFile=./Tests/baseline-ignore"/>
     </php>
 
     <filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     </testsuites>
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0&amp;max[indirect]=99&amp;ignoreFile=./Tests/baseline-ignore"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0&amp;ignoreFile=./Tests/baseline-ignore"/>
     </php>
 
     <filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     </testsuites>
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=9999&amp;ignoreFile=./Tests/baseline-ignore"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./Tests/baseline-ignore"/>
     </php>
 
     <filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     </testsuites>
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0&amp;ignoreFile=./Tests/baseline-ignore"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=9999&amp;ignoreFile=./Tests/baseline-ignore"/>
     </php>
 
     <filter>


### PR DESCRIPTION
WDYT about showing the doctrine deprecations?

```
Remaining indirect deprecation notices (7)

  1x: Not configuring a schema manager factory is deprecated. Use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory which is going to be the default in DBAL 4. (Connection.php:225 called by DriverManager.php:193, https://github.com/doctrine/dbal/issues/5812, package doctrine/dbal)
    1x in CreateDatabaseDoctrineTest::testExecute from Doctrine\Bundle\DoctrineBundle\Tests\Command

  1x: SqliteSchemaManager::createDatabase() is deprecated. The engine will create the database file automatically. (SqliteSchemaManager.php:140 called by CreateDatabaseDoctrineCommand.php:85, https://github.com/doctrine/dbal/issues/4963, package doctrine/dbal)
    1x in CreateDatabaseDoctrineTest::testExecute from Doctrine\Bundle\DoctrineBundle\Tests\Command

  1x: The "platform" connection parameter is deprecated. Use a driver middleware that would instantiate the platform instead. (Connection.php:207 called by DriverManager.php:193, https://github.com/doctrine/dbal/pull/5699, package doctrine/dbal)
    1x in ContainerTest::testContainer from Doctrine\Bundle\DoctrineBundle\Tests

  1x: Using XML mapping driver with XSD validation disabled is deprecated and will not be supported in Doctrine ORM 3.0. (XmlDriver.php:65 called by SimplifiedXmlDriver.php:23, https://github.com/doctrine/orm/pull/6728, package doctrine/orm)
    1x in ContainerTest::testContainer from Doctrine\Bundle\DoctrineBundle\Tests

  1x: Passing an instance of Doctrine\ORM\Mapping\ClassMetadataInfo to Doctrine\ORM\Tools\SchemaValidator::validateClass is deprecated, please pass a ClassMetadata instance instead. (SchemaValidator.php:82 called by DoctrineDataCollector.php:116, https://github.com/doctrine/orm/pull/249, package doctrine/orm)
    1x in DoctrineDataCollectorTest::testCollectEntities from Doctrine\Bundle\DoctrineBundle\Tests\DataCollector

  1x: DebugStack is deprecated. (DebugStack.php:41 called by Generator.php:715, https://github.com/doctrine/dbal/pull/4967, package doctrine/dbal)
    1x in DoctrineDataCollectorTest::testGetGroupedQueries from Doctrine\Bundle\DoctrineBundle\Tests\DataCollector

  1x: Passing an instance of Doctrine\Common\Cache\Psr6\DoctrineProvider to Doctrine\ORM\Cache\DefaultCacheFactory::__construct is deprecated, pass a Psr\Cache\CacheItemPoolInterface instead. (DefaultCacheFactory.php:62 called by getDoctrine_Orm_DefaultEntityManagerService.php:36, https://github.com/doctrine/orm/pull/9322, package doctrine/orm)
    1x in CacheCompatibilityPassTest::testCacheConfigUsingServiceDefinedByApplication from Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler
