### PR TITLE
update deprecation baseline

### DIFF
--- a/.github/workflows/test-dev-stability.yml
+++ b/.github/workflows/test-dev-stability.yml
@@ -52,4 +52,4 @@ jobs:
           composer-options: "--prefer-dist"
 
       - name: "Run PHPUnit"
-        run: "SYMFONY_DEPRECATIONS_HELPER=${{env.GITHUB_WORKSPACE}}/tests/baseline-ignore vendor/bin/phpunit"
+        run: "vendor/bin/phpunit"

--- a/Tests/baseline-ignore
+++ b/Tests/baseline-ignore
@@ -1,2 +1,1 @@
-%Method "ArrayAccess::(offsetExists|offsetGet|offsetSet|offsetUnset)+\(\)" might add "\w+" as a native return type declaration in the future. Do the same in implementation "Doctrine\\\Common\\Collections\\ArrayCollection" now to avoid errors or add an explicit @return annotation to suppress this message\.%
-%Method "Countable::count\(\)" might add "int" as a native return type declaration in the future. Do the same in implementation "Doctrine\\Common\\Collections\\ArrayCollection" now to avoid errors or add an explicit @return annotation to suppress this message\.%
+%Using XML mapping driver with XSD validation disabled is deprecated%


### PR DESCRIPTION
The baseline was outdated and used the wrong syntax on the scheduled job