### PR TITLE
Ensure connection is closed before deleting sqlite file

### DIFF
--- a/Command/DropDatabaseDoctrineCommand.php
+++ b/Command/DropDatabaseDoctrineCommand.php
@@ -104,6 +104,7 @@ EOT
             if ($shouldDropDatabase) {
                 if ($schemaManager instanceof SqliteSchemaManager) {
                     // dropDatabase() is deprecated for Sqlite
+                    $connection->close();
                     if (file_exists($name)) {
                         unlink($name);
                     }


### PR DESCRIPTION
This should fix inability to drop sqlite DB on Windows OS

Fixes https://github.com/doctrine/DoctrineBundle/issues/1658