### PR TITLE
Expose the XSD validation in the DoctrineOrmMappingsPass

### DIFF
--- a/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -66,10 +66,10 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
      *
      * @return self
      */
-    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
+    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [], bool $enableXsdValidation = false)
     {
         $locator = new Definition(SymfonyFileLocator::class, [$namespaces, '.orm.xml']);
-        $driver  = new Definition(XmlDriver::class, [$locator]);
+        $driver  = new Definition(XmlDriver::class, [$locator, null, $enableXsdValidation]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }


### PR DESCRIPTION
Closes https://github.com/doctrine/DoctrineBundle/issues/1647

This allows bundles registering a custom mapping through the DoctrineOrmMappingsPass to opt-in for the XSD validation, which was forgotten when adding support for this opt-in in other places in the bundle.