### PR TITLE
improve DoctrineDataCollectorTest and fix some deprecations

### DIFF
--- a/DataCollector/DoctrineDataCollector.php
+++ b/DataCollector/DoctrineDataCollector.php
@@ -73,10 +73,7 @@ class DoctrineDataCollector extends BaseCollector
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function collect(Request $request, Response $response, ?Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         parent::collect($request, $response, $exception);
 

--- a/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -87,7 +87,16 @@ class DoctrineDataCollectorTest extends TestCase
     {
         $debugDataHolder = new DebugDataHolder();
 
+        /**
+         * @psalm-suppress InternalClass
+         * @psalm-suppress InternalMethod
+         */
         $debugDataHolder->addQuery('default', new Query('SELECT * FROM foo WHERE bar = :bar'));
+
+        /**
+         * @psalm-suppress InternalClass
+         * @psalm-suppress InternalMethod
+         */
         $debugDataHolder->addQuery('default', new Query('SELECT * FROM foo WHERE bar = :bar'));
 
         $collector = $this->createCollector([], true, $debugDataHolder);
@@ -97,6 +106,10 @@ class DoctrineDataCollectorTest extends TestCase
         $this->assertSame('SELECT * FROM foo WHERE bar = :bar', $groupedQueries['default'][0]['sql']);
         $this->assertSame(2, $groupedQueries['default'][0]['count']);
 
+        /**
+         * @psalm-suppress InternalClass
+         * @psalm-suppress InternalMethod
+         */
         $debugDataHolder->addQuery('default', new Query('SELECT * FROM bar'));
         $collector->collect(new Request(), new Response());
         $groupedQueries = $collector->getGroupedQueries();

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -1025,9 +1025,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         }
     }
 
-    /**
-     * @group legacy
-     */
+    /** @group legacy */
     public function testWellKnownSchemaFilterDefaultTables(): void
     {
         $container = $this->getContainer([]);
@@ -1063,9 +1061,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertTrue($filter->__invoke('anything_else'));
     }
 
-    /**
-     * @group legacy
-     */
+    /** @group legacy */
     public function testWellKnownSchemaFilterOverriddenTables(): void
     {
         $container = $this->getContainer([]);

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -75,5 +75,15 @@
                 <file name="Repository/ServiceEntityRepository.php"/>
             </errorLevel>
         </DuplicateClass>
+        <InternalClass>
+            <errorLevel type="suppress">
+                <file name="Tests/DataCollector/DoctrineDataCollectorTest.php"/>
+            </errorLevel>
+        </InternalClass>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <file name="Tests/DataCollector/DoctrineDataCollectorTest.php"/>
+            </errorLevel>
+        </InternalMethod>
     </issueHandlers>
 </psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -75,15 +75,5 @@
                 <file name="Repository/ServiceEntityRepository.php"/>
             </errorLevel>
         </DuplicateClass>
-        <InternalClass>
-            <errorLevel type="suppress">
-                <file name="Tests/DataCollector/DoctrineDataCollectorTest.php"/>
-            </errorLevel>
-        </InternalClass>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <file name="Tests/DataCollector/DoctrineDataCollectorTest.php"/>
-            </errorLevel>
-        </InternalMethod>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
Fixes

```
Remaining self deprecation notices (1)

  1x: Method "Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector::collect()" might add "void" as a native return type declaration in the future. Do the same in child class "Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in DoctrineDataCollectorTest::testCollectEntities from Doctrine\Bundle\DoctrineBundle\Tests\DataCollector

Remaining indirect deprecation notices (2)

  1x: Passing an instance of Doctrine\ORM\Mapping\ClassMetadataInfo to Doctrine\ORM\Tools\SchemaValidator::validateClass is deprecated, please pass a ClassMetadata instance instead. (SchemaValidator.php:82 called by DoctrineDataCollector.php:116, https://github.com/doctrine/orm/pull/249, package doctrine/orm)
    1x in DoctrineDataCollectorTest::testCollectEntities from Doctrine\Bundle\DoctrineBundle\Tests\DataCollector

  1x: DebugStack is deprecated. (DebugStack.php:41 called by Generator.php:715, https://github.com/doctrine/dbal/pull/4967, package doctrine/dbal)
    1x in DoctrineDataCollectorTest::testGetGroupedQueries from Doctrine\Bundle\DoctrineBundle\Tests\DataCollector
``` 