### PR TITLE
Ensure classes using the `#[Entity]` attribute are not declared as service

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -27,6 +27,9 @@ use Doctrine\ORM\Mapping\Driver\PHPDriver as LegacyPHPDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
 use Doctrine\ORM\Mapping\Driver\StaticPHPDriver as LegacyStaticPHPDriver;
+use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand;
@@ -642,6 +645,16 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'priority'   => $attribute->priority,
                 'connection' => $attribute->connection,
             ]);
+        });
+
+        $container->registerAttributeForAutoconfiguration(Embeddable::class, static function (ChildDefinition $definition) {
+            $definition->setAbstract(true)->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', Embeddable::class)]);
+        });
+        $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
+            $definition->setAbstract(true)->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', Entity::class)]);
+        });
+        $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition) {
+            $definition->setAbstract(true)->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', MappedSuperclass::class)]);
         });
 
         /** @see DoctrineBundle::boot() */

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -32,6 +32,9 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
+use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use InvalidArgumentException;
 use LogicException;
@@ -1163,6 +1166,43 @@ class DoctrineExtensionTest extends TestCase
                 'cacheConfig' => ['type' => 'service', 'id' => 'service_target_result'],
             ],
         ];
+    }
+
+    /** @return array<array{0: class-string}> */
+    public static function provideAttributeExcludedFromContainer(): array
+    {
+        return [
+            'Embeddable' => [Embeddable::class],
+            'Entity' => [Entity::class],
+            'MappedSuperclass' => [MappedSuperclass::class],
+        ];
+    }
+
+    /** @dataProvider provideAttributeExcludedFromContainer */
+    public function testEntityAttributeExcludesFromContainer(string $class)
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $config = BundleConfigurationBuilder::createBuilder()
+            ->addBaseConnection()
+            ->addBaseEntityManager()
+            ->build();
+
+        $extension->load([$config], $container);
+
+        $attributes = $container->getAutoconfiguredAttributes();
+        $this->assertInstanceOf(Closure::class, $attributes[$class]);
+
+        $definition = new ChildDefinition('');
+        $attributes[$class]($definition);
+
+        $this->assertSame([['source' => sprintf('with #[%s] attribute', $class)]], $definition->getTag('container.excluded'));
+        $this->assertTrue($definition->isAbstract());
     }
 
     public function testAsEntityListenerAttribute()


### PR DESCRIPTION
In order to enable discovery of entity classes by the Symfony DIC, we need to exclude them from being registered as actual services.

- We can remove the exclusion of the `src/Entity/` directory from the [`symfony/framework-bundle` recipe](https://github.com/symfony/recipes/blob/2d8f656159ca9132c55b6e848171a7dabc1d8554/symfony/framework-bundle/7.2/config/services.yaml#L20).
- Entity classes using the `#[ApiResource]` attribute can be discovered using DI instead of using a custom-made mechanism of directory scanning and cache: https://github.com/api-platform/core/pull/6943
- This is not using the new upcoming helpers for compatiblity with Symfony 6.4: https://github.com/symfony/symfony/pull/59704
- The same was done in DoctrineMongoDBODMBundle: https://github.com/doctrine/DoctrineMongoDBBundle/pull/876