### PR TITLE
Fix the JS code in the profiler panel for Symfony 7

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -453,7 +453,6 @@
                     }).then(async function (response) {
                         targetElement.innerHTML = await response.text()
                         targetElement.setAttribute('data-sfurl', link.href)
-                        targetElement.classList.remove('loading')
                     }, function () {
                         targetElement.innerHTML = 'An error occurred while loading the query explanation.';
                     })
@@ -498,8 +497,6 @@
             });
 
             for (i = 0; i < items.length; ++i) {
-                items[i].classList.remove(i % 2 ? 'even' : 'odd');
-                items[i].classList.add(i % 2 ? 'odd' : 'even');
                 target.appendChild(items[i]);
             }
         }

--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -447,9 +447,17 @@
             var targetElement = document.getElementById(targetId);
 
             if (targetElement.style.display != 'block') {
-                Sfjs.load(targetId, link.href, null, function(xhr, el) {
-                    el.innerHTML = 'An error occurred while loading the query explanation.';
-                });
+                if (targetElement.getAttribute('data-sfurl') !== link.href) {
+                    fetch(link.href, {
+                        headers: {'X-Requested-With': 'XMLHttpRequest'}
+                    }).then(async function (response) {
+                        targetElement.innerHTML = await response.text()
+                        targetElement.setAttribute('data-sfurl', link.href)
+                        targetElement.classList.remove('loading')
+                    }, function () {
+                        targetElement.innerHTML = 'An error occurred while loading the query explanation.';
+                    })
+                }
 
                 targetElement.style.display = 'block';
                 link.innerHTML = 'Hide query explanation';
@@ -490,15 +498,15 @@
             });
 
             for (i = 0; i < items.length; ++i) {
-                Sfjs.removeClass(items[i], i % 2 ? 'even' : 'odd');
-                Sfjs.addClass(items[i], i % 2 ? 'odd' : 'even');
+                items[i].classList.remove(i % 2 ? 'even' : 'odd');
+                items[i].classList.add(i % 2 ? 'odd' : 'even');
                 target.appendChild(items[i]);
             }
         }
 
         if (navigator.clipboard) {
             document.querySelectorAll('[data-clipboard-text]').forEach(function(button) {
-                Sfjs.removeClass(button, 'hidden');
+                button.classList.remove('hidden');
                 button.addEventListener('click', function() {
                     navigator.clipboard.writeText(button.getAttribute('data-clipboard-text'));
                 })


### PR DESCRIPTION
In Symfony 7, the `Sfjs` object holding the code for the web debug toolbar is not present in the profiler pages anymore as the JS code has been split.
This replaces its usages by native browser APIs instead (even when running on older versions of Symfony).