### PR TITLE
Make doctrine/cache optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/dbal": "^3.7.0 || ^4.0",
         "doctrine/persistence": "^2.2 || ^3",
         "doctrine/sql-formatter": "^1.0.1",
@@ -46,6 +45,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1 || ^2",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/coding-standard": "^12",
         "doctrine/deprecations": "^1.0",
         "doctrine/orm": "^2.17 || ^3.0",
@@ -70,6 +70,7 @@
     },
     "conflict": {
         "doctrine/annotations": ">=3.0",
+        "doctrine/cache": "< 1.11",
         "doctrine/orm": "<2.17 || >=4.0",
         "twig/twig": "<1.34 || >=2.0 <2.4"
     },


### PR DESCRIPTION
DBAL and ORM don't need the doctrine/cache package anymore, so let's not force an obsolete package into the vendor folders of downstream projects.