### PR TITLE
Service definition changes for EntityValueResolver

### DIFF
--- a/config/orm.xml
+++ b/config/orm.xml
@@ -188,6 +188,10 @@
             <argument type="service" id="doctrine" />
         </service>
 
+        <service id="doctrine.orm.entity_value_resolver_variable_injector" class="Symfony\Bridge\Doctrine\ArgumentResolver\UserInjector">
+            <argument type="service" id="security.token_storage" on-invalid="ignore" />
+        </service>
+
         <service id="doctrine.orm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">
             <argument type="service" id="doctrine" />
             <argument type="service" id="doctrine.orm.entity_value_resolver.expression_language" on-invalid="ignore" />

--- a/config/orm.xml
+++ b/config/orm.xml
@@ -188,8 +188,9 @@
             <argument type="service" id="doctrine" />
         </service>
 
-        <service id="doctrine.orm.entity_value_resolver_variable_injector" class="Symfony\Bridge\Doctrine\ArgumentResolver\UserInjector">
+        <service id="Symfony\Bridge\Doctrine\ArgumentResolver\UserInjector">
             <argument type="service" id="security.token_storage" on-invalid="ignore" />
+            <tag name="doctrine.orm.entity_value_resolver_expression_modifier_injector" key="userInjector"/>
         </service>
 
         <service id="doctrine.orm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -77,7 +77,7 @@ class Configuration implements ConfigurationInterface
     private function addDbalSection(ArrayNodeDefinition $node): void
     {
         // Key that should not be rewritten to the connection config
-        $excludedKeys = ['default_connection' => true, 'driver_schemes' => true, 'driver_scheme' => true, 'types' => true, 'type' => true];
+        $excludedKeys = ['default_connection' => true, 'driver_schemes' => true, 'driver_scheme' => true, 'types' => true, 'type' => true, 'default_expression_modifier_injector' => true];
 
         $node
             ->children()
@@ -165,6 +165,11 @@ class Configuration implements ConfigurationInterface
                                 return $value;
                             })
                         ->end()
+                    ->end()
+                ->end()
+                ->children()
+                    ->arrayNode('default_expression_modifier_injector')->scalarPrototype()->end()
+                        ->beforeNormalization()->castToArray()->end()
                     ->end()
                 ->end()
                 ->fixXmlConfig('connection')

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -33,6 +33,7 @@ use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use InvalidArgumentException;
 use LogicException;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
+use Symfony\Bridge\Doctrine\ArgumentResolver\UserInjector;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
@@ -533,6 +534,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
                     $controllerResolverDefaults['evict_cache'] ?? null,
                     $controllerResolverDefaults['disabled'] ?? false,
                 ]));
+            } else {
+                $container->getDefinition('doctrine.orm.entity_value_resolver')->setArgument(2, (new Definition(MapEntity::class)));
+            }
+
+            if (class_exists(ExpressionLanguage::class) && class_exists(UserInjector::class)) {
+                $container->getDefinition('doctrine.orm.entity_value_resolver')->setArgument(3, new Reference('doctrine.orm.entity_value_resolver_variable_injector'));
             }
         }
 

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1451,7 +1451,7 @@ class DoctrineExtensionTest extends TestCase
 
         $controllerResolver = $container->getDefinition('doctrine.orm.entity_value_resolver');
 
-        $this->assertEquals([new Reference('doctrine'), new Reference('doctrine.orm.entity_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE)], $controllerResolver->getArguments());
+        $this->assertEquals([new Reference('doctrine'), new Reference('doctrine.orm.entity_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE), new Definition(MapEntity::class)], $controllerResolver->getArguments());
 
         $container = $this->getContainer();
 


### PR DESCRIPTION
This PR is related https://github.com/symfony/symfony/pull/57676 for add a variableLoader service to inject in EntityValueResolver to allow user to have it's own variables (eg: user) in mapEntity