### PR TITLE
Make deprecation warning about `enable_lazy_ghost_objects` more explicit

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -567,7 +567,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'Lazy ghost objects cannot be disabled for ORM 3.',
             );
         } elseif (PHP_VERSION_ID >= 80100) {
-            trigger_deprecation('doctrine/doctrine-bundle', '2.11', 'Not setting "enable_lazy_ghost_objects" to true is deprecated.');
+            trigger_deprecation('doctrine/doctrine-bundle', '2.11', 'Not setting "doctrine.orm.enable_lazy_ghost_objects" to true is deprecated.');
         }
 
         $options = ['auto_generate_proxy_classes', 'enable_lazy_ghost_objects', 'proxy_dir', 'proxy_namespace'];


### PR DESCRIPTION
To ease fixing the deprecation related to `enable_lazy_ghost_objects` configuration, it would be helpful if the message was a bit more explicit.

#### Currently the deprecation is shown as

![Screenshot 2023-11-23 at 16 25 02](https://github.com/doctrine/DoctrineBundle/assets/308513/33650915-a64a-4d83-a505-1a50c453aca9)

Which makes you need to look up the line [569](https://github.com/doctrine/DoctrineBundle/blob/2.11.1/DependencyInjection/DoctrineExtension.php#L569) and scroll back to the [function name](https://github.com/doctrine/DoctrineBundle/blob/2.11.1/DependencyInjection/DoctrineExtension.php#L438) to know it is part of the `orm` config.

#### Adjusted message

![Screenshot 2023-11-23 at 16 34 44](https://github.com/doctrine/DoctrineBundle/assets/308513/9cd57c5d-a668-436c-9c7b-f843f3892720)