### PR TITLE
Don't mock the service container

### DIFF
--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -10,9 +10,9 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use RuntimeException;
 use stdClass;
+use Symfony\Component\DependencyInjection\Container;
 
 use function interface_exists;
 
@@ -127,19 +127,13 @@ EXCEPTION
     }
 
     /** @param array<string, object> $services */
-    private function createContainer(array $services): ContainerInterface
+    private function createContainer(array $services): Container
     {
-        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
-        $container->expects($this->any())
-            ->method('has')
-            ->willReturnCallback(static function ($id) use ($services) {
-                return isset($services[$id]);
-            });
-        $container->expects($this->any())
-            ->method('get')
-            ->willReturnCallback(static function ($id) use ($services) {
-                return $services[$id];
-            });
+        $container = new Container();
+
+        foreach ($services as $id => $service) {
+            $container->set($id, $service);
+        }
 
         return $container;
     }


### PR DESCRIPTION
Spotted while reviewing #1692.

Mocking the service container for tests requires us to write some pretty complicated mocking logic for little to no gain. I think, our tests are easier to comprehend and maintain, if we use Symfony's `Conatiner` class instead.