### PR TITLE
fix: add doctrine common to dependency list in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "doctrine/cache": "^1.11 || ^2.0",
+        "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^3.7.0 || ^4.0",
         "doctrine/persistence": "^2.2 || ^3",
         "doctrine/sql-formatter": "^1.0.1",


### PR DESCRIPTION
As described in #1745 , the PR hopes to resolve a missing dependency on `doctrine/common` that is encountered when upgrading `doctrine/orm` to `3.0.x`.

Running `composer update --prefer-lowest` installed the `2.0.x` version of `doctrine/orm`.
Running `composer why doctrine/common` informed me that `doctrine/orm 2.14.0 requires doctrine/common (^3.0.3)`

Running `composer req doctrine/common ^3.0.3` added the dependency as resulted in the change for this PR

After implementing this change, and installing this branch into my project, the issue was resolved.