### PR TITLE
make "use_savepoints = true" no-op with DBAL 4

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -307,7 +307,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                     $def->addMethodCall('setNestTransactionsWithSavepoints', [$connection['use_savepoints']]);
                 }
             } elseif (! $connection['use_savepoints']) {
-                throw new LogicException('The "use_savepoints" option can only be set to "true" when using DBAL >= 4');
+                throw new LogicException('The "use_savepoints" option can only be set to "true" and should ideally not be set when using DBAL >= 4');
             }
         }
 

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -300,8 +300,15 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $def->setClass($options['wrapperClass']);
         }
 
-        if (! empty($connection['use_savepoints'])) {
-            $def->addMethodCall('setNestTransactionsWithSavepoints', [$connection['use_savepoints']]);
+        if (isset($connection['use_savepoints'])) {
+            // DBAL >= 4 always has savepoints enabled. So we only need to call "setNestTransactionsWithSavepoints" for DBAL < 4
+            if (method_exists(Connection::class, 'getEventManager')) {
+                if ($connection['use_savepoints']) {
+                    $def->addMethodCall('setNestTransactionsWithSavepoints', [$connection['use_savepoints']]);
+                }
+            } elseif (! $connection['use_savepoints']) {
+                throw new LogicException('The "use_savepoints" option can only be set to "true" when using DBAL >= 4');
+            }
         }
 
         $container->setDefinition(

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -240,6 +240,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testDbalLoadSavepointsForNestedTransactions(): void
     {
+        if (!method_exists(Connection::class, 'getEventManager')) {
+            self::markTestSkipped('This test requires DBAL < 4');
+        }
+
         $container = $this->loadContainer('dbal_savepoints');
 
         $calls = $container->getDefinition('doctrine.dbal.savepoints_connection')->getMethodCalls();

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -554,10 +554,14 @@ class DoctrineExtensionTest extends TestCase
             ],
         ], $container);
 
+        $isUsingDBAL3 = method_exists(Connection::class, 'getEventManager');
+
         $calls = $container->getDefinition('doctrine.dbal.default_connection')->getMethodCalls();
-        $this->assertCount(1, $calls);
-        $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
-        $this->assertTrue($calls[0][1][0]);
+        $this->assertCount((int) $isUsingDBAL3, $calls);
+        if ($isUsingDBAL3) {
+            $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
+            $this->assertTrue($calls[0][1][0]);
+        }
     }
 
     public function testAutoGenerateProxyClasses(): void


### PR DESCRIPTION
While working on some bundles that support DBAL 3 and DBAL 4 I noticed that its quite a struggle to activate savepoints in a deprecation free way :confused: 

So I agree with @derrabus (see https://github.com/symfony/recipes/pull/1290#issuecomment-1947418192) and propose to make this no-op with DBAL 4.

Fixes https://github.com/doctrine/DoctrineBundle/issues/1758