### PR TITLE
Allow using connection `url` with `driver_class`

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -242,12 +242,6 @@ class ConnectionFactory
             throw new Exception('Malformed parameter "url".', 0, $e);
         }
 
-        if (isset($parsedParams['driver'])) {
-            // The requested driver from the URL scheme takes precedence
-            // over the default custom driver from the connection parameters (if any).
-            unset($params['driverClass']);
-        }
-
         $params = array_merge($params, $parsedParams);
 
         // If a schemeless connection URL is given, we require a default driver or default custom driver

--- a/Tests/ConnectionFactoryTest.php
+++ b/Tests/ConnectionFactoryTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 
 use function array_intersect_key;
+use function get_class;
 
 class ConnectionFactoryTest extends TestCase
 {
@@ -155,6 +156,29 @@ class ConnectionFactoryTest extends TestCase
 
         $this->assertSame('primary_test', $parsedParams['primary']['dbname']);
         $this->assertSame('replica_test', $parsedParams['replica']['replica1']['dbname']);
+    }
+
+    public function testCanUseDriverClassWithUrl(): void
+    {
+        $driver     = $this->createMock(Driver::class);
+        $connection = (new ConnectionFactory([]))->createConnection(
+            [
+                'driverClass' => get_class($driver),
+                'url' => 'foo://root:pAssword@database:3306/main',
+                'serverVersion' => '6',
+            ],
+            $this->configuration
+        );
+
+        $params = $connection->getParams();
+
+        $this->assertSame(get_class($driver), $params['driverClass']);
+        $this->assertSame('foo', $params['driver']);
+        $this->assertSame('root', $params['user']);
+        $this->assertSame('pAssword', $params['password']);
+        $this->assertSame(3306, $params['port']);
+        $this->assertSame('main', $params['dbname']);
+        $this->assertSame('6', $params['serverVersion']);
     }
 }
 


### PR DESCRIPTION
2.10 (#1669) removed passing the `url` param to custom drivers. Instead, it parses it with `DsnParser` from dbal. It's not currently possible to use a custom driver and have the url parsed. You end up with an unknown driver exception because the custom `driver_class` is not used.

I propose we allow `driver_class` to take precedence over any driver parsed by `DsnParser`.