### PR TITLE
Wire up type aliases support in EntityValueResolver

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -549,19 +549,22 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $controllerResolverDefaults['evict_cache'] = true;
             }
 
-            if ($controllerResolverDefaults) {
-                $container->getDefinition('doctrine.orm.entity_value_resolver')->setArgument(2, (new Definition(MapEntity::class))->setArguments([
-                    null,
-                    null,
-                    null,
-                    $controllerResolverDefaults['mapping'] ?? null,
-                    null,
-                    null,
-                    null,
-                    $controllerResolverDefaults['evict_cache'] ?? null,
-                    $controllerResolverDefaults['disabled'] ?? false,
-                ]));
-            }
+            $valueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver');
+
+            $valueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([
+                null,
+                null,
+                null,
+                $controllerResolverDefaults['mapping'] ?? null,
+                null,
+                null,
+                null,
+                $controllerResolverDefaults['evict_cache'] ?? null,
+                $controllerResolverDefaults['disabled'] ?? false,
+            ]));
+
+            // Symfony 7.3 and higher expose type alias support in the EntityValueResolver
+            $valueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
         }
 
         // not available in Doctrine ORM 3.0 and higher

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Tools\Console\Command\InfoCommand;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
@@ -23,6 +24,7 @@ use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
+use function class_exists;
 use function interface_exists;
 
 class ContainerTest extends TestCase
@@ -37,6 +39,10 @@ class ContainerTest extends TestCase
 
         if (interface_exists(Reader::class)) {
             $this->assertInstanceOf(Reader::class, $container->get('doctrine.orm.metadata.annotation_reader'));
+        }
+
+        if (class_exists(EntityValueResolver::class)) {
+            $this->assertInstanceOf(EntityValueResolver::class, $container->get('doctrine.orm.entity_value_resolver'));
         }
 
         $this->assertInstanceOf(DoctrineDataCollector::class, $container->get('data_collector.doctrine'));

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1460,13 +1460,29 @@ class DoctrineExtensionTest extends TestCase
             $config['orm'] = [];
         }
 
-        $config['orm']['controller_resolver'] = ['auto_mapping' => true];
+        $config['orm']['controller_resolver']     = ['auto_mapping' => true];
+        $config['orm']['resolve_target_entities'] = ['Throwable' => 'stdClass'];
 
         $extension->load([$config], $container);
 
         $controllerResolver = $container->getDefinition('doctrine.orm.entity_value_resolver');
 
-        $this->assertEquals([new Reference('doctrine'), new Reference('doctrine.orm.entity_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE)], $controllerResolver->getArguments());
+        $this->assertEquals([
+            0 => new Reference('doctrine'),
+            1 => new Reference('doctrine.orm.entity_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE),
+            2 => (new Definition(MapEntity::class))->setArguments([
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+            ]),
+            3 => ['Throwable' => 'stdClass'],
+        ], $controllerResolver->getArguments());
 
         $container = $this->getContainer();
 


### PR DESCRIPTION
This is an addendum to PR https://github.com/symfony/symfony/pull/54545 targeted at issue https://github.com/symfony/symfony/issues/51765 in the Symfony Doctrine Bridge, which adds type alias support to EntityValueResolver.

This code injects the doctrine.orm.resolve_target_entities configuration into the EntityValueResolver class.