### PR TITLE
Change type hint from `Registry` to `ManagerRegistry` in `ProfilerController`

### DIFF
--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ConnectionRegistry;
 use Exception;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,10 +21,10 @@ use function assert;
 class ProfilerController
 {
     private Environment $twig;
-    private ManagerRegistry $registry;
+    private ConnectionRegistry $registry;
     private Profiler $profiler;
 
-    public function __construct(Environment $twig, ManagerRegistry $registry, Profiler $profiler)
+    public function __construct(Environment $twig, ConnectionRegistry $registry, Profiler $profiler)
     {
         $this->twig     = $twig;
         $this->registry = $registry;

--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -2,11 +2,11 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Controller;
 
-use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,10 +21,10 @@ use function assert;
 class ProfilerController
 {
     private Environment $twig;
-    private Registry $registry;
+    private ManagerRegistry $registry;
     private Profiler $profiler;
 
-    public function __construct(Environment $twig, Registry $registry, Profiler $profiler)
+    public function __construct(Environment $twig, ManagerRegistry $registry, Profiler $profiler)
     {
         $this->twig     = $twig;
         $this->registry = $registry;


### PR DESCRIPTION
The previous code breaks decorating `ManagerRegistry`. `ProfilerController` only uses `getConnection()` which is in the interface, so it is not a problem. And it is also the only remaining place in the package where `Registry` is used as the type hint instead of `ManagerRegistry`.