### PR TITLE
allow configuring schema manager factory

### DIFF
--- a/Command/CreateDatabaseDoctrineCommand.php
+++ b/Command/CreateDatabaseDoctrineCommand.php
@@ -65,7 +65,7 @@ EOT
         // Need to get rid of _every_ occurrence of dbname from connection configuration and we have already extracted all relevant info from url
         unset($params['dbname'], $params['path'], $params['url']);
 
-        $tmpConnection = DriverManager::getConnection($params);
+        $tmpConnection = DriverManager::getConnection($params, $connection->getConfiguration());
 
         $schemaManager           = method_exists($tmpConnection, 'createSchemaManager')
             ? $tmpConnection->createSchemaManager()

--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -88,7 +88,7 @@ EOT
         // Reopen connection without database name set
         // as some vendors do not allow dropping the database connected to.
         $connection->close();
-        $connection         = DriverManager::getConnection($params);
+        $connection         = DriverManager::getConnection($params, $connection->getConfiguration());
         $schemaManager      = method_exists($connection, 'createSchemaManager')
             ? $connection->createSchemaManager()
             : $connection->getSchemaManager();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -195,6 +195,9 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('scalar')->end()
                 ->end()
+                ->scalarNode('schema_manager_factory')
+                    ->defaultValue('doctrine.dbal.default_schema_manager_factory')
+                ->end()
             ->end();
 
         // dbal < 2.11

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -196,8 +196,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('schema_manager_factory')
-                    ->defaultValue('doctrine.dbal.legacy_schema_manager_factory')
-                    ->cannotBeEmpty()
+                    ->defaultNull()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -196,7 +196,9 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('schema_manager_factory')
-                    ->defaultValue('doctrine.dbal.default_schema_manager_factory')
+                    ->defaultValue('doctrine.dbal.legacy_schema_manager_factory')
+                    ->cannotBeEmpty()
+                    ->end()
                 ->end()
             ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
 use Doctrine\Common\Proxy\AbstractProxyFactory;
+use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
@@ -196,7 +197,8 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('schema_manager_factory')
-                    ->defaultNull()
+                    ->cannotBeEmpty()
+                    ->defaultValue($this->getDefaultSchemaManagerFactory())
                 ->end()
             ->end();
 
@@ -789,5 +791,14 @@ class Configuration implements ConfigurationInterface
             'names' => $namesArray,
             'values' => $valuesArray,
         ];
+    }
+
+    private function getDefaultSchemaManagerFactory(): string
+    {
+        if (class_exists(LegacySchemaManagerFactory::class)) {
+            return 'doctrine.dbal.legacy_schema_manager_factory';
+        }
+
+        return 'doctrine.dbal.default_schema_manager_factory';
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,7 +197,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('schema_manager_factory')
                     ->defaultNull()
-                    ->end()
                 ->end()
             ->end();
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -242,6 +242,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ManagerRegistryAwareConnectionProvider::class,
             new Definition(ManagerRegistryAwareConnectionProvider::class, [$container->getDefinition('doctrine')])
         );
