### PR TITLE
Fix the DoctrineOrmMappingsPass passing null as the file extension argument of the XmlDriver

### DIFF
--- a/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -68,7 +68,7 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
     public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [], bool $enableXsdValidation = false)
     {
         $locator = new Definition(SymfonyFileLocator::class, [$namespaces, '.orm.xml']);
-        $driver  = new Definition(XmlDriver::class, [$locator, null, $enableXsdValidation]);
+        $driver  = new Definition(XmlDriver::class, [$locator, XmlDriver::DEFAULT_FILE_EXTENSION, $enableXsdValidation]);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }


### PR DESCRIPTION
The `createXmlMappingDriver` method of the DoctrineOrmMappingsPass is passing null as the file extension argument, while the [XmlDriver](https://github.com/doctrine/orm/blob/3.0.x/src/Mapping/Driver/XmlDriver.php#L49) expects it to be a string, generating a TypeError.

The error was raised only by trying to upgrade to orm 3.0. I did not have any issue in 2.18.
This is however quite concerning since it prevents the usage of a bundle like [Messenger Monitor](https://github.com/zenstruck/messenger-monitor-bundle/blob/1.x/src/ZenstruckMessengerMonitorBundle.php#L28) on a project using doctrine/orm 3.0