### PR TITLE
Fix SQL syntax highlight on Symfony 6.3

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -102,6 +102,16 @@
         .time-bar { display: block; position: absolute; top: 0; left: 0; bottom: 0; background: #e0e0e0; }
         .sql-runnable.sf-toggle-content.sf-toggle-visible { display: flex; flex-direction: column; }
         .sql-runnable button { align-self: end; }
+        {% if profiler_markup_version >= 3 %}
+        .highlight .keyword   { color: var(--highlight-keyword); font-weight: bold; }
+        .highlight .word      { color: var(--color-text); }
+        .highlight .variable  { color: var(--highlight-variable); }
+        .highlight .symbol    { color: var(--color-text); }
+        .highlight .comment   { color: var(--highlight-comment); }
+        .highlight .string    { color: var(--highlight-string); }
+        .highlight .number    { color: var(--highlight-constant); font-weight: bold; }
+        .highlight .error     { color: var(--highlight-error); }
+        {% endif %}
     </style>
 
     <h2>Query Metrics</h2>

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -101,6 +101,7 @@ class ProfilerTest extends BaseTestCase
             'profile' => $profile,
             'collector' => $this->collector,
             'queries' => $this->debugDataHolder->getData(),
+            'profiler_markup_version' => 3,
         ]);
 
         $expectedEscapedSql = 'SELECT&#x0A;&#x20;&#x20;&#x2A;&#x0A;FROM&#x0A;&#x20;&#x20;foo&#x0A;WHERE&#x0A;&#x20;&#x20;bar&#x20;IN&#x20;&#x28;&#x3F;,&#x20;&#x3F;&#x29;&#x0A;&#x20;&#x20;AND&#x20;&quot;&quot;&#x20;&gt;&#x3D;&#x20;&quot;&quot;';


### PR DESCRIPTION
The SQL syntax highlighting is broken on Symfony 6.3:

![image](https://github.com/doctrine/DoctrineBundle/assets/2445045/8c71248b-03a7-4b36-8baa-19201d11a61d)

The CSS was removed in https://github.com/symfony/symfony/pull/48757 (https://github.com/symfony/symfony/commit/b5a10cebca5f5eb90150c613ca2de08b8f5e2c18).

Since the idea of the PR was to move panel specific styles to their respective template files, it'd make sense to move this CSS to the Doctrine bundle. The only problem with this approach is that on Symfony 6.2 the CSS would be displayed twice, once by Symfony's WebProfilerBundle and once by the DoctrineBundle. I don't think that's a big issue however.

Maybe @javiereguiluz has some input?