### PR TITLE
Fix compatibility for Symfony 6 projects without doctrine/persistence 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3",
-        "symfony/doctrine-bridge": "^5.4.46 || ^6.4.3 || ^7.0.3",
+        "symfony/doctrine-bridge": "^5.4.46 || ~6.3.12 || ^6.4.3 || ^7.0.3",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.1.1 || ^2.0 || ^3"


### PR DESCRIPTION
Sadly this PR #1832 make projects which do not have compatibility to Symfony 6.4 Doctrine Bridge (like Sulu 2.5 version) yet fail because of using not yet supporting doctrine/persistence 3. Symfony 6.4 doctrine bridge requires atleast doctrine/persistence 3 but some projects may are on Symfony 6 still on version 2. 


Composer instead of downgrading to / keep 2.13.0 it downgrades doctrine/bridge to 5.4.46 which ends up in another failure:


![Bildschirmfoto 2024-11-21 um 10 41 52](https://github.com/user-attachments/assets/382fa091-ea85-4b52-8646-d6515867d143)

> "Declaration of Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getProperties(string $class, array $context = []) must be compatible with Symfony\Component\PropertyInfo\PropertyListExtractorInterface::getProperties(string $class, array $context = []): ?array

Sure projects using flex would not run into that. But to avoid this error on libs without flex and with a wider range of support symfony version we should also add the version of 6.3.12 released with the 6.4.3 to still support Symfony 6 + Doctrine Persistence 2.

@MatTheCat 