### PR TITLE
Fix extraneous index:: in docs

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -1,7 +1,3 @@
-.. index::
-   single: Doctrine; ORM Configuration Reference
-   single: Configuration Reference; Doctrine ORM
-
 Configuration Reference
 =======================
 

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -770,10 +770,6 @@ can control. The following configuration options exist for a mapping:
     was specified and the metadata files are most likely in a directory outside
     of a bundle.
 
-.. index::
-    single: Configuration; Doctrine DBAL
-    single: Doctrine; DBAL configuration
-
 Filters Configuration
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
`.. index::` does not seem to be used in `symfony-docs` anymore that's why this PR removes it competely

Closes #1835 