### PR TITLE
Update the Symfony bundle configuration file

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -10,6 +10,6 @@ branches:
 maintained_branches:
     - "2.11.x"
     - "2.12.x"
-doc_dir: "Resources/doc/"
+doc_dir: { "2.11.x": "Resources/doc/", "2.12.x": "docs/" }
 current_branch: "2.11.x"
 dev_branch: "2.12.x"


### PR DESCRIPTION
The docs dir changed in 2.12.x branch (see https://github.com/doctrine/DoctrineBundle/tree/2.12.x/docs) so we need to update the Symfony bundle configuration file (this file must be stored in the default branch, so the update must be done in 2.11.x branch although the change happened in 2.12.x).

Thanks!