### PR TITLE
fix Doctrine deprecations

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -742,6 +742,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ->setArguments([
                 new Reference(sprintf('doctrine.dbal.%s_connection', $entityManager['connection'])),
                 new Reference(sprintf('doctrine.orm.%s_configuration', $entityManager['name'])),
+                new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $entityManager['connection'])),
             ])
             ->setConfigurator([new Reference($managerConfiguratorName), 'configure']);
 

--- a/Tests/Dbal/Logging/BacktraceLoggerTest.php
+++ b/Tests/Dbal/Logging/BacktraceLoggerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 use function current;
 
+/** @group legacy */
 class BacktraceLoggerTest extends TestCase
 {
     public function testBacktraceLogged(): void

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -296,6 +296,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICConstructorArguments($definition, [
             new Reference('doctrine.dbal.default_connection'),
             new Reference('doctrine.orm.default_configuration'),
+            new Reference('doctrine.dbal.default_connection.event_manager'),
         ]);
     }
 
@@ -334,6 +335,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICConstructorArguments($definition, [
             new Reference('doctrine.dbal.default_connection'),
             new Reference('doctrine.orm.default_configuration'),
+            new Reference('doctrine.dbal.default_connection.event_manager'),
         ]);
     }
 
@@ -370,6 +372,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICConstructorArguments($definition, [
             new Reference('doctrine.dbal.default_connection'),
             new Reference('doctrine.orm.default_configuration'),
+            new Reference('doctrine.dbal.default_connection.event_manager'),
         ]);
 
         $configDef = $container->getDefinition('doctrine.orm.default_configuration');
@@ -1424,8 +1427,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $calls = $definition->getMethodCalls();
         if (! isset($calls[$pos][0])) {
             $this->fail(sprintf('Method call at position %s not found!', $pos));
-
-            return;
         }
 
         $this->assertEquals($methodName, $calls[$pos][0], "Method '" . $methodName . "' is expected to be called at position " . $pos . '.');

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -597,6 +597,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertDICConstructorArguments($definition, [
             new Reference('doctrine.dbal.default_connection'),
             new Reference('doctrine.orm.default_configuration'),
+            new Reference('doctrine.dbal.default_connection.event_manager'),
         ]);
     }
 
@@ -645,6 +646,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertDICConstructorArguments($definition, [
             new Reference('doctrine.dbal.default_connection'),
             new Reference('doctrine.orm.default_configuration'),
+            new Reference('doctrine.dbal.default_connection.event_manager'),
         ]);
 
         $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');
@@ -680,6 +682,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertDICConstructorArguments($definition, [
             new Reference('doctrine.dbal.default_connection'),
             new Reference('doctrine.orm.default_configuration'),
+            new Reference('doctrine.dbal.default_connection.event_manager'),
         ]);
 
         $slcDefinition = $container->getDefinition('doctrine.orm.default_second_level_cache.default_cache_factory');

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -53,6 +53,7 @@ class TestKernel extends Kernel
                     'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
                 ],
                 'orm' => [
+                    'report_fields_where_declared' => true,
                     'auto_generate_proxy_classes' => true,
                     'mappings' => [
                         'RepositoryServiceBundle' => [


### PR DESCRIPTION
Partly fixes https://github.com/doctrine/DoctrineBundle/issues/1665

- [ ] The "url" connection parameter is deprecated (@stof is looking into it)
- [x] DebugStack is deprecated.
- [x] In ORM 3.0, the AttributeDriver will report fields for the classes where they are declared. This may uncover invalid mapping configurations. To opt into the new mode today, set the "reportFieldsWhereDeclared" constructor parameter to true.
- [x] Doctrine\DBAL\Connection::getEventManager is deprecated
- [ ] Doctrine\DBAL\Platforms\AbstractPlatform::usesSequenceEmulatedIdentityColumns is deprecated (See https://github.com/doctrine/orm/issues/10744) 