### PR TITLE
Extend dbal config and extension for result cache

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -249,6 +249,7 @@ class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                     ->defaultValue($this->getDefaultSchemaManagerFactory())
                 ->end()
+                ->scalarNode('result_cache')->end()
             ->end();
 
         // dbal < 2.11

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -303,6 +303,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $configuration->addMethodCall('setSchemaManagerFactory', [new Reference($connection['schema_manager_factory'])]);
 
+        if (isset($connection['result_cache'])) {
+            $configuration->addMethodCall('setResultCache', [new Reference($connection['result_cache'])]);
+        }
+
         if (class_exists(LegacySchemaManagerFactory::class)) {
             return;
         }

--- a/Resources/config/schema/doctrine-1.0.xsd
+++ b/Resources/config/schema/doctrine-1.0.xsd
@@ -39,6 +39,7 @@
         <xsd:attribute name="profiling-collect-schema-errors" type="xsd:string" default="true" />
         <xsd:attribute name="server-version" type="xsd:string" />
         <xsd:attribute name="schema-manager-factory" type="xsd:string" />
+        <xsd:attribute name="result-cache" type="xsd:string" />
         <xsd:attribute name="use-savepoints" type="xsd:boolean" />
         <xsd:attribute name="disable-type-comments" type="xsd:boolean" />
         <xsd:attributeGroup ref="driver-config" />

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -142,6 +142,10 @@ Configuration Reference
                             # collation:    utf8mb4_unicode_ci # When using doctrine/dbal 3.x
                             # engine:       InnoDB
 
+                        # Service identifier of a Psr\Cache\CacheItemPoolInterface implementation
+                        # to use as the cache driver for dbal result sets.
+                        result_cache:        ~
+
                         replicas:
                             # A collection of named replica connections (e.g. replica1, replica2)
                             replica1:

--- a/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -291,6 +291,26 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         );
     }
 
+    public function testDbalResultCache(): void
+    {
+        $container = $this->loadContainer('dbal_result_cache');
+
+        $this->assertDICDefinitionMethodCallOnce(
+            $container->getDefinition('doctrine.dbal.connection_with_cache_connection.configuration'),
+            'setResultCache',
+            [
+                new Reference('example.cache'),
+            ],
+        );
+
+        $this->assertDICDefinitionMethodCallCount(
+            $container->getDefinition('doctrine.dbal.connection_without_cache_connection.configuration'),
+            'setResultCache',
+            [],
+            0,
+        );
+    }
+
     public function testLoadSimpleSingleConnection(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/Tests/DependencyInjection/Fixtures/config/xml/dbal_result_cache.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/dbal_result_cache.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="connection_with_cache">
+            <connection
+                name="connection_with_cache"
+                result-cache="example.cache" />
+            <connection
+                name="connection_without_cache" />
+        </dbal>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/dbal_result_cache.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/dbal_result_cache.yml
@@ -1,0 +1,7 @@
+doctrine:
+    dbal:
+        default_connection: connection_with_cache
+        connections:
+            connection_with_cache:
+                result_cache: example.cache
+            connection_without_cache: ~


### PR DESCRIPTION
This is super embarrassing, what do I overlook, this can't be the solution for #114, right?

tested it successfully with symfony demo:

```yaml
# config/packages/cache.yaml
framework:
    cache:
        pools:
            cache.dbal:
                adapter: cache.adapter.filesystem
```
```yaml
# config/packages/doctrine.yaml
doctrine:
    dbal:
        url: '%env(resolve:DATABASE_URL)%'
        result_cache: 'cache.dbal'
```
```php
$conn->executeQuery(
    sql: 'SELECT * FROM symfony_demo_post WHERE id = :id',
    params: ['id' => 1],
    qcp: new QueryCacheProfile(
        lifetime: 3600,
        cacheKey: 'my_cache_key',
    ),
);
```