### PR TITLE
fix deprecations for deprecated mysql server versions

### DIFF
--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -120,7 +120,10 @@ class ConnectionFactory
             $driver     = $connection->getDriver();
             /** @psalm-suppress InvalidScalarArgument Bogus error, StaticServerVersionProvider implements Doctrine\DBAL\ServerVersionProvider  */
             $platform = $driver->getDatabasePlatform(
-                ...(class_exists(StaticServerVersionProvider::class) ? [new StaticServerVersionProvider($params['serverVersion'] ?? '')] : []),
+                ...(class_exists(StaticServerVersionProvider::class)
+                    ? [new StaticServerVersionProvider($params['serverVersion'] ?? $params['primary']['serverVersion'] ?? '')]
+                    : []
+                ),
             );
 
             if (! isset($params['charset'])) {

--- a/tests/ConnectionFactoryTest.php
+++ b/tests/ConnectionFactoryTest.php
@@ -43,7 +43,7 @@ class ConnectionFactoryTest extends TestCase
     public function testDefaultCharsetMySql(): void
     {
         $factory = new ConnectionFactory([]);
-        $params  = ['driver' => 'pdo_mysql'];
+        $params  = ['driver' => 'pdo_mysql', 'serverVersion' => '8.0.31'];
 
         $connection = $factory->createConnection($params, $this->configuration);
 
@@ -53,7 +53,7 @@ class ConnectionFactoryTest extends TestCase
     public function testDefaultCollationMySql(): void
     {
         $factory    = new ConnectionFactory([]);
-        $connection = $factory->createConnection(['driver' => 'pdo_mysql'], $this->configuration);
+        $connection = $factory->createConnection(['driver' => 'pdo_mysql', 'serverVersion' => '8.0.31'], $this->configuration);
 
         $this->assertSame(
             'utf8mb4_unicode_ci',

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
@@ -8,9 +8,9 @@
 
     <config>
         <dbal default-connection="connection1">
-            <connection name="connection1" schema-filter="~^(?!t_)~" />
-            <connection name="connection2" />
-            <connection name="connection3" />
+            <connection name="connection1" schema-filter="~^(?!t_)~" server-version="8.0.31" />
+            <connection name="connection2" server-version="8.0.31" />
+            <connection name="connection3" server-version="8.0.31" />
         </dbal>
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
@@ -8,7 +8,7 @@
 
     <config>
         <dbal default-connection="default">
-            <connection name="default" dbname="db" />
+            <connection name="default" dbname="db" server-version="8.0.31" />
         </dbal>
 
         <orm enable-lazy-ghost-objects="true">

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
@@ -4,5 +4,8 @@ doctrine:
         connections:
             connection1:
                 schema_filter: ~^(?!t_)~
-            connection2: []
-            connection3: []
+                server_version: 8.0.31
+            connection2:
+                server_version: 8.0.31
+            connection3:
+                server_version: 8.0.31

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
@@ -4,6 +4,7 @@ doctrine:
         connections:
             default:
                 dbname: db
+                server_version: 8.0.31
 
     orm:
         enable_lazy_ghost_objects: true


### PR DESCRIPTION
Fixes

```
  9x: Support for MySQL < 8 is deprecated and will be removed in DBAL 5 (AbstractMySQLDriver.php:60 called by ConnectionFactory.php:122, https://github.com/doctrine/dbal/pull/6343, package doctrine/dbal)
    2x in XmlDoctrineExtensionTest::testDbalSchemaFilterNewConfig from Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection
    2x in YamlDoctrineExtensionTest::testDbalSchemaFilterNewConfig from Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection
    1x in ConnectionFactoryTest::testDefaultCharsetMySql from Doctrine\Bundle\DoctrineBundle\Tests
    1x in ConnectionFactoryTest::testDefaultCollationMySql from Doctrine\Bundle\DoctrineBundle\Tests
    1x in ConnectionFactoryTest::testDbnameSuffixForReplicas from Doctrine\Bundle\DoctrineBundle\Tests
    ...
``` 


now deprecation free:

```
..S......SSSSS.................................................  63 / 328 ( 19%)
.....................SSS....................................... 126 / 328 ( 38%)
.........................................S..................... 189 / 328 ( 57%)
..................................S............................ 252 / 328 ( 76%)
............................................................... 315 / 328 ( 96%)
.............                                                   328 / 328 (100%)

Time: 00:01.739, Memory: 48.50 MB

OK, but incomplete, skipped, or risky tests!
Tests: 328, Assertions: 1174, Skipped: 11.

Legacy deprecation notices (96)
```