### PR TITLE
Update documentation for regex delimiters in schema_filter

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -883,7 +883,7 @@ can configure. The following block shows all possible configuration keys:
                 logging:                  "%kernel.debug%"
                 platform_service:         MyOwnDatabasePlatformService
                 auto_commit:              false
-                schema_filter:            ^sf2_
+                schema_filter:            /^sf2_/
                 mapping_types:
                     enum: string
                 types:


### PR DESCRIPTION
This PR adds necessary delimiters to regular expressions used in schema_filter configurations, preventing the  `No ending delimiter '^' found` 