### PR TITLE
Resolve controller resolver auto_mapping test deprecations

### DIFF
--- a/tests/Builder/BundleConfigurationBuilder.php
+++ b/tests/Builder/BundleConfigurationBuilder.php
@@ -5,7 +5,11 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\Builder;
 class BundleConfigurationBuilder
 {
     /** @var array<string, mixed> */
-    private array $configuration = [];
+    private array $configuration = [ // todo: revert to empty array with 3.x release
+        'orm' => [
+            'controller_resolver' => ['auto_mapping' => false],
+        ],
+    ];
 
     public static function createBuilder(): self
     {
@@ -71,7 +75,9 @@ class BundleConfigurationBuilder
     /** @param array<string, mixed> $config */
     public function addEntityManager(array $config): self
     {
-        $this->configuration['orm'] = $config;
+        foreach ($config as $key => $value) {
+            $this->configuration['orm'][$key] = $value;
+        }
 
         return $this;
     }

--- a/tests/Builder/BundleConfigurationBuilder.php
+++ b/tests/Builder/BundleConfigurationBuilder.php
@@ -2,14 +2,24 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Builder;
 
+use Doctrine\ORM\EntityManager;
+
+use function class_exists;
+
 class BundleConfigurationBuilder
 {
     /** @var array<string, mixed> */
-    private array $configuration = [ // todo: revert to empty array with 3.x release
-        'orm' => [
-            'controller_resolver' => ['auto_mapping' => false],
-        ],
-    ];
+    private array $configuration = [];
+
+    /** @todo Remove constructor with 3.x release */
+    private function __construct()
+    {
+        if (! class_exists(EntityManager::class)) {
+            return;
+        }
+
+        $this->configuration['orm'] = ['controller_resolver' => ['auto_mapping' => false]];
+    }
 
     public static function createBuilder(): self
     {

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -332,7 +332,10 @@ class DoctrineExtensionTest extends TestCase
                             'cn2' => [],
                         ],
                     ],
-                    'orm' => ['entity_managers' => $entityManagers],
+                    'orm' => [
+                        'entity_managers' => $entityManagers,
+                        'controller_resolver' => ['auto_mapping' => false], // todo: remove this line with 3.x release
+                    ],
                 ],
             ],
             $container,
@@ -629,6 +632,8 @@ class DoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
 
+        $ormConfiguration['controller_resolver']['auto_mapping'] = false; // todo: remove this line with 3.x release
+
         $extension->load([
             [
                 'dbal' => [],
@@ -716,7 +721,11 @@ class DoctrineExtensionTest extends TestCase
         $config        = BundleConfigurationBuilder::createBuilder()
              ->addBaseConnection()
              ->build();
-        $config['orm'] = ['default_entity_manager' => 'default', 'entity_managers' => ['default' => ['mappings' => ['YamlBundle' => []]]]];
+        $config['orm'] = [
+            'default_entity_manager' => 'default',
+            'entity_managers' => ['default' => ['mappings' => ['YamlBundle' => []]]],
+            'controller_resolver' => ['auto_mapping' => false], // todo: remove this line with 3.x release
+        ];
         $extension->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
@@ -739,7 +748,11 @@ class DoctrineExtensionTest extends TestCase
         $config        = BundleConfigurationBuilder::createBuilder()
              ->addBaseConnection()
              ->build();
-        $config['orm'] = ['default_entity_manager' => 'default', 'entity_managers' => ['default' => ['mappings' => ['YamlBundle' => ['alias' => 'yml']]]]];
+        $config['orm'] = [
+            'default_entity_manager' => 'default',
+            'entity_managers' => ['default' => ['mappings' => ['YamlBundle' => ['alias' => 'yml']]]],
+            'controller_resolver' => ['auto_mapping' => false], // todo: remove this line with 3.x release
+        ];
         $extension->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
@@ -761,7 +774,12 @@ class DoctrineExtensionTest extends TestCase
 
         $extension->load([
             ['dbal' => [], 'orm' => ['default_entity_manager' => 'app', 'entity_managers' => ['app' => ['mappings' => ['YamlBundle' => ['alias' => 'yml']]]]]],
-            ['orm' => ['metadata_cache_driver' => ['type' => 'pool', 'pool' => 'doctrine.system_cache_pool']]],
+            [
+                'orm' => [
+                    'metadata_cache_driver' => ['type' => 'pool', 'pool' => 'doctrine.system_cache_pool'],
+                    'controller_resolver' => ['auto_mapping' => false], // todo: remove this line with 3.x release
+                ],
+            ],
         ], $container);
 
         $this->assertEquals('app', $container->getParameter('doctrine.default_entity_manager'));
@@ -1442,6 +1460,8 @@ class DoctrineExtensionTest extends TestCase
         if ($simpleEntityManagerConfig) {
             $config['orm'] = [];
         }
+
+        $config['orm']['controller_resolver'] = ['auto_mapping' => true];
 
         $extension->load([$config], $container);
 


### PR DESCRIPTION
Fixes the introduced test deprecations caused by the changed default of the controller resolver auto mapping value. Lines that have been changed to reflect the new default value have been annotated with a todo so they can be remove when preparing the 3.0 release.

As requested by @dmaicher in https://github.com/doctrine/DoctrineBundle/pull/1762#issuecomment-2005883237.