### PR TITLE
Deprecate not setting doctrine.orm.controller_resolver.auto_mapping

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -515,7 +515,7 @@ class Configuration implements ConfigurationInterface
                             ->canBeDisabled()
                             ->children()
                                 ->booleanNode('auto_mapping')
-                                    ->defaultTrue()
+                                    ->defaultNull()
                                     ->info('Set to false to disable using route placeholders as lookup criteria when the primary key doesn\'t match the argument name')
                                 ->end()
                                 ->booleanNode('evict_cache')

--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -501,6 +501,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $controllerResolverDefaults['disabled'] = true;
             }
 
+            if ($config['controller_resolver']['auto_mapping'] === null) {
+                trigger_deprecation('doctrine/doctrine-bundle', '2.12', 'The default value of "doctrine.orm.controller_resolver.auto_mapping" will be changed from `true` to `false`. Explicitly configure `true` to keep existing behaviour.');
+                $config['controller_resolver']['auto_mapping'] = true;
+            }
+
             if (! $config['controller_resolver']['auto_mapping']) {
                 $controllerResolverDefaults['mapping'] = [];
             }

--- a/UPGRADE-2.12.md
+++ b/UPGRADE-2.12.md
@@ -1,0 +1,13 @@
+UPGRADE FROM 2.11 to 2.12
+========================
+
+Configuration
+-------------
+
+### Controller resolver auto mapping default configuration will be changed
+
+The default value of `doctrine.orm.controller_resolver.auto_mapping` will be changed from `true` to `false` in 3.0.
+
+Auto mapping uses any route parameter that matches with a field name of the Entity to resolve as criteria in a find by query.
+
+If you are relying on this functionality, you will need to configure it explicitly to silence the deprecation notice.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,6 +1,17 @@
 UPGRADE FROM 2.x to 3.0
 =======================
 
+Configuration
+-------------
+
+### Controller resolver auto mapping default configuration changed
+
+The default value of `doctrine.orm.controller_resolver.auto_mapping` has changed from `true` to `false`.
+
+Auto mapping uses any route parameters that match with a field name of the Entity to resolve as criteria in a find by query.
+
+If you were relying on this functionality, you will need to explicitly configure this now.
+
 Types
 -----
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -8,7 +8,7 @@ Configuration
 
 The default value of `doctrine.orm.controller_resolver.auto_mapping` has changed from `true` to `false`.
 
-Auto mapping uses any route parameters that match with a field name of the Entity to resolve as criteria in a find by query.
+Auto mapping uses any route parameter that matches with a field name of the Entity to resolve as criteria in a find by query.
 
 If you were relying on this functionality, you will need to explicitly configure this now.
 


### PR DESCRIPTION
As I have been bitten by this again in one of my projects, and I saw a related issue in the Symfony repository (https://github.com/symfony/symfony/issues/50739 and a comment from @stof), I propose to change the default with the next major. The deprecation will only be triggered when not explicitly configured. 

In the future, this will prevent new users from unexpected behaviour, but keeps the existing functionality available for anyone that wants to use this. And, with the new `MapEntity` attributes it would also be trivial to change the mapping configuration for a single controller argument, which is in my opinion preferable to have this wildcard match enabled globally.

If this is to be merged, the documentation on https://symfony.com/doc/current/doctrine.html#fetch-automatically needs to be updated as well. I can do that as well.