### PR TITLE
Override Bundle::getPath()

### DIFF
--- a/src/DoctrineBundle.php
+++ b/src/DoctrineBundle.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use function assert;
 use function class_exists;
 use function clearstatcache;
+use function dirname;
 use function spl_autoload_unregister;
 
 /** @final since 2.9 */
@@ -167,5 +168,10 @@ class DoctrineBundle extends Bundle
     /** @return void */
     public function registerCommands(Application $application)
     {
+    }
+
+    public function getPath(): string
+    {
+        return dirname(__DIR__);
     }
 }


### PR DESCRIPTION
This is required when the bundle class is not at the root path of the
bundle, which is the case since https://github.com/doctrine/DoctrineBundle/pull/1767