+
+        $configuration->addMethodCall('setSchemaManagerFactory', [new Reference($connection['schema_manager_factory'])]);
     }
 
     /**
@@ -265,6 +267,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         unset($options['override_url']);
+        unset($options['schema_manager_factory']);
 
         $options += $connectionDefaults;
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -66,6 +66,7 @@ use function reset;
 use function sprintf;
 use function str_replace;
 use function trait_exists;
+use function trigger_deprecation;
 
 /**
  * DoctrineExtension is an extension for the Doctrine DBAL and ORM library.
@@ -243,7 +244,18 @@ class DoctrineExtension extends AbstractDoctrineExtension
             new Definition(ManagerRegistryAwareConnectionProvider::class, [$container->getDefinition('doctrine')])
         );
 
-        $configuration->addMethodCall('setSchemaManagerFactory', [new Reference($connection['schema_manager_factory'])]);
+        $schemaManagerFactoryId = $connection['schema_manager_factory'];
+        if ($schemaManagerFactoryId === 'doctrine.dbal.legacy_schema_manager_factory') {
+            trigger_deprecation(
+                'doctrine/doctrine-bundle',
+                '2.9',
+                'Using "%s" as schema_manager_factory is deprecated. Use "%s" or a custom factory instead. See UPGRADE-2.9.md for details.',
+                'doctrine.dbal.legacy_schema_manager_factory',
+                'doctrine.dbal.default_schema_manager_factory',
+            );
+        }
+
+        $configuration->addMethodCall('setSchemaManagerFactory', [new Reference($schemaManagerFactoryId)]);
     }
 
     /**

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -245,17 +245,16 @@ class DoctrineExtension extends AbstractDoctrineExtension
         );
 
         $schemaManagerFactoryId = $connection['schema_manager_factory'];
-        if ($schemaManagerFactoryId === 'doctrine.dbal.legacy_schema_manager_factory') {
+        if ($schemaManagerFactoryId === null) {
             trigger_deprecation(
                 'doctrine/doctrine-bundle',
                 '2.9',
-                'Using "%s" as schema_manager_factory is deprecated. Use "%s" or a custom factory instead. See UPGRADE-2.9.md for details.',
-                'doctrine.dbal.legacy_schema_manager_factory',
+                'Not configuring schema_manager_factory is deprecated. Use "%s" or a custom factory instead. See UPGRADE-2.9.md for details.',
                 'doctrine.dbal.default_schema_manager_factory',
             );
+        } else {
+            $configuration->addMethodCall('setSchemaManagerFactory', [new Reference($schemaManagerFactoryId)]);
         }
-
-        $configuration->addMethodCall('setSchemaManagerFactory', [new Reference($schemaManagerFactoryId)]);
     }
 
     /**

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -98,6 +98,7 @@
         </service>
 
         <service id="doctrine.dbal.default_schema_manager_factory" class="Doctrine\DBAL\Schema\DefaultSchemaManagerFactory" />
+        <service id="doctrine.dbal.legacy_schema_manager_factory" class="Doctrine\DBAL\Schema\LegacySchemaManagerFactory" />
 
     </services>
 </container>

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -98,7 +98,9 @@
         </service>
 
         <service id="doctrine.dbal.default_schema_manager_factory" class="Doctrine\DBAL\Schema\DefaultSchemaManagerFactory" />
-        <service id="doctrine.dbal.legacy_schema_manager_factory" class="Doctrine\DBAL\Schema\LegacySchemaManagerFactory" />
+        <service id="doctrine.dbal.legacy_schema_manager_factory" class="Doctrine\DBAL\Schema\LegacySchemaManagerFactory">
+            <deprecated package="doctrine/doctrine-bundle" version="2.9">The "%service_id%" service is deprecated. Use "doctrine.dbal.default_schema_manager_factory" instead.</deprecated>
+        </service>
 
     </services>
 </container>

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -98,9 +98,6 @@
         </service>
 
         <service id="doctrine.dbal.default_schema_manager_factory" class="Doctrine\DBAL\Schema\DefaultSchemaManagerFactory" />
-        <service id="doctrine.dbal.legacy_schema_manager_factory" class="Doctrine\DBAL\Schema\LegacySchemaManagerFactory">
-            <deprecated package="doctrine/doctrine-bundle" version="2.9">The "%service_id%" service is deprecated. Use "doctrine.dbal.default_schema_manager_factory" instead.</deprecated>
-        </service>
 
     </services>
 </container>

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -97,5 +97,7 @@
             <tag name="controller.service_arguments" />
         </service>
 
+        <service id="doctrine.dbal.default_schema_manager_factory" class="Doctrine\DBAL\Schema\DefaultSchemaManagerFactory" />
+
     </services>
 </container>

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -38,7 +38,7 @@
         <xsd:attribute name="profiling-collect-backtrace" type="xsd:string" default="false" />
         <xsd:attribute name="profiling-collect-schema-errors" type="xsd:string" default="true" />
         <xsd:attribute name="server-version" type="xsd:string" />
-        <xsd:attribute name="schema-manager-factory" type="xsd:string" default="doctrine.dbal.default_schema_manager_factory" />
+        <xsd:attribute name="schema-manager-factory" type="xsd:string" />
         <xsd:attribute name="use-savepoints" type="xsd:boolean" />
         <xsd:attributeGroup ref="driver-config" />
     </xsd:attributeGroup>

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -38,6 +38,7 @@
         <xsd:attribute name="profiling-collect-backtrace" type="xsd:string" default="false" />
         <xsd:attribute name="profiling-collect-schema-errors" type="xsd:string" default="true" />
         <xsd:attribute name="server-version" type="xsd:string" />
+        <xsd:attribute name="schema-manager-factory" type="xsd:string" default="doctrine.dbal.default_schema_manager_factory" />
         <xsd:attribute name="use-savepoints" type="xsd:boolean" />
         <xsd:attributeGroup ref="driver-config" />
     </xsd:attributeGroup>

--- a/Tests/Command/CreateDatabaseDoctrineTest.php
+++ b/Tests/Command/CreateDatabaseDoctrineTest.php
@@ -3,8 +3,10 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand;
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -68,10 +70,10 @@ class CreateDatabaseDoctrineTest extends TestCase
             ->withAnyParameters()
             ->willReturn($connectionName);
 
-        $mockConnection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParams'])
-            ->getMockForAbstractClass();
+        $config = (new Configuration())->setSchemaManagerFactory($this->createMock(SchemaManagerFactory::class));
+
+        $mockConnection = $this->createMock(Connection::class);
+        $mockConnection->method('getConfiguration')->willReturn($config);
 
         $mockConnection->expects($this->any())
             ->method('getParams')

--- a/Tests/Command/DropDatabaseDoctrineTest.php
+++ b/Tests/Command/DropDatabaseDoctrineTest.php
@@ -3,9 +3,11 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\Persistence\ManagerRegistry;
 use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -150,10 +152,10 @@ class DropDatabaseDoctrineTest extends TestCase
             ->withAnyParameters()
             ->willReturn($connectionName);
 
-        $mockConnection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParams'])
-            ->getMockForAbstractClass();
+        $config = (new Configuration())->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+
+        $mockConnection = $this->createMock(Connection::class);
+        $mockConnection->method('getConfiguration')->willReturn($config);
 
         $mockConnection->expects($this->any())
             ->method('getParams')

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -235,6 +235,23 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertCount(0, $calls);
     }
 
+    public function testDbalSchemaManagerFactory(): void
+    {
+        $container = $this->loadContainer('dbal_schema_manager_factory');
+
+        $this->assertDICDefinitionMethodCallOnce(
+            $container->getDefinition('doctrine.dbal.default_schema_manager_factory_connection.configuration'),
+            'setSchemaManagerFactory',
+            [new Reference('doctrine.dbal.default_schema_manager_factory')]
+        );
+
+        $this->assertDICDefinitionMethodCallOnce(
+            $container->getDefinition('doctrine.dbal.custom_schema_manager_factory_connection.configuration'),
+            'setSchemaManagerFactory',
+            [new Reference('custom_factory')]
+        );
+    }
+
     public function testLoadSimpleSingleConnection(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -13,6 +13,7 @@ use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Generator;
@@ -39,6 +40,7 @@ use function array_intersect_key;
 use function array_keys;
 use function array_values;
 use function assert;
+use function class_exists;
 use function end;
 use function interface_exists;
 use function is_dir;
@@ -243,13 +245,11 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce(
             $container->getDefinition('doctrine.dbal.default_schema_manager_factory_connection.configuration'),
             'setSchemaManagerFactory',
-            [new Reference('doctrine.dbal.default_schema_manager_factory')]
-        );
-
-        // Remove when DBAL 3 support is dropped
-        $this->assertDICDefinitionNoMethodCall(
-            $container->getDefinition('doctrine.dbal.legacy_schema_manager_factory_connection.configuration'),
-            'setSchemaManagerFactory',
+            [
+                new Reference(class_exists(LegacySchemaManagerFactory::class)
+                ? 'doctrine.dbal.legacy_schema_manager_factory'
+                : 'doctrine.dbal.default_schema_manager_factory'),
+            ]
         );
 
         $this->assertDICDefinitionMethodCallOnce(

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -247,10 +247,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         );
 
         // Remove when DBAL 3 support is dropped
-        $this->assertDICDefinitionMethodCallOnce(
+        $this->assertDICDefinitionNoMethodCall(
             $container->getDefinition('doctrine.dbal.legacy_schema_manager_factory_connection.configuration'),
             'setSchemaManagerFactory',
-            [new Reference('doctrine.dbal.legacy_schema_manager_factory')]
         );
 
         $this->assertDICDefinitionMethodCallOnce(

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -235,6 +235,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertCount(0, $calls);
     }
 
+    /** @group legacy */
     public function testDbalSchemaManagerFactory(): void
     {
         $container = $this->loadContainer('dbal_schema_manager_factory');
@@ -243,6 +244,13 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             $container->getDefinition('doctrine.dbal.default_schema_manager_factory_connection.configuration'),
             'setSchemaManagerFactory',
             [new Reference('doctrine.dbal.default_schema_manager_factory')]
+        );
+
+        // Remove when DBAL 3 support is dropped
+        $this->assertDICDefinitionMethodCallOnce(
+            $container->getDefinition('doctrine.dbal.legacy_schema_manager_factory_connection.configuration'),
+            'setSchemaManagerFactory',
+            [new Reference('doctrine.dbal.legacy_schema_manager_factory')]
         );
 
         $this->assertDICDefinitionMethodCallOnce(

--- a/Tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
@@ -104,6 +104,7 @@ class IdGeneratorPassTest extends TestCase
                 'dbal' => [
                     'driver' => 'pdo_sqlite',
                     'charset' => 'UTF8',
+                    'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
                 ],
                 'orm' => ['mappings' => $mappings],
             ],

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -48,7 +48,10 @@ class TestKernel extends Kernel
             ]);
 
             $container->loadFromExtension('doctrine', [
-                'dbal' => ['driver' => 'pdo_sqlite'],
+                'dbal' => [
+                    'driver' => 'pdo_sqlite',
+                    'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
+                ],
                 'orm' => [
                     'auto_generate_proxy_classes' => true,
                     'mappings' => [

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_manager_factory.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_manager_factory.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="custom_schema_manager_factory">
+            <connection name="default_schema_manager_factory" />
+            <connection name="custom_schema_manager_factory" schema-manager-factory="custom_factory" />
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_manager_factory.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_manager_factory.xml
@@ -8,7 +8,8 @@
 
     <config>
         <dbal default-connection="custom_schema_manager_factory">
-            <connection name="default_schema_manager_factory" />
+            <connection name="legacy_schema_manager_factory" />
+            <connection name="default_schema_manager_factory" schema-manager-factory="doctrine.dbal.default_schema_manager_factory" />
             <connection name="custom_schema_manager_factory" schema-manager-factory="custom_factory" />
         </dbal>
     </config>

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_manager_factory.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_schema_manager_factory.xml
@@ -8,8 +8,7 @@
 
     <config>
         <dbal default-connection="custom_schema_manager_factory">
-            <connection name="legacy_schema_manager_factory" />
-            <connection name="default_schema_manager_factory" schema-manager-factory="doctrine.dbal.default_schema_manager_factory" />
+            <connection name="default_schema_manager_factory" />
             <connection name="custom_schema_manager_factory" schema-manager-factory="custom_factory" />
         </dbal>
     </config>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_manager_factory.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_manager_factory.yml
@@ -1,0 +1,7 @@
+doctrine:
+    dbal:
+        default_connection: custom_schema_manager_factory
+        connections:
+            default_schema_manager_factory: ~
+            custom_schema_manager_factory:
+                schema_manager_factory: custom_factory

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_manager_factory.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_manager_factory.yml
@@ -2,6 +2,8 @@ doctrine:
     dbal:
         default_connection: custom_schema_manager_factory
         connections:
-            default_schema_manager_factory: ~
+            legacy_schema_manager_factory: ~
+            default_schema_manager_factory:
+                schema_manager_factory: doctrine.dbal.default_schema_manager_factory
             custom_schema_manager_factory:
                 schema_manager_factory: custom_factory

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_manager_factory.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_schema_manager_factory.yml
@@ -2,8 +2,6 @@ doctrine:
     dbal:
         default_connection: custom_schema_manager_factory
         connections:
-            legacy_schema_manager_factory: ~
-            default_schema_manager_factory:
-                schema_manager_factory: doctrine.dbal.default_schema_manager_factory
+            default_schema_manager_factory: ~
             custom_schema_manager_factory:
                 schema_manager_factory: custom_factory

--- a/Tests/Middleware/DebugMiddlewareTest.php
+++ b/Tests/Middleware/DebugMiddlewareTest.php
@@ -7,6 +7,7 @@ use Doctrine\Bundle\DoctrineBundle\Middleware\DebugMiddleware;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 
@@ -30,7 +31,8 @@ class DebugMiddlewareTest extends TestCase
 
     public function testData(): void
     {
-        $configuration   = new Configuration();
+        $configuration = new Configuration();
+        $configuration->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
         $debugDataHolder = new BacktraceDebugDataHolder(['default']);
         $configuration->setMiddlewares([new DebugMiddleware($debugDataHolder, null)]);
 

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -84,6 +84,7 @@ class ServiceRepositoryTest extends TestCase
                 'dbal' => [
                     'driver' => 'pdo_sqlite',
                     'charset' => 'UTF8',
+                    'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
                 ],
                 'orm' => [
                     'mappings' => [

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -49,6 +49,7 @@ class TestCase extends BaseTestCase
                             'driver' => 'pdo_mysql',
                             'charset' => 'UTF8',
                             'platform-service' => 'my.platform',
+                            'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
                         ],
                     ],
                     'default_connection' => 'default',

--- a/UPGRADE-2.9.md
+++ b/UPGRADE-2.9.md
@@ -1,0 +1,32 @@
+UPGRADE FROM 2.8 to 2.9
+=======================
+
+Configuration
+--------
+
+### Schema manager factory
+
+Due to changes and deprecations on `doctrine/dbal` 3.6+ we introduced a new option to configure a Schema manager factory.
+
+By default, it configures an instance of `Doctrine\DBAL\Schema\LegacySchemaManagerFactory` which is deprecated and won't work with the upcoming DBAL 4 anymore.
+
+To fix this deprecation you need to use an instance of `Doctrine\DBAL\Schema\DefaultSchemaManagerFactory` (or possibly a custom implementation that suits your needs).
+
+Before:
+```yaml
+doctrine:
+    dbal:
+        connections:
+            default: ~
+```
+
+After:
+```yaml
+doctrine:
+    dbal:
+        connections:
+            default:
+                schema_manager_factory: doctrine.dbal.default_schema_manager_factory
+```
+
+

--- a/UPGRADE-2.9.md
+++ b/UPGRADE-2.9.md
@@ -8,9 +8,10 @@ Configuration
 
 Due to changes and deprecations on `doctrine/dbal` 3.6+ we introduced a new option to configure a Schema manager factory.
 
-Not setting this option is deprecated and won't work with the upcoming DBAL 4 anymore.
+On DBAL 3 the default factory is an instance of `Doctrine\DBAL\Schema\LegacySchemaManagerFactory`. 
+For the upcoming DBAL 4 release the default will change to `Doctrine\DBAL\Schema\DefaultSchemaManagerFactory`.
 
-To fix this deprecation you need to configure an instance of `Doctrine\DBAL\Schema\DefaultSchemaManagerFactory` (or possibly a custom implementation that suits your needs).
+To prepare for DBAL 4 and fix DBAL related deprecations we recommend changing the configuration to use the new factory.
 
 Before:
 ```yaml

--- a/UPGRADE-2.9.md
+++ b/UPGRADE-2.9.md
@@ -8,9 +8,9 @@ Configuration
 
 Due to changes and deprecations on `doctrine/dbal` 3.6+ we introduced a new option to configure a Schema manager factory.
 
-By default, it configures an instance of `Doctrine\DBAL\Schema\LegacySchemaManagerFactory` which is deprecated and won't work with the upcoming DBAL 4 anymore.
+Not setting this option is deprecated and won't work with the upcoming DBAL 4 anymore.
 
-To fix this deprecation you need to use an instance of `Doctrine\DBAL\Schema\DefaultSchemaManagerFactory` (or possibly a custom implementation that suits your needs).
+To fix this deprecation you need to configure an instance of `Doctrine\DBAL\Schema\DefaultSchemaManagerFactory` (or possibly a custom implementation that suits your needs).
 
 Before:
 ```yaml

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/dbal": "^3.4.0",
+        "doctrine/dbal": "^3.6.0",
         "doctrine/persistence": "^2.2 || ^3",
         "doctrine/sql-formatter": "^1.0.1",
         "symfony/cache": "^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "conflict": {
         "doctrine/annotations": ">=3.0",
         "doctrine/orm": "<2.11 || >=3.0",
-        "twig/twig": "<1.34 || >=2.0,<2.4"
+        "twig/twig": "<1.34 || >=2.0 <2.4"
     },
     "suggest": {
         "ext-pdo": "*",


### PR DESCRIPTION
Will get rid of this deprecation

```
  1x: Not configuring a schema manager factory is deprecated. Use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory which is going to be the default in DBAL 4. (Connection.php:225 called by DriverManager.php:193, https://github.com/doctrine/dbal/issues/5812, package doctrine/dbal)
```

Also see https://github.com/doctrine/dbal/pull/5876