### PR TITLE
Improve support doctrine/orm 3.0

### DIFF
--- a/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -68,7 +68,7 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
     public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [], bool $enableXsdValidation = false)
     {
         $locator = new Definition(SymfonyFileLocator::class, [$namespaces, '.orm.xml']);
-        $driver  = new Definition(XmlDriver::class, [$locator, null, $enableXsdValidation]);
+        $driver  = new Definition(XmlDriver::class, [$locator, XmlDriver::DEFAULT_FILE_EXTENSION, $enableXsdValidation]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }


### PR DESCRIPTION
After update doctrine/orm to 3.0 version:

```
PHP Fatal error:  Uncaught TypeError: Doctrine\ORM\Mapping\Driver\XmlDriver::__construct(): Argument #2 ($fileExtension) must be of type string, null given, called in /app/var/cache/dev/ContainerN1ivQrS/App_KernelDevDebugContainer.php on line 889 and defined in /app/vendor/doctrine/orm/src/Mapping/Driver/XmlDriver.php:47
Stack trace:
#0 /app/var/cache/dev/ContainerN1ivQrS/App_KernelDevDebugContainer.php(889): Doctrine\ORM\Mapping\Driver\XmlDriver->__construct(Object(Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator), NULL, true)
#1 /app/var/cache/dev/ContainerN1ivQrS/App_KernelDevDebugContainer.php(855): ContainerN1ivQrS\App_KernelDevDebugContainer::getDoctrine_Orm_DefaultEntityManagerService(Object(ContainerN1ivQrS\App_KernelDevDebugContainer), Object(ContainerN1ivQrS\EntityManagerGhostEbeb667))
#2 /app/vendor/symfony/var-exporter/Internal/LazyObjectState.php(61): ContainerN1ivQrS\App_KernelDevDebugContainer::ContainerN1ivQrS\{closure}(Object(ContainerN1ivQrS\EntityManagerGhostEbeb667))
#3 /app/vendor/symfony/var-exporter/LazyGhostTrait.php(118): Symfony\Component\VarExporter\Internal\LazyObjectState->initialize(Object(ContainerN1ivQrS\EntityManagerGhostEbeb667), 'config', 'Doctrine\\ORM\\En...')
#4 /app/vendor/doctrine/orm/src/EntityManager.php(513): ContainerN1ivQrS\EntityManagerGhostEbeb667->__get('config')
#5 /app/vendor/symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php(45): Doctrine\ORM\EntityManager->getConfiguration()
#6 /app/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php(99): Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer->warmUp('/app/var/cache/...', '/app/var/cache/...')
```

doctrine/orm 3.0:

```php
class XmlDriver extends FileDriver
{
    public const DEFAULT_FILE_EXTENSION = '.dcm.xml';

    /**
     * {@inheritDoc}
     */
    public function __construct(
        string|array|FileLocator $locator,
        string $fileExtension = self::DEFAULT_FILE_EXTENSION,
        private readonly bool $isXsdValidationEnabled = true,
    ) {
```

doctrine/orm 2.4:

```php
class XmlDriver extends FileDriver
{
    public const DEFAULT_FILE_EXTENSION = '.dcm.xml';

    /** @var bool */
    private $isXsdValidationEnabled;

    /**
     * {@inheritDoc}
     */
    public function __construct($locator, $fileExtension = self::DEFAULT_FILE_EXTENSION, bool $isXsdValidationEnabled = false)
    {
```

I'm really not sure that my decision is correct