### PR TITLE
Rename abstract test case classes with deprecated "Test"  suffix

### DIFF
--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -58,7 +58,7 @@ use function uniqid;
 
 use const DIRECTORY_SEPARATOR;
 
-abstract class AbstractDoctrineExtensionTest extends TestCase
+abstract class AbstractDoctrineExtensionTestCase extends TestCase
 {
     abstract protected function loadFromFile(ContainerBuilder $container, string $file): void;
 

--- a/tests/DependencyInjection/XmlDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/XmlDoctrineExtensionTest.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-class XmlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
+class XmlDoctrineExtensionTest extends AbstractDoctrineExtensionTestCase
 {
     protected function loadFromFile(ContainerBuilder $container, string $file): void
     {

--- a/tests/DependencyInjection/YamlDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/YamlDoctrineExtensionTest.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-class YamlDoctrineExtensionTest extends AbstractDoctrineExtensionTest
+class YamlDoctrineExtensionTest extends AbstractDoctrineExtensionTestCase
 {
     protected function loadFromFile(ContainerBuilder $container, string $file): void
     {


### PR DESCRIPTION
> Abstract test case classes with "Test" suffix are deprecated (Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\AbstractDoctrineExtensionTest)

- https://github.com/sebastianbergmann/phpunit/issues/5132