### PR TITLE
Fix icon display in WDT when profiler_markup_version >= 3

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -8,7 +8,11 @@
         {% set icon %}
             {% set status = collector.invalidEntityCount > 0 ? 'red' : collector.querycount > 50 ? 'yellow' %}
 
-            <span class="icon">{{ include('@Doctrine/Collector/' ~ (profiler_markup_version < 3 ? 'icon' : 'database') ~ '.svg') }}</span>
+            {% if profiler_markup_version >= 3 %}
+                {{ include('@Doctrine/Collector/database.svg') }}
+            {% else %}
+                <span class="icon">{{ include('@Doctrine/Collector/icon.svg') }}</span>
+            {% endif %}
 
             {% if collector.querycount == 0 and collector.invalidEntityCount > 0 %}
                 <span class="sf-toolbar-value">{{ collector.invalidEntityCount }}</span>


### PR DESCRIPTION
Hi,

This PR fixes a little issue when displaying the icon in the WDT with profiler version >= 3.

| Before | After |
| --- | --- |
| ![wdt-before](https://user-images.githubusercontent.com/3929498/227881534-3bae2030-4cfe-4f2f-937a-9f66fc18055c.png) | ![wdt-after](https://user-images.githubusercontent.com/3929498/227881586-b8bd3b37-0f64-4cd1-8029-718a3218a025.png) |