### PR TITLE
Fix wiring of PHP metadata drivers on doctrine/orm 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3",
-        "symfony/doctrine-bridge": "^5.4.19 || ^6.0.7 || ^7.0",
+        "symfony/doctrine-bridge": "^5.4.46 || ^6.4.3 || ^7.0.3",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.1.1 || ^2.0 || ^3"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -40,6 +40,8 @@
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\YamlDriver"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\AnnotationDriver"/>
+                <referencedClass name="Doctrine\ORM\Mapping\Driver\PHPDriver"/>
+                <referencedClass name="Doctrine\ORM\Mapping\Driver\StaticPHPDriver"/>
                 <referencedClass name="Doctrine\ORM\ORMException"/>
                 <!-- Dropped in DBAL 4 -->
                 <referencedClass name="Doctrine\DBAL\Exception"/>

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -22,13 +22,21 @@ use Doctrine\ORM\Configuration as OrmConfiguration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\AbstractIdGenerator;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\Driver\PHPDriver as LegacyPHPDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
+use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
+use Doctrine\ORM\Mapping\Driver\StaticPHPDriver as LegacyStaticPHPDriver;
 use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand;
 use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
 use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use InvalidArgumentException;
 use LogicException;
@@ -1163,7 +1171,31 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
     protected function getMetadataDriverClass(string $driverType): string
     {
-        return '%' . $this->getObjectManagerElementName('metadata.' . $driverType . '.class') . '%';
+        switch ($driverType) {
+            case 'driver_chain':
+                return MappingDriverChain::class;
+
+            case 'annotation':
+                return AnnotationDriver::class;
+
+            case 'xml':
+                return SimplifiedXmlDriver::class;
+
+            case 'yml':
+                return SimplifiedYamlDriver::class;
+
+            case 'php':
+                return class_exists(PHPDriver::class) ? PHPDriver::class : LegacyPHPDriver::class;
+
+            case 'staticphp':
+                return class_exists(StaticPHPDriver::class) ? StaticPHPDriver::class : LegacyStaticPHPDriver::class;
+
+            case 'attribute':
+                return AttributeDriver::class;
+
+            default:
+                throw new LogicException(sprintf('Unknown "%s" metadata driver type.', $driverType));
+        }
     }
 
     private function loadMessengerServices(ContainerBuilder $container): void

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -1176,6 +1176,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 return MappingDriverChain::class;
 
             case 'annotation':
+                if (! class_exists(AnnotationDriver::class)) {
+                    throw new LogicException('The annotation driver is only available in doctrine/orm v2.');
+                }
+
                 return AnnotationDriver::class;
 
             case 'xml':

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -898,7 +898,7 @@ class DoctrineExtensionTest extends TestCase
             self::markTestSkipped('This test requires ORM');
         }
 
-        $container = $this->getContainer(['XmlBundle', 'AnnotationsBundle', 'AttributesBundle']);
+        $container = $this->getContainer(['XmlBundle', 'AttributesBundle']);
         $extension = new DoctrineExtension();
 
         $config1 = BundleConfigurationBuilder::createBuilder()
@@ -908,10 +908,7 @@ class DoctrineExtensionTest extends TestCase
                 'default_entity_manager' => 'default',
                 'entity_managers' => [
                     'default' => [
-                        'mappings' => [
-                            'AnnotationsBundle' => [],
-                            'AttributesBundle' => ['type' => 'attribute'],
-                        ],
+                        'mappings' => ['AttributesBundle' => ['type' => 'attribute']],
                     ],
                 ],
             ])
@@ -934,16 +931,10 @@ class DoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', [
-            new Reference(class_exists(AnnotationLoader::class)
-                ? 'doctrine.orm.default_annotation_metadata_driver'
-                : 'doctrine.orm.default_attribute_metadata_driver'),
-            'Fixtures\Bundles\AnnotationsBundle\Entity',
-        ]);
-        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', [
             new Reference('doctrine.orm.default_attribute_metadata_driver'),
             'Fixtures\Bundles\AttributesBundle\Entity',
         ]);
