### PR TITLE
Fully deprecate controller resolver auto mapping

### DIFF
--- a/UPGRADE-2.13.md
+++ b/UPGRADE-2.13.md
@@ -1,0 +1,13 @@
+UPGRADE FROM 2.12 to 2.13
+========================
+
+Configuration
+-------------
+
+### Controller resolver auto mapping deprecated
+
+The controller resolver auto mapping functionality has been deprecated with Symfony 7.1, and is replaced with explicit mapped route parameters. Enabling the auto mapper by default using this bundle is now deprecated as well.
+
+Auto mapping uses any route parameter that matches with a field name of the Entity to resolve as criteria in a find by query.
+
+If you are relying on this functionality, you can update your code to use explicit mapped route parameters instead.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -4,13 +4,13 @@ UPGRADE FROM 2.x to 3.0
 Configuration
 -------------
 
-### Controller resolver auto mapping default configuration changed
+### Controller resolver auto mapping can no longer be configured
 
-The default value of `doctrine.orm.controller_resolver.auto_mapping` has changed from `true` to `false`.
+The `doctrine.orm.controller_resolver.auto_mapping` option now only accepts `false` as value, to disallow the usage of the controller resolver auto mapping feature by default. The configuration option will be fully removed in 4.0.
 
-Auto mapping uses any route parameter that matches with a field name of the Entity to resolve as criteria in a find by query.
+Auto mapping used any route parameter that matches with a field name of the Entity to resolve as criteria in a find by query. This method has been deprecated in Symfony 7.1 and is replaced with mapped route parameters.
 
-If you were relying on this functionality, you will need to explicitly configure this now.
+If you were relying on this functionality, you will need to update your code to use explicit mapped route parameters instead.
 
 Types
 -----

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -529,6 +529,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $config['controller_resolver']['auto_mapping'] = true;
             }
 
+            if ($config['controller_resolver']['auto_mapping'] === true) {
+                trigger_deprecation('doctrine/doctrine-bundle', '2.13', 'Enabling the controller resolver automapping feature has been deprecated. Symfony Mapped Route Parameters should be used as replacement.');
+            }
+
             if (! $config['controller_resolver']['auto_mapping']) {
                 $controllerResolverDefaults['mapping'] = [];
             }

--- a/tests/baseline-ignore
+++ b/tests/baseline-ignore
@@ -1,1 +1,2 @@
 %"doctrine.orm.controller_resolver.auto_mapping" will be changed from `true` to `false`.%
+%Enabling the controller resolver automapping feature has been deprecated.%


### PR DESCRIPTION
Symfony 7.1 has deprecated the use of the controller resolver auto mapper functionality in favour of the new mapped route parameters, which have the benefit of being explicit and concise (see https://github.com/symfony/symfony/pull/54455, https://github.com/symfony/symfony/pull/54720 and https://symfony.com/blog/new-in-symfony-7-1-mapped-route-parameters for the discussion and more details).

Note that we already deprecated not setting a value with https://github.com/doctrine/DoctrineBundle/pull/1762 to be able to change its default to false with 3.0, but now I propose to fully remove this configuration option with 3.0 instead, with both not setting and true being deprecated. Depending on when 3.0 would be available, removed the option could be postponed to 4.0 if desired.

/cc @nicolas-grekas - https://github.com/symfony/recipes/pull/1316