### PR TITLE
fix doWarmUp $buildDir deprecation

### DIFF
--- a/CacheWarmer/DoctrineMetadataCacheWarmer.php
+++ b/CacheWarmer/DoctrineMetadataCacheWarmer.php
@@ -31,8 +31,7 @@ class DoctrineMetadataCacheWarmer extends AbstractPhpFileCacheWarmer
         return false;
     }
 
-    /** @param string $cacheDir */
-    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter): bool
+    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter, ?string $buildDir = null): bool
     {
         // cache already warmed up, no needs to do it again
         if (is_file($this->phpArrayFile)) {


### PR DESCRIPTION
```
Remaining self deprecation notices (1)

  1x: The "Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer::doWarmUp()" method will require a new "string|null $buildDir" argument in the next major version of its parent class "Symfony\Bundle\FrameworkBundle\CacheWarmer\AbstractPhpFileCacheWarmer", not defining it is deprecated.
    1x in CacheCompatibilityPassTest::testCacheConfigUsingServiceDefinedByApplication from Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler
```

Also see https://github.com/doctrine/DoctrineBundle/actions/runs/6600459221/job/17930490923#step:7:44