-        $this->assertDICDefinitionMethodCallAt(2, $definition, 'addDriver', [
+        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', [
             new Reference('doctrine.orm.default_xml_metadata_driver'),
             'Fixtures\Bundles\XmlBundle\Entity',
         ]);

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -50,7 +50,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransportFactory;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 
 use function array_values;
 use function class_exists;
@@ -820,39 +819,6 @@ class DoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', [
             new Reference('doctrine.orm.default_xml_metadata_driver'),
             'Fixtures\Bundles\XmlBundle\Entity',
-        ]);
-    }
-
-    public function testAnnotationsBundleMappingDetection(): void
-    {
-        if (! interface_exists(EntityManagerInterface::class)) {
-            self::markTestSkipped('This test requires ORM');
-        }
-
-        $container = $this->getContainer(['AnnotationsBundle']);
-        $extension = new DoctrineExtension();
-
-        $config = BundleConfigurationBuilder::createBuilder()
-            ->addBaseConnection()
-            ->addEntityManager([
-                'default_entity_manager' => 'default',
-                'entity_managers' => [
-                    'default' => [
-                        'mappings' => [
-                            'AnnotationsBundle' => [],
-                        ],
-                    ],
-                ],
-            ])
-            ->build();
-        $extension->load([$config], $container);
-
-        $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
-        $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', [
-            new Reference(class_exists(AnnotationLoader::class)
-                ? 'doctrine.orm.default_annotation_metadata_driver'
-                : 'doctrine.orm.default_attribute_metadata_driver'),
-            'Fixtures\Bundles\AnnotationsBundle\Entity',
         ]);
     }
 

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
@@ -13,7 +13,6 @@
 
         <orm default-entity-manager="em2">
             <entity-manager name="em1">
-                <mapping name="AnnotationsBundle" />
                 <mapping name="AttributesBundle" type="attribute" />
             </entity-manager>
             <entity-manager name="em2" validate-xml-mapping="true">

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
@@ -12,7 +12,6 @@
         </dbal>
 
         <orm validate-xml-mapping="true">
-            <mapping name="AnnotationsBundle" />
             <mapping name="AttributesBundle" type="attribute" />
             <mapping name="YamlBundle" dir="Resources/config/doctrine" alias="yml" />
             <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_default_table_options.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_default_table_options.xml
@@ -16,7 +16,6 @@
         </dbal>
 
         <orm>
-            <mapping name="AnnotationsBundle" />
             <mapping name="AttributesBundle" type="attribute" />
             <mapping name="YamlBundle" dir="Resources/config/doctrine" alias="yml" />
             <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
@@ -10,7 +10,6 @@ doctrine:
         entity_managers:
             em1:
                 mappings:
-                    AnnotationsBundle: ~
                     AttributesBundle:
                       type: attribute
             em2:

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
@@ -8,7 +8,6 @@ doctrine:
     orm:
         validate_xml_mapping: true
         mappings:
-            AnnotationsBundle: ~
             AttributesBundle:
                 type: attribute
             YamlBundle:

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_default_table_options.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_default_table_options.yml
@@ -11,7 +11,6 @@ doctrine:
 
     orm:
         mappings:
-            AnnotationsBundle: ~
             AttributesBundle: ~
             YamlBundle:
                 dir: Resources/config/doctrine


### PR DESCRIPTION
Follows https://github.com/symfony/symfony/pull/33319, takes over https://github.com/doctrine/DoctrineBundle/pull/1755 and fixes https://github.com/symfony/symfony/issues/58738.

Some metadata drivers were removed in doctrine/orm 3 and must then be used from doctrine/persistence.

Since the parameters used to infer their class name are deprecated, this PR rewrites `getMetadataDriverClass` so that it selects the right one.

Note that some class parameters are still used in the `DoctrineExtension` but I considered them out of this PR’s scope.