### PR TITLE
[DoctrineBundle] remove doctrine.event_subscriber tag and replace by doctrine.event_listener tag

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
 use Doctrine\ORM\Configuration as OrmConfiguration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand;
@@ -554,7 +555,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 ]);
             }
 
-            $def->addTag('doctrine.event_subscriber');
+            $def
+                ->addTag('doctrine.event_listener', ['event' => Events::loadClassMetadata])
+                ->addTag('doctrine.event_listener', ['event' => Events::onClassMetadataNotFound]);
         }
 
         $container->registerForAutoconfiguration(ServiceEntityRepositoryInterface::class)

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -890,7 +890,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $tags = $definition->getTags();
         unset($tags['container.no_preload']);
-        $this->assertEquals(['doctrine.event_subscriber' => [[]]], $tags);
+        $this->assertEquals(['doctrine.event_listener' => [['event' => 'loadClassMetadata'], ['event' => 'onClassMetadataNotFound']]], $tags);
     }
 
     public function testSchemaIgnoreClasses(): void


### PR DESCRIPTION
Remove doctrine.event_subscribers tag in bundle and replace them with doctrine.event_listener tag.

following https://github.com/symfony/symfony/pull/49918