### PR TITLE
Add a new `use_trigger_error_for_deprecations` config setting

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -65,6 +65,12 @@ class Configuration implements ConfigurationInterface
         $this->addDbalSection($rootNode);
         $this->addOrmSection($rootNode);
 
+        $rootNode
+            ->children()
+            ->booleanNode('use_trigger_error_for_deprecations')
+            ->defaultFalse()
+            ->info('Setting this to "true" will make Doctrine use trigger_error() to report deprecations, just like Symfony does');
+
         return $treeBuilder;
     }
 

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -92,6 +92,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $configuration = $this->getConfiguration($configs, $container);
         $config        = $this->processConfigurationPrependingDefaults($configuration, $configs);
 
+        $container->setParameter('doctrine.use_trigger_error_for_deprecations', $config['use_trigger_error_for_deprecations']);
+
         if (! empty($config['dbal'])) {
             $this->dbalLoad($config['dbal'], $container);
 

--- a/DoctrineBundle.php
+++ b/DoctrineBundle.php
@@ -14,6 +14,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RemoveProfilerCo
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\WellKnownSchemaFilterPass;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Autoloader;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
@@ -85,6 +86,10 @@ class DoctrineBundle extends Bundle
     /** @return void */
     public function boot()
     {
+        if ($this->container->getParameter('doctrine.use_trigger_error_for_deprecations')) {
+            Deprecation::enableWithTriggerError();
+        }
+
         // Register an autoloader for proxies to avoid issues when unserializing them
         // when the ORM is used.
         if (! $this->container->hasParameter('doctrine.orm.proxy_namespace')) {


### PR DESCRIPTION
This adds a new `use_trigger_error_for_deprecations` config setting that can be used to make `doctrine/deprecations` report deprecations through `trigger_error`.

That way, those deprecations should show up in the same place/way as other Symfony deprecations.

See #1662 for the preceding discussion.

#### TODO

- [ ] Document the new setting
- [ ] Add UPGRADING notice?
