### PR TITLE
Fix usage of deprecated doctrine/orm StaticPHP driver factory

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -34,7 +34,7 @@
         <parameter key="doctrine.orm.metadata.xml.class">Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver</parameter>
         <parameter key="doctrine.orm.metadata.yml.class">Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver</parameter>
         <parameter key="doctrine.orm.metadata.php.class">Doctrine\ORM\Mapping\Driver\PHPDriver</parameter>
-        <parameter key="doctrine.orm.metadata.staticphp.class">Doctrine\ORM\Mapping\Driver\StaticPHPDriver</parameter>
+        <parameter key="doctrine.orm.metadata.staticphp.class">Doctrine\Persistence\Mapping\Driver\StaticPHPDriver</parameter>
         <parameter key="doctrine.orm.metadata.attribute.class">Doctrine\ORM\Mapping\Driver\AttributeDriver</parameter>
 
         <!-- cache warmer -->


### PR DESCRIPTION
## The background

I'm using the latest version of this bundle and the `staticphp` driver for entity mapping. I'm trying to upgrade to doctrine/orm:3.0.0 and this version of the ORM removes the deprecated `Doctrine\ORMapping\Driver\StaticPHPDriver` class (replaced by `Doctrine\Persistence\Mapping\Driver\StaticPHPDriver`).

## The problem

In the default DIC settings containing the driver class name `staticphp` still points to the old class that was deleted by doctrine/orm:3.0.0, it crashes completely after migration

```
Internal error: Class "Doctrine\ORM\Mapping\Driver\StaticPHPDriver"
```

## The solution

Stop referring to the old class and switch to the new one.
