### PR TITLE
[DoctrineBundle] deprecate EventSubscriberInterface

### DIFF
--- a/EventSubscriber/EventSubscriberInterface.php
+++ b/EventSubscriber/EventSubscriberInterface.php
@@ -4,6 +4,9 @@ namespace Doctrine\Bundle\DoctrineBundle\EventSubscriber;
 
 use Doctrine\Common\EventSubscriber;
 
+/**
+ * @deprecated use the {@see AsDoctrineListener} attribute instead
+ */
 interface EventSubscriberInterface extends EventSubscriber
 {
 }

--- a/UPGRADE-2.10.md
+++ b/UPGRADE-2.10.md
@@ -1,0 +1,6 @@
+UPGRADE FROM 2.9 to 2.10
+========================
+
+### Deprecations
+
+- `Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface` has been deprecated. Use the `#[AsDoctrineListener]` attribute instead.


### PR DESCRIPTION
Doctrine subscribers are flawed because they force eager loading by design so the goal since https://github.com/symfony/symfony/pull/49918 and https://github.com/doctrine/DoctrineBundle/pull/1650 is to push projects to use attributes to register their listeners through autoconfiguration. In order to achieve this goal, this PR propose to deprecate the EventSubscriberInterface available in doctrine/doctrine-bundle.