### PR TITLE
Enable report_fields_where_declared for ORM 3

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use InvalidArgumentException;
 use ReflectionClass;
@@ -661,7 +662,14 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('schema_ignore_classes')
                         ->prototype('scalar')->end()
                     ->end()
-                    ->scalarNode('report_fields_where_declared')->defaultFalse()->info('Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455.')->end()
+                    ->booleanNode('report_fields_where_declared')
+                        ->defaultValue(! class_exists(AnnotationDriver::class))
+                        ->info('Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455.')
+                        ->validate()
+                            ->ifTrue(static fn (bool $v): bool => ! class_exists(AnnotationDriver::class) && ! $v)
+                            ->thenInvalid('The setting "report_fields_where_declared" cannot be disabled for ORM 3.')
+                        ->end()
+                    ->end()
                     ->booleanNode('validate_xml_mapping')->defaultFalse()->info('Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728.')->end()
                 ->end()
                 ->children()

--- a/Tests/DependencyInjection/Fixtures/config/xml/orm_no_report_fields.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/orm_no_report_fields.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm report-fields-where-declared="false" />
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/orm_no_report_fields.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/orm_no_report_fields.yml
@@ -1,0 +1,9 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        report_fields_where_declared: false


### PR DESCRIPTION
Having `report_fields_where_declared` default to `false` does not make sense if ORM 3 is installed because it will result in a unusable driver configuration.

This PR picks a smart default depending on the installed ORM version. On top of that, it disallows opting out of the `report_fields_where_declared` setting when ORM 3 is installed.