### PR TITLE
Use the DsnParser to handle the url option

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsMiddleware;
 use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
+use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use Doctrine\Bundle\DoctrineBundle\Dbal\ManagerRegistryAwareConnectionProvider;
 use Doctrine\Bundle\DoctrineBundle\Dbal\RegexSchemaAssetFilter;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
@@ -171,6 +172,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $container->setAlias('doctrine.dbal.event_manager', new Alias(sprintf('doctrine.dbal.%s_connection.event_manager', $this->defaultConnection), false));
 
         $container->setParameter('doctrine.dbal.connection_factory.types', $config['types']);
+
+        $container->getDefinition('doctrine.dbal.connection_factory.dsn_parser')->setArgument(0, array_merge(ConnectionFactory::DEFAULT_SCHEME_MAP, $config['driver_schemes']));
 
         $connections = [];
 

--- a/Resources/config/dbal.xml
+++ b/Resources/config/dbal.xml
@@ -28,6 +28,11 @@
 
         <service id="doctrine.dbal.connection_factory" class="%doctrine.dbal.connection_factory.class%">
             <argument>%doctrine.dbal.connection_factory.types%</argument>
+            <argument type="service" id="doctrine.dbal.connection_factory.dsn_parser" />
+        </service>
+
+        <service id="doctrine.dbal.connection_factory.dsn_parser" class="Doctrine\DBAL\Tools\DsnParser">
+            <argument type="collection" />
         </service>
 
         <service id="doctrine.dbal.connection" class="Doctrine\DBAL\Connection" abstract="true">

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -89,11 +89,20 @@
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="connection" type="connection" />
             <xsd:element name="type" type="named_scalar" />
+            <xsd:element name="driver-scheme" type="driver_scheme" />
             <xsd:group ref="connection-child-config" />
         </xsd:choice>
 
         <xsd:attribute name="default-connection" type="xsd:string" />
         <xsd:attributeGroup ref="connection-config" />
+    </xsd:complexType>
+
+    <xsd:complexType name="driver_scheme">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="scheme" type="xsd:string" use="required" />
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
 
     <xsd:complexType name="option">

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -186,6 +186,16 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertSame('_test', $config['dbname_suffix']);
     }
 
+    public function testDbalDriverScheme(): void
+    {
+        $container = $this->loadContainer('dbal_driver_schemes');
+        $schemes   = $container->getDefinition('doctrine.dbal.connection_factory.dsn_parser')->getArgument(0);
+
+        $this->assertSame('my_driver', $schemes['my-scheme']);
+        $this->assertSame('pgsql', $schemes['postgresql'], 'Overriding a default mapping should be supported.');
+        $this->assertSame('pdo_mysql', $schemes['mysql']);
+    }
+
     public function testDbalLoadSinglePrimaryReplicaConnection(): void
     {
         $container = $this->loadContainer('dbal_service_single_primary_replica_connection');

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -42,6 +42,7 @@ use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -229,6 +230,16 @@ class DoctrineExtensionTest extends TestCase
         // doctrine.dbal.default_connection
         $this->assertEquals('%doctrine.default_connection%', $container->getDefinition('doctrine')->getArgument(3), '->load() overrides existing configuration options');
         $this->assertEquals('foo', $container->getParameter('doctrine.default_connection'), '->load() overrides existing configuration options');
+    }
+
+    public function testDbalInvalidDriverScheme(): void
+    {
+        $extension = new DoctrineExtension();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "doctrine.dbal.driver_schemes": Registering a scheme with the name of one of the official drivers is forbidden, as those are defined in DBAL itself. The following schemes are forbidden: pdo-mysql, pgsql');
+
+        $extension->load([['dbal' => ['driver_schemes' => ['pdo-mysql' => 'sqlite3', 'pgsql' => 'pgsql', 'other' => 'mysqli']]]], $this->getContainer());
     }
 
     public function testOrmRequiresDbal(): void

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_driver_schemes.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_driver_schemes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8">
+            <driver-scheme scheme="postgresql">pgsql</driver-scheme>
+            <driver-scheme scheme="my-scheme">my_driver</driver-scheme>
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_driver_schemes.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_driver_schemes.yml
@@ -1,0 +1,6 @@
+doctrine:
+    dbal:
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        driver_schemes:
+            postgresql: pgsql
+            my-scheme: my_driver


### PR DESCRIPTION
The DsnParser tool is used in the ConnectionFactory to support the `url` option (the processing is done in the same way than the deprecated logic in DBAL's DriverManager).

As the goal of Symfony is to be compatible out-of-the-box with cloud providers, we always register a default mapping of schemes to DBAL drivers instead of forcing to use DBAL driver names directly, as this is unlikely to happen. For instance, the Postgresql project defines URI-based connection strings that can use `postgres` or `postgresql` as scheme, so cloud providers that are not tied to Doctrine DBAL only will use one of those for sure. But DBAL has drivers named `pgsql` and `pdo_pgsql` depending on the extension name. However, unlike the old DBAL logic which forced the choice of which of the drivers is used for those standard schemes (which was the reason to deprecate those aliases in DBAL itself in favor of a configurable DsnParser), the bundle allows to configure the driver used for each scheme. The configured schemes are merged with the default map (and they win over our default map).

Closes #1665