### PR TITLE
Add support for disabling type comments in the schema

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -217,6 +217,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(true)
                     ->info('Enables collecting schema errors when profiling is enabled')
                 ->end()
+                ->booleanNode('disable_type_comments')->end()
                 ->scalarNode('server_version')->end()
                 ->scalarNode('driver_class')->end()
                 ->scalarNode('wrapper_class')->end()

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -250,6 +250,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         unset($connection['auto_commit']);
 
+        if (isset($connection['disable_type_comments'])) {
+            $configuration->addMethodCall('setDisableTypeComments', [$connection['disable_type_comments']]);
+        }
+
+        unset($connection['disable_type_comments']);
+
         if (isset($connection['schema_filter']) && $connection['schema_filter']) {
             $definition = new Definition(RegexSchemaAssetFilter::class, [$connection['schema_filter']]);
             $definition->addTag('doctrine.dbal.schema_filter', ['connection' => $name]);

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -40,6 +40,7 @@
         <xsd:attribute name="server-version" type="xsd:string" />
         <xsd:attribute name="schema-manager-factory" type="xsd:string" />
         <xsd:attribute name="use-savepoints" type="xsd:boolean" />
+        <xsd:attribute name="disable-type-comments" type="xsd:boolean" />
         <xsd:attributeGroup ref="driver-config" />
     </xsd:attributeGroup>
 

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -113,6 +113,10 @@ Configuration Reference
                         # When true, profiling also collects schema errors for each query
                         profiling_collect_schema_errors: true
 
+                        # When true, type comments are skipped in the database schema, matching the behavior of DBAL 4.
+                        # This requires using the non-deprecated schema comparison APIs of DBAL.
+                        disable_type_comments: false
+
                         server_version:       ~
                         driver_class:         ~
                         # Allows to specify a custom wrapper implementation to use.
@@ -417,6 +421,7 @@ Configuration Reference
                         profiling="%kernel.debug%"
                         profiling-collect-backtrace="false"
                         profiling-collect-schema-errors="true"
+                        disable-type-comments="false"
                         server-version=""
                         driver-class=""
                         wrapper-class=""

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -249,6 +249,26 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertCount(0, $calls);
     }
 
+    public function testDbalLoadDisableTypeComments(): void
+    {
+        $container = $this->loadContainer('dbal_disable_type_comments');
+
+        $calls = $container->getDefinition('doctrine.dbal.no_comments_connection.configuration')->getMethodCalls();
+        $calls = array_values(array_filter($calls, static fn ($call) => $call[0] === 'setDisableTypeComments'));
+        $this->assertCount(1, $calls);
+        $this->assertEquals('setDisableTypeComments', $calls[0][0]);
+        $this->assertTrue($calls[0][1][0]);
+
+        $calls = $container->getDefinition('doctrine.dbal.comments_connection.configuration')->getMethodCalls();
+        $calls = array_values(array_filter($calls, static fn ($call) => $call[0] === 'setDisableTypeComments'));
+        $this->assertCount(1, $calls);
+        $this->assertFalse($calls[0][1][0]);
+
+        $calls = $container->getDefinition('doctrine.dbal.notset_connection.configuration')->getMethodCalls();
+        $calls = array_values(array_filter($calls, static fn ($call) => $call[0] === 'setDisableTypeComments'));
+        $this->assertCount(0, $calls);
+    }
+
     /** @group legacy */
     public function testDbalSchemaManagerFactory(): void
     {

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_disable_type_comments.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_disable_type_comments.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="no_comments">
+            <connection
+                name="no_comments"
+                disable-type-comments="true" />
+            <connection
+                name="comments"
+                disable-type-comments="false" />
+            <connection
+                name="notset"
+                user="root" />
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_disable_type_comments.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_disable_type_comments.yml
@@ -1,0 +1,10 @@
+doctrine:
+    dbal:
+        default_connection: no_comments
+        connections:
+            no_comments:
+                disable_type_comments: true
+            comments:
+                disable_type_comments: false
+            notset:
+                user: root

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/dbal": "^3.6.0",
+        "doctrine/dbal": "^3.7.0",
         "doctrine/persistence": "^2.2 || ^3",
         "doctrine/sql-formatter": "^1.0.1",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",


### PR DESCRIPTION
This adds a new `disable_type_comments` boolean setting in the DBAL configuration to expose the DBAL feature added in https://github.com/doctrine/dbal/pull/6150

DBAL 3.2 implemented the platform-aware schema comparison APIs which don't rely on the DC2Type comments on columns anymore and has deprecated the old schema comparison APIs. DBAL 4.0 removes type comments entirely (In 4.0, this setter would become a no-op in the Configuration class and it will be deprecated in 4.1).
For projects that use the new APIs (and doctrine/migrations uses them), the type comment is pure noise in the DB. And it would generate a DB migration when migrating to DBAL 4 to remove those comments (which are added for any `date*_immutable` fields for instance). The new setting allows to perform the cleanup earlier than the DBAL 4 release (and avoiding to add new type comments for further schema changes until then).