### PR TITLE
Avoid indirect deprecations for the AttributeDriver in the testsuite

### DIFF
--- a/Tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
@@ -106,7 +106,7 @@ class IdGeneratorPassTest extends TestCase
                     'charset' => 'UTF8',
                     'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
                 ],
-                'orm' => ['mappings' => $mappings],
+                'orm' => ['mappings' => $mappings, 'report_fields_where_declared' => true],
             ],
         ], $container);
 

--- a/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -859,6 +859,7 @@ class DoctrineExtensionTest extends TestCase
                 'default_entity_manager' => 'default',
                 'entity_managers' => [
                     'default' => [
+                        'report_fields_where_declared' => true,
                         'mappings' => [
                             'AttributesBundle' => ['type' => 'attribute'],
                         ],

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -87,6 +87,7 @@ class ServiceRepositoryTest extends TestCase
                     'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
                 ],
                 'orm' => [
+                    'report_fields_where_declared' => true,
                     'mappings' => [
                         'RepositoryServiceBundle' => [
                             'type' => PHP_VERSION_ID >= 80000 ? 'attribute' : 'annotation',


### PR DESCRIPTION
this makes the contributor experience nicer when running tests if they don't get reports about them. Opting in for the new behavior in those tests does not change what the tests are intended to cover and avoids the deprecation.