### PR TITLE
Fix configuration inheritance to not override default connection/EM values

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -45,6 +45,7 @@ use Symfony\Bridge\Doctrine\SchemaListener\RememberMeTokenProviderDoctrineSchema
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -62,6 +63,7 @@ use Symfony\Component\VarExporter\LazyGhostTrait;
 
 use function array_intersect_key;
 use function array_keys;
+use function array_merge;
 use function class_exists;
 use function interface_exists;
 use function is_dir;
@@ -88,17 +90,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = $this->getConfiguration($configs, $container);
-        $config        = $this->processConfiguration($configuration, $configs);
+        $config        = $this->processConfigurationPrependingDefaults($configuration, $configs);
 
         if (! empty($config['dbal'])) {
-            // if no DB connection defined, append an empty one for the default
-            // connection name in order to make Symfony Config resolve the
-            // default values
-            if (empty($config['dbal']['connections'])) {
-                $configs[] = ['dbal' => ['connections' => [($config['dbal']['default_connection'] ?? 'default') => []]]];
-                $config    = $this->processConfiguration($configuration, $configs);
-            }
-
             $this->dbalLoad($config['dbal'], $container);
 
             $this->loadMessengerServices($container);
@@ -112,14 +106,41 @@ class DoctrineExtension extends AbstractDoctrineExtension
             throw new LogicException('Configuring the ORM layer requires to configure the DBAL layer as well.');
         }
 
-        // if no EM defined, append an empty one for the default EM name in
-        // order to make Symfony Config resolve the default values
-        if (empty($config['orm']['entity_managers'])) {
-            $configs[] = ['orm' => ['entity_managers' => [($config['orm']['default_entity_manager'] ?? 'default') => []]]];
-            $config    = $this->processConfiguration($configuration, $configs);
+        $this->ormLoad($config['orm'], $container);
+    }
+
+    /**
+     * Process user configuration and adds a default DBAL connection and/or a
+     * default EM if required, then process again the configuration to get
+     * default values for each.
+     *
+     * @param array<array<mixed>> $configs
+     *
+     * @return array<mixed>
+     */
+    private function processConfigurationPrependingDefaults(ConfigurationInterface $configuration, array $configs): array
+    {
+        $config      = $this->processConfiguration($configuration, $configs);
+        $configToAdd = [];
+
+        // if no DB connection defined, prepend an empty one for the default
+        // connection name in order to make Symfony Config resolve the default
+        // values
+        if (isset($config['dbal']) && empty($config['dbal']['connections'])) {
+            $configToAdd['dbal'] = ['connections' => [($config['dbal']['default_connection'] ?? 'default') => []]];
         }
 
-        $this->ormLoad($config['orm'], $container);
+        // if no EM defined, prepend an empty one for the default EM name in
+        // order to make Symfony Config resolve the default values
+        if (isset($config['orm']) && empty($config['orm']['entity_managers'])) {
+            $configToAdd['orm'] = ['entity_managers' => [($config['orm']['default_entity_manager'] ?? 'default') => []]];
+        }
+
+        if (! $configToAdd) {
+            return $config;
+        }
+
+        return $this->processConfiguration($configuration, array_merge([$configToAdd], $configs));
     }
 
     /**

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -91,6 +91,14 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $config        = $this->processConfiguration($configuration, $configs);
 
         if (! empty($config['dbal'])) {
+            // if no DB connection defined, append an empty one for the default
+            // connection name in order to make Symfony Config resolve the
+            // default values
+            if (empty($config['dbal']['connections'])) {
+                $configs[] = ['dbal' => ['connections' => [($config['dbal']['default_connection'] ?? 'default') => []]]];
+                $config    = $this->processConfiguration($configuration, $configs);
+            }
+
             $this->dbalLoad($config['dbal'], $container);
 
             $this->loadMessengerServices($container);
@@ -102,6 +110,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         if (empty($config['dbal'])) {
             throw new LogicException('Configuring the ORM layer requires to configure the DBAL layer as well.');
+        }
+
+        // if no EM defined, append an empty one for the default EM name in
+        // order to make Symfony Config resolve the default values
+        if (empty($config['orm']['entity_managers'])) {
+            $configs[] = ['orm' => ['entity_managers' => [($config['orm']['default_entity_manager'] ?? 'default') => []]]];
+            $config    = $this->processConfiguration($configuration, $configs);
         }
 
         $this->ormLoad($config['orm'], $container);


### PR DESCRIPTION
Hi there!

I recently unveiled a weird behavior when doing some cleanup on a project I work on.
Long story short, we have several connections, use a different name than `default` for the main one, and because we have config files defining only `doctrine.dbal.types`, the `default_connection` ends up being reset to `default`. 

While trying to fix this I realized this is similar to #1337 (just another section of the config really), so I try to fix #1337 at the same time (therefore being an alternative to #1356).

The true nature of the fix is mostly not to run the custom pre-normalization process but then this makes the default empty configuration not work anymore.
So we move the side effect of this process (creating an empty 'default' connection configuration) out in the Extension and we rerun the normalization process again so that the default values for connections and entity manager get resolved properly.

This should be considered a bugfix, but I'm not really sure which branch to target in that case, let me know if you want me to rebase and target another branch instead 