### PR TITLE
Add missing "kernel.reset" tag on BacktraceDebugDataHolder service

### DIFF
--- a/Resources/config/middlewares.xml
+++ b/Resources/config/middlewares.xml
@@ -11,6 +11,7 @@
         </service>
         <service id="doctrine.debug_data_holder" class="Doctrine\Bundle\DoctrineBundle\Middleware\BacktraceDebugDataHolder">
             <argument type="collection" />
+            <tag name="kernel.reset" method="reset" />
         </service>
         <service id="doctrine.dbal.debug_middleware" class="Doctrine\Bundle\DoctrineBundle\Middleware\DebugMiddleware" abstract="true">
             <argument type="service" id="doctrine.debug_data_holder" />


### PR DESCRIPTION
Without this patch, it cause a huge memory leak in batch