### PR TITLE
Avoid falling back on autoload rule more than necessary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,8 +86,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "": "tests/DependencyInjection",
-            "Doctrine\\Bundle\\DoctrineBundle\\Tests\\": "tests"
+            "Doctrine\\Bundle\\DoctrineBundle\\Tests\\": "tests",
+            "Fixtures\\": "tests/DependencyInjection/Fixtures"
         }
     },
     "config": {


### PR DESCRIPTION
That rule is meant for fixtures and fixtures alone.