### PR TITLE
add DSN schemes for mysqli, oci8 and sqlsrv

### DIFF
--- a/ConnectionFactory.php
+++ b/ConnectionFactory.php
@@ -30,12 +30,15 @@ class ConnectionFactory
         'db2'        => 'ibm_db2',
         'mssql'      => 'pdo_sqlsrv',
         'mysql'      => 'pdo_mysql',
+        'mysqli'     => 'mysqli',
         'mysql2'     => 'pdo_mysql', // Amazon RDS, for some weird reason
+        'oci8'       => 'oci8',
         'postgres'   => 'pdo_pgsql',
         'postgresql' => 'pdo_pgsql',
         'pgsql'      => 'pdo_pgsql',
         'sqlite'     => 'pdo_sqlite',
         'sqlite3'    => 'pdo_sqlite',
+        'sqlsrv'     => 'sqlsrv',
     ];
 
     /** @var mixed[][] */


### PR DESCRIPTION
This PR adds 3 schemes to be able to use the `mysqli`, `oci8` and `sqlsrv` drivers in DSN configurations.

Adding `mysqli` provides another driver option for MySQL (in addition to `pdo_mysql` which can already be used with the `mysql` and `mysql2` schemes).

Adding `oci8` and `sqlsrv` improves developer experience because these drivers were previously not supported and the validation made in the `Configuration` class prevents these schemes from being overridden (even though they were not available !).

https://github.com/doctrine/DoctrineBundle/blob/f549108cd9ee253c8f1a7c16ab866ff5e6cae81f/DependencyInjection/Configuration.php#L141-L166

Fixes #1718 