### PR TITLE
Register the idle connection listener

### DIFF
--- a/config/dbal.xml
+++ b/config/dbal.xml
@@ -101,6 +101,12 @@
             <tag name="controller.service_arguments" />
         </service>
 
+        <service id="doctrine.dbal.idle_connection_listener" class="Symfony\Bridge\Doctrine\Middleware\IdleConnection\Listener">
+            <argument type="service" id="doctrine.dbal.connection_expiries" />
+            <argument type="service" id="service_container" />
+            <tag name="kernel.event_subscriber" />
+        </service>
+
         <service id="doctrine.dbal.default_schema_manager_factory" class="Doctrine\DBAL\Schema\DefaultSchemaManagerFactory" />
         <service id="doctrine.dbal.legacy_schema_manager_factory" class="Doctrine\DBAL\Schema\LegacySchemaManagerFactory" />
 

--- a/config/middlewares.xml
+++ b/config/middlewares.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="doctrine.dbal.connection_expiries" class="ArrayObject" />
         <service id="doctrine.dbal.logging_middleware" class="Doctrine\DBAL\Logging\Middleware" abstract="true">
             <argument type="service" id="logger" />
             <tag name="monolog.logger" channel="doctrine" />
@@ -16,6 +17,10 @@
         <service id="doctrine.dbal.debug_middleware" class="Doctrine\Bundle\DoctrineBundle\Middleware\DebugMiddleware" abstract="true">
             <argument type="service" id="doctrine.debug_data_holder" />
             <argument type="service" id="debug.stopwatch" on-invalid="null" />
+        </service>
+        <service id="doctrine.dbal.idle_connection_middleware" class="Doctrine\Bundle\DoctrineBundle\Middleware\IdleConnectionMiddleware" abstract="true">
+            <argument type="service" id="doctrine.dbal.connection_expiries" />
+            <argument /> <!-- check timing -->
         </service>
     </services>
 </container>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -43,6 +43,8 @@
                 <referencedClass name="Doctrine\ORM\ORMException"/>
                 <!-- Dropped in DBAL 4 -->
                 <referencedClass name="Doctrine\DBAL\Exception"/>
+                <!-- Available starting from Symfony 7.1 -->
+                <referencedClass name="Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver"/>
             </errorLevel>
         </UndefinedClass>
         <DuplicateClass>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -221,6 +221,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('disable_type_comments')->end()
                 ->scalarNode('server_version')->end()
+                ->integerNode('idle_connection_ttl')->defaultValue(600)->end()
                 ->scalarNode('driver_class')->end()
                 ->scalarNode('wrapper_class')->end()
                 ->booleanNode('keep_slave')

--- a/src/Middleware/IdleConnectionMiddleware.php
+++ b/src/Middleware/IdleConnectionMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Middleware;
+
+use ArrayObject;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver as IdleConnectionDriver;
+
+class IdleConnectionMiddleware implements Middleware, ConnectionNameAwareInterface
+{
+    private ArrayObject $connectionExpiries;
+    /** @var array<string, int> */
+    private array $ttlByConnection;
+    private string $connectionName;
+
+    /**
+     * @param ArrayObject<string, int> $connectionExpiries
+     * @param array<string, int>       $ttlByConnection
+     */
+    public function __construct(ArrayObject $connectionExpiries, array $ttlByConnection)
+    {
+        $this->connectionExpiries = $connectionExpiries;
+        $this->ttlByConnection    = $ttlByConnection;
+    }
+
+    public function setConnectionName(string $name): void
+    {
+        $this->connectionName = $name;
+    }
+
+    public function wrap(Driver $driver): IdleConnectionDriver
+    {
+        return new IdleConnectionDriver($driver, $this->connectionExpiries, $this->ttlByConnection[$this->connectionName], $this->connectionName);
+    }
+}

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -220,6 +220,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'host' => 'localhost',
                 'unix_socket' => '/path/to/mysqld.sock',
                 'driverOptions' => [PDO::ATTR_STRINGIFY_FETCHES => 1],
+                'idle_connection_ttl' => 600,
             ],
             $param['primary'],
         );
@@ -340,6 +341,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'driver' => 'pdo_mysql',
                 'driverOptions' => [],
                 'defaultTableOptions' => [],
+                'idle_connection_ttl' => 600,
             ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             method_exists(Connection::class, 'getEventManager')
@@ -379,6 +381,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'driver' => 'pdo_mysql',
                 'driverOptions' => [],
                 'defaultTableOptions' => [],
+                'idle_connection_ttl' => 600,
             ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             method_exists(Connection::class, 'getEventManager')
@@ -418,6 +421,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'dbname' => 'sqlite_db',
                 'memory' => true,
                 'defaultTableOptions' => [],
+                'idle_connection_ttl' => 600,
             ],
             new Reference('doctrine.dbal.default_connection.configuration'),
             method_exists(Connection::class, 'getEventManager')

--- a/tests/Middleware/IdleConnectionMiddlewareTest.php
+++ b/tests/Middleware/IdleConnectionMiddlewareTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Middleware;
+
+use ArrayObject;
+use Doctrine\Bundle\DoctrineBundle\Middleware\IdleConnectionMiddleware;
+use Doctrine\DBAL\Driver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver as IdleConnectionDriver;
+
+use function time;
+
+class IdleConnectionMiddlewareTest extends TestCase
+{
+    /** @requires function Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver::__construct */
+    public function testWrap()
+    {
+        $connectionExpiries = new ArrayObject(['connectionone' => time() - 30, 'connectiontwo' => time() + 40]);
+        $ttlByConnection    = ['connectionone' => 25, 'connectiontwo' => 60];
+
+        $middleware = new IdleConnectionMiddleware($connectionExpiries, $ttlByConnection);
+        $middleware->setConnectionName('connectionone');
+
+        $driverMock    = $this->createMock(Driver::class);
+        $wrappedDriver = $middleware->wrap($driverMock);
+
+        $this->assertInstanceOf(IdleConnectionDriver::class, $wrappedDriver);
+    }
+}


### PR DESCRIPTION
linked to https://github.com/symfony/symfony/pull/53214

This pull request introduces a solution based on the RoadRunner bundle's Doctrine ORM/ODM middleware https://github.com/Baldinof/roadrunner-bundle/blob/3.x/src/Integration/Doctrine/DoctrineORMMiddleware.php.
It checks the status of Doctrine connection, then if the connection is initialized and connected, it performs a 'ping' to check its viability. If the ping fails, it closes the connection.