### PR TITLE
Enable to set custom TypedFieldMapper;

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,16 +4,22 @@
   "slug": "doctrine-bundle",
   "versions": [
     {
-      "name": "2.12",
-      "branchName": "2.12.x",
+      "name": "2.13",
+      "branchName": "2.13.x",
       "slug": "latest",
       "upcoming": true
+    },
+    {
+      "name": "2.12",
+      "branchName": "2.12.x",
+      "slug": "2.12",
+      "current": true
     },
     {
       "name": "2.11",
       "branchName": "2.11.x",
       "slug": "2.11",
-      "current": true
+      "maintained": false
     },
     {
       "name": "2.10",

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,6 @@
 phpunit.xml.dist       export-ignore
 phpcs.xml.dist         export-ignore
 psalm.xml.dist         export-ignore
-/Resources/doc         export-ignore
-/Tests                 export-ignore
+/docs                  export-ignore
+/tests                 export-ignore
+.symfony.bundle.yaml   export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "CI"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,6 +12,6 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@3.1.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@5.0.1"
     with:
       composer-options: "--prefer-dist --prefer-stable"

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   composer-lint:
     name: "Composer Lint"
-    uses: "doctrine/.github/.github/workflows/composer-lint.yml@3.1.0"
+    uses: "doctrine/.github/.github/workflows/composer-lint.yml@5.0.1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,6 +126,8 @@ jobs:
           path: "reports"
 
       - name: "Upload to Codecov"
-        uses: "codecov/codecov-action@v3"
+        uses: "codecov/codecov-action@v4"
         with:
           directory: reports
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
         stability:
@@ -46,22 +47,22 @@ jobs:
           # Test last supported minor version
           - symfony-require: "6.*"
             dependencies: "highest"
-            php-version: "8.2"
+            php-version: "8.3"
 
           # DBAL only without ORM
-          - php-version: "8.2"
+          - php-version: "8.3"
             dependencies: "highest"
             stability: "stable"
             remove-orm: true
 
           # DBAL 4
-          - php-version: "8.2"
+          - php-version: "8.3"
             dependencies: "highest"
             stability: "dev"
             remove-orm: true
 
           # Bleeding edge
-          - php-version: "8.2"
+          - php-version: "8.3"
             dependencies: "highest"
             stability: "dev"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -103,7 +103,7 @@ jobs:
         run: "vendor/bin/phpunit --coverage-clover=coverage.xml"
 
       - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v3"
+        uses: "actions/upload-artifact@v4"
         with:
           name: "phpunit-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}.coverage"
           path: "coverage.xml"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,7 +121,7 @@ jobs:
           fetch-depth: 2
 
       - name: "Download coverage files"
-        uses: "actions/download-artifact@v3"
+        uses: "actions/download-artifact@v4"
         with:
           path: "reports"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -94,7 +94,7 @@ jobs:
         if: "${{ matrix.remove-orm }}"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@3.1.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@5.0.1"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         run: "composer config minimum-stability stable"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
 
       - name: "Run a static analysis with vimeo/psalm"
         run: "vendor/bin/psalm --show-info=false --stats --output-format=github --find-unused-psalm-suppress"

--- a/.github/workflows/test-dev-stability.yml
+++ b/.github/workflows/test-dev-stability.yml
@@ -44,7 +44,7 @@ jobs:
         if: "${{ startsWith(matrix.symfony-require, '4.') }}"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist"

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -11,6 +11,6 @@ branches:
 maintained_branches:
     - "2.12.x"
     - "2.13.x"
-doc_dir: { "2.11.x": "Resources/doc/", "2.12.x": "docs/" }
+doc_dir: "docs/"
 current_branch: "2.12.x"
 dev_branch: "2.13.x"

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -7,9 +7,10 @@ branches:
     - "2.10.x"
     - "2.11.x"
     - "2.12.x"
+    - "2.13.x"
 maintained_branches:
-    - "2.11.x"
     - "2.12.x"
+    - "2.13.x"
 doc_dir: { "2.11.x": "Resources/doc/", "2.12.x": "docs/" }
-current_branch: "2.11.x"
-dev_branch: "2.12.x"
+current_branch: "2.12.x"
+dev_branch: "2.13.x"

--- a/config/orm.xml
+++ b/config/orm.xml
@@ -62,6 +62,9 @@
         <parameter key="doctrine.orm.quote_strategy.default.class">Doctrine\ORM\Mapping\DefaultQuoteStrategy</parameter>
         <parameter key="doctrine.orm.quote_strategy.ansi.class">Doctrine\ORM\Mapping\AnsiQuoteStrategy</parameter>
 
+        <!-- typed field mapper -->
+        <parameter key="doctrine.orm.typed_field_mapper.default.class">Doctrine\ORM\Mapping\DefaultTypedFieldMapper</parameter>
+
         <!-- entity listener resolver -->
         <parameter key="doctrine.orm.entity_listener_resolver.class">Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver</parameter>
 
@@ -172,6 +175,9 @@
         <!-- quote strategy -->
         <service id="doctrine.orm.quote_strategy.default" class="%doctrine.orm.quote_strategy.default.class%" public="false" />
         <service id="doctrine.orm.quote_strategy.ansi" class="%doctrine.orm.quote_strategy.ansi.class%" public="false" />
+
+        <!-- typed field mapper -->
+        <service id="doctrine.orm.typed_field_mapper.default" class="%doctrine.orm.typed_field_mapper.default.class%" public="false" />
 
         <!-- custom id generators -->
         <service id="doctrine.ulid_generator" class="Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator">

--- a/config/schema/doctrine-1.0.xsd
+++ b/config/schema/doctrine-1.0.xsd
@@ -228,6 +228,7 @@
         <xsd:attribute name="class-metadata-factory-name" type="xsd:string" />
         <xsd:attribute name="naming-strategy" type="xsd:string" />
         <xsd:attribute name="quote-strategy" type="xsd:string" />
+        <xsd:attribute name="typed-field-mapper" type="xsd:string" />
         <xsd:attribute name="entity-listener-resolver" type="xsd:string" />
         <xsd:attribute name="repository-factory" type="xsd:string" />
         <xsd:attribute name="report-fields-where-declared" type="xsd:boolean" />

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -883,7 +883,7 @@ can configure. The following block shows all possible configuration keys:
                 logging:                  "%kernel.debug%"
                 platform_service:         MyOwnDatabasePlatformService
                 auto_commit:              false
-                schema_filter:            ^sf2_
+                schema_filter:            /^sf2_/
                 mapping_types:
                     enum: string
                 types:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -262,6 +262,7 @@ Configuration Reference
                         validate_xml_mapping: false
                         naming_strategy:              doctrine.orm.naming_strategy.default
                         quote_strategy:               doctrine.orm.quote_strategy.default
+                        typed_field_mapper:           doctrine.orm.typed_field_mapper.default
                         entity_listener_resolver:     ~
                         repository_factory:           ~
                         second_level_cache:
@@ -514,6 +515,7 @@ Configuration Reference
                         report-fields-where-declared="false"
                         naming-strategy="doctrine.orm.naming_strategy.default"
                         quote-strategy="doctrine.orm.quote_strategy.default"
+                        typed-field-mapper="doctrine.orm.typed_field_mapper.default"
                         entity-listener-resolver="null"
                         repository-factory="null"
                     >

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,7 @@
     <config name="php_version" value="70400"/>
 
     <file>src</file>
+    <file>tests</file>
 
     <rule ref="Doctrine">
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
@@ -22,11 +23,11 @@
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
-        <exclude-pattern>Tests/*</exclude-pattern>
-        <exclude-pattern>Repository/RepositoryFactoryCompatibility.php</exclude-pattern>
-        <exclude-pattern>Repository/ServiceEntityRepository.php</exclude-pattern>
+        <exclude-pattern>tests/*</exclude-pattern>
+        <exclude-pattern>src/Repository/RepositoryFactoryCompatibility.php</exclude-pattern>
+        <exclude-pattern>src/Repository/ServiceEntityRepository.php</exclude-pattern>
     </rule>
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
-        <exclude-pattern>Tests/*</exclude-pattern>
+        <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true" bootstrap="tests/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
     <testsuites>
         <testsuite name="DoctrineBundle for the Symfony Framework">
             <directory>./tests</directory>
@@ -11,11 +14,11 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./tests/baseline-ignore"/>
     </php>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,10 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./tests/baseline-ignore"/>
+    </php>
+
     <filter>
         <whitelist>
             <directory>src</directory>

--- a/src/Command/CreateDatabaseDoctrineCommand.php
+++ b/src/Command/CreateDatabaseDoctrineCommand.php
@@ -66,7 +66,8 @@ EOT);
         unset($params['dbname'], $params['path'], $params['url']);
 
         if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $params['dbname'] = 'postgres';
+            /** @psalm-suppress InvalidArrayOffset It's still available in DBAL 3.x that we need to support */
+            $params['dbname'] = $params['default_dbname'] ?? 'postgres';
         }
 
         $tmpConnection           = DriverManager::getConnection($params, $connection->getConfiguration());

--- a/src/Command/DropDatabaseDoctrineCommand.php
+++ b/src/Command/DropDatabaseDoctrineCommand.php
@@ -77,7 +77,8 @@ EOT);
         unset($params['dbname'], $params['url']);
 
         if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $params['dbname'] = 'postgres';
