### PR TITLE
Fix sorting profiler columns

### DIFF
--- a/Resources/views/Collector/db.html.twig
+++ b/Resources/views/Collector/db.html.twig
@@ -490,8 +490,6 @@
             });
 
             for (i = 0; i < items.length; ++i) {
-                Sfjs.removeClass(items[i], i % 2 ? 'even' : 'odd');
-                Sfjs.addClass(items[i], i % 2 ? 'odd' : 'even');
                 target.appendChild(items[i]);
             }
         }


### PR DESCRIPTION
While using the profiler, I just noticed that sorting columns by clicking on the header was not working.

This happens because `Sfjs` is no longer available on that page.
The new profiler design seems to not require even/odd css classes, we can just remove them.

The file contains 2 others occurrences of `Sfjs` that should also be fixed, if someone wants to investigate and create another PR for them.