### PR TITLE
Add a `priority` attribute on `doctrine.middleware` tag and `#[AsMiddleware]` attribute

### DIFF
--- a/Attribute/AsMiddleware.php
+++ b/Attribute/AsMiddleware.php
@@ -10,6 +10,7 @@ class AsMiddleware
     /** @param string[] $connections */
     public function __construct(
         public array $connections = [],
+        public ?int $priority = null,
     ) {
     }
 }

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -207,14 +207,16 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $container->registerForAutoconfiguration(MiddlewareInterface::class)->addTag('doctrine.middleware');
 
         $container->registerAttributeForAutoconfiguration(AsMiddleware::class, static function (ChildDefinition $definition, AsMiddleware $attribute) {
+            $priority = isset($attribute->priority) ? ['priority' => $attribute->priority] : [];
+
             if ($attribute->connections === []) {
-                $definition->addTag('doctrine.middleware');
+                $definition->addTag('doctrine.middleware', $priority);
 
                 return;
             }
 
             foreach ($attribute->connections as $connName) {
-                $definition->addTag('doctrine.middleware', ['connection' => $connName]);
+                $definition->addTag('doctrine.middleware', array_merge($priority, ['connection' => $connName]));
             }
         });
 

--- a/Resources/doc/middlewares.rst
+++ b/Resources/doc/middlewares.rst
@@ -98,14 +98,45 @@ Let's limit our middleware to a connection named ``legacy``:
         }
     }
 
+If you register multiple middlewares in your application, they will be executed
+in the order they were registered. If some middleware needs to be executed
+before another, you can set priority through the ``AsMiddleware`` PHP attribute.
+This priority can be any integer, positive or negative. The higher the priority,
+the earlier the middleware is executed. If no priority is defined, the priority
+is considered 0. Let's make sure our middleware is the first middleware
+executed, so that we don't set up debugging or logging if the connection will
+be prevented:
+
+.. code-block:: php
+
+    <?php
+
+    namespace App\Middleware;
+
+    use Doctrine\Bundle\DoctrineBundle\Attribute\AsMiddleware;
+    use Doctrine\DBAL\Driver;
+    use Doctrine\DBAL\Driver\Middleware;
+
+    #[AsMiddleware(priority: 10)]
+    class PreventRootConnectionMiddleware implements Middleware
+    {
+        public function wrap(Driver $driver): Driver
+        {
+            return new PreventRootConnectionDriver($driver);
+        }
+    }
+
+``priority`` and ``connections`` can be used together to restrict a middleware
+to a specific connection while changing its priority.
+
 All the examples presented above assume ``autoconfigure`` is enabled.
 If ``autoconfigure`` is disabled, the ``doctrine.middleware`` tag must be
 added to the middleware. This tag supports a ``connections`` attribute to
-limit the scope of the middleware.
+limit the scope of the middleware and a ``priority`` attribute to change
+the execution order of the registered middlewares.
 
 .. note::
 
     Middlewares have been introduced in version 3.2 of ``doctrine/dbal``
     and at least the 2.6 version of ``doctrine/doctrine-bundle`` is needed
     to integrate them in Symfony as shown above.
-


### PR DESCRIPTION
Currently, the ordering of the middlewares is only driven by the order in which they were registered in the container, which is not very predictable and sometimes impossible to modify (if one middleware is injected by another bundle for instance). By setting the priority on the `doctrine.middleware` tag, this ordering can be modified more easily.