+            /** @psalm-suppress InvalidArrayOffset It's still available in DBAL 3.x that we need to support */
+            $params['dbname'] = $params['default_dbname'] ?? 'postgres';
         }
 
         if (! $input->getOption('force')) {

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -120,7 +120,10 @@ class ConnectionFactory
             $driver     = $connection->getDriver();
             /** @psalm-suppress InvalidScalarArgument Bogus error, StaticServerVersionProvider implements Doctrine\DBAL\ServerVersionProvider  */
             $platform = $driver->getDatabasePlatform(
-                ...(class_exists(StaticServerVersionProvider::class) ? [new StaticServerVersionProvider($params['serverVersion'] ?? '')] : []),
+                ...(class_exists(StaticServerVersionProvider::class)
+                    ? [new StaticServerVersionProvider($params['serverVersion'] ?? $params['primary']['serverVersion'] ?? '')]
+                    : []
+                ),
             );
 
             if (! isset($params['charset'])) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -659,6 +659,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('auto_mapping')->defaultFalse()->end()
                     ->scalarNode('naming_strategy')->defaultValue('doctrine.orm.naming_strategy.default')->end()
                     ->scalarNode('quote_strategy')->defaultValue('doctrine.orm.quote_strategy.default')->end()
+                    ->scalarNode('typed_field_mapper')->defaultValue('doctrine.orm.typed_field_mapper.default')->end()
                     ->scalarNode('entity_listener_resolver')->defaultNull()->end()
                     ->scalarNode('repository_factory')->defaultValue('doctrine.orm.container_repository_factory')->end()
                     ->arrayNode('schema_ignore_classes')

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -696,6 +696,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             'setDefaultRepositoryClassName' => $entityManager['default_repository_class'],
             'setNamingStrategy' => new Reference($entityManager['naming_strategy']),
             'setQuoteStrategy' => new Reference($entityManager['quote_strategy']),
+            'setTypedFieldMapper' => new Reference($entityManager['typed_field_mapper']),
             'setEntityListenerResolver' => new Reference(sprintf('doctrine.orm.%s_entity_listener_resolver', $entityManager['name'])),
             'setLazyGhostObjectEnabled' => '%doctrine.orm.enable_lazy_ghost_objects%',
         ];

--- a/tests/ConnectionFactoryTest.php
+++ b/tests/ConnectionFactoryTest.php
@@ -43,7 +43,7 @@ class ConnectionFactoryTest extends TestCase
     public function testDefaultCharsetMySql(): void
     {
         $factory = new ConnectionFactory([]);
-        $params  = ['driver' => 'pdo_mysql'];
+        $params  = ['driver' => 'pdo_mysql', 'serverVersion' => '8.0.31'];
 
         $connection = $factory->createConnection($params, $this->configuration);
 
@@ -53,7 +53,7 @@ class ConnectionFactoryTest extends TestCase
     public function testDefaultCollationMySql(): void
     {
         $factory    = new ConnectionFactory([]);
-        $connection = $factory->createConnection(['driver' => 'pdo_mysql'], $this->configuration);
+        $connection = $factory->createConnection(['driver' => 'pdo_mysql', 'serverVersion' => '8.0.31'], $this->configuration);
 
         $this->assertSame(
             'utf8mb4_unicode_ci',

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -725,6 +725,19 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($def2, 'setQuoteStrategy', [0 => new Reference('doctrine.orm.quote_strategy.ansi')]);
     }
 
+    public function testSetTypedFieldMapper(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->loadContainer('orm_typedfieldmapper');
+
+        $definition = $container->getDefinition('doctrine.orm.default_configuration');
+
+        $this->assertDICDefinitionMethodCallOnce($definition, 'setTypedFieldMapper', [0 => new Reference('doctrine.orm.typed_field_mapper.default')]);
+    }
+
     /**
      * @dataProvider cacheConfigProvider
      * @group legacy

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -240,7 +240,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     public function testDbalLoadSavepointsForNestedTransactions(): void
     {
-        if (!method_exists(Connection::class, 'getEventManager')) {
+        if (! method_exists(Connection::class, 'getEventManager')) {
             self::markTestSkipped('This test requires DBAL < 4');
         }
 

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -558,10 +558,12 @@ class DoctrineExtensionTest extends TestCase
 
         $calls = $container->getDefinition('doctrine.dbal.default_connection')->getMethodCalls();
         $this->assertCount((int) $isUsingDBAL3, $calls);
-        if ($isUsingDBAL3) {
-            $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
-            $this->assertTrue($calls[0][1][0]);
+        if (! $isUsingDBAL3) {
+            return;
         }
+
+        $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
+        $this->assertTrue($calls[0][1][0]);
     }
 
     public function testAutoGenerateProxyClasses(): void

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1443,6 +1443,8 @@ class DoctrineExtensionTest extends TestCase
             $config['orm'] = [];
         }
 
+        $config['orm']['controller_resolver'] = ['auto_mapping' => true];
+
         $extension->load([$config], $container);
 
         $controllerResolver = $container->getDefinition('doctrine.orm.entity_value_resolver');

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -512,7 +512,8 @@ class DoctrineExtensionTest extends TestCase
 
         $this->assertEquals('doctrine.orm.naming_strategy.default', (string) $calls[11][1][0]);
         $this->assertEquals('doctrine.orm.quote_strategy.default', (string) $calls[12][1][0]);
-        $this->assertEquals('doctrine.orm.default_entity_listener_resolver', (string) $calls[13][1][0]);
+        $this->assertEquals('doctrine.orm.typed_field_mapper.default', (string) $calls[13][1][0]);
+        $this->assertEquals('doctrine.orm.default_entity_listener_resolver', (string) $calls[14][1][0]);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_cache_warmer');
         $this->assertSame(DoctrineMetadataCacheWarmer::class, $definition->getClass());

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
@@ -8,9 +8,9 @@
 
     <config>
         <dbal default-connection="connection1">
-            <connection name="connection1" schema-filter="~^(?!t_)~" />
-            <connection name="connection2" />
-            <connection name="connection3" />
+            <connection name="connection1" schema-filter="~^(?!t_)~" server-version="8.0.31" />
+            <connection name="connection2" server-version="8.0.31" />
+            <connection name="connection3" server-version="8.0.31" />
         </dbal>
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
@@ -8,7 +8,7 @@
 
     <config>
         <dbal default-connection="default">
-            <connection name="default" dbname="db" />
+            <connection name="default" dbname="db" server-version="8.0.31" />
         </dbal>
 
         <orm enable-lazy-ghost-objects="true">

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_typedfieldmapper.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_typedfieldmapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm default-entity-manager="default">
+            <entity-manager name="default" typed-field-mapper="doctrine.orm.typed_field_mapper.default">
+                <mapping name="YamlBundle" />
+            </entity-manager>
+        </orm>
+    </config>
+</srv:container>

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
@@ -4,5 +4,8 @@ doctrine:
         connections:
             connection1:
                 schema_filter: ~^(?!t_)~
-            connection2: []
-            connection3: []
+                server_version: 8.0.31
+            connection2:
+                server_version: 8.0.31
+            connection3:
+                server_version: 8.0.31

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
@@ -4,6 +4,7 @@ doctrine:
         connections:
             default:
                 dbname: db
+                server_version: 8.0.31
 
     orm:
         enable_lazy_ghost_objects: true

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_typedfieldmapper.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_typedfieldmapper.yml
@@ -1,0 +1,14 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        default_entity_manager: default
+        entity_managers:
+            default:
+                mappings:
+                    YamlBundle: ~
+                typed_field_mapper: doctrine.orm.typed_field_mapper.default

--- a/tests/ProfilerTest.php
+++ b/tests/ProfilerTest.php
@@ -23,7 +23,8 @@ use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
-use Twig\RuntimeLoader\RuntimeLoaderInterface;
+use Twig\Runtime\EscaperRuntime;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 use function class_exists;
 use function html_entity_decode;
@@ -79,9 +80,10 @@ class ProfilerTest extends BaseTestCase
         $this->twig->addExtension(new WebProfilerExtension());
         $this->twig->addExtension(new DoctrineExtension());
 
-        $loader = $this->getMockBuilder(RuntimeLoaderInterface::class)->getMock();
-        $loader->method('load')->willReturn($kernelRuntime);
-        $this->twig->addRuntimeLoader($loader);
+        $this->twig->addRuntimeLoader(new FactoryRuntimeLoader([
+            HttpKernelRuntime::class => static fn () => $kernelRuntime,
+            EscaperRuntime::class => static fn () => new EscaperRuntime(),
+        ]));
     }
 
     public function testRender(): void

--- a/tests/baseline-ignore
+++ b/tests/baseline-ignore
@@ -1,0 +1,1 @@
+%"doctrine.orm.controller_resolver.auto_mapping" will be changed from `true` to `false`.%


### PR DESCRIPTION
This PR add `typed_field_mapper` option allowing to override or set custom TypedFieldMapper as described in ORM documentation. This option allows  auto detection of doctrine types based on PHP typed properties.

https://www.doctrine-project.org/projects/doctrine-orm/en/3.1/reference/typedfieldmapper.html

`\Doctrine\ORM\Configuration::getTypedFieldMapper()` return `null` as default and `\Doctrine\ORM\Mapping\ClassMetadataInfo` instance is created by providing `null` or `TypedFieldMapper`. If `null` `\Doctrine\ORM\Mapping\DefaultTypedFieldMapper` is created. This why i set it as default under `typed_field_mapper` option.

```
public function __construct($entityName, ?NamingStrategy $namingStrategy = null, ?TypedFieldMapper $typedFieldMapper = null)
{
   // [..]
    $this->typedFieldMapper = $typedFieldMapper ?? new DefaultTypedFieldMapper();
}
```