### PR TITLE
Add loaded entities profiler section

### DIFF
--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -43,12 +43,15 @@ use function usort;
  *    errors: array<string, array<class-string, list<string>>>,
  *    managers: list<string>,
  *    queries: array<string, list<QueryType>>,
+ *    entityCounts: array<string, array<class-string, int>>
  * }
  * @psalm-property DataType $data
  */
 class DoctrineDataCollector extends BaseCollector
 {
     private int|null $invalidEntityCount = null;
+
+    private int|null $managedEntityCount = null;
 
     /**
      * @var mixed[][]|null
@@ -117,7 +120,7 @@ class DoctrineDataCollector extends BaseCollector
             }
 
             foreach ($em->getUnitOfWork()->getIdentityMap() as $className => $entityList) {
-                $entityCounts[$className] = ($entityCounts[$className] ?? 0) + count($entityList);
+                $entityCounts[$name][$className] = ($entityCounts[$name][$className] ?? 0) + count($entityList);
             }
 
             $emConfig   = $em->getConfiguration();
@@ -240,7 +243,16 @@ class DoctrineDataCollector extends BaseCollector
 
     public function getManagedEntityCount(): int
     {
-        return array_sum($this->data['entityCounts']);
+        if ($this->managedEntityCount === null) {
+            $total = 0;
+            foreach ($this->data['entityCounts'] as $entities) {
+                $total += array_sum($entities);
+            }
+
+            $this->managedEntityCount = $total;
+        }
+
+        return $this->managedEntityCount;
     }
 
     /** @return array<class-string, int> */

--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -120,7 +120,7 @@ class DoctrineDataCollector extends BaseCollector
             }
 
             foreach ($em->getUnitOfWork()->getIdentityMap() as $className => $entityList) {
-                $entityCounts[$name][$className] = ($entityCounts[$name][$className] ?? 0) + count($entityList);
+                $entityCounts[$name][$className] = count($entityList);
             }
 
             $emConfig   = $em->getConfiguration();

--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -119,9 +119,13 @@ class DoctrineDataCollector extends BaseCollector
                 }
             }
 
+            $entityCounts[$name] = [];
             foreach ($em->getUnitOfWork()->getIdentityMap() as $className => $entityList) {
                 $entityCounts[$name][$className] = count($entityList);
             }
+
+            // Sort entities by count (in descending order)
+            arsort($entityCounts[$name]);
 
             $emConfig   = $em->getConfiguration();
             $slcEnabled = $emConfig->isSecondLevelCacheEnabled();
@@ -173,9 +177,6 @@ class DoctrineDataCollector extends BaseCollector
                 $caches['regions']['misses'][$key] += $value;
             }
         }
-
-        // Sort entities by count (in descending order)
-        arsort($entityCounts);
 
         $this->data['entities']     = $entities;
         $this->data['errors']       = $errors;
@@ -255,7 +256,7 @@ class DoctrineDataCollector extends BaseCollector
         return $this->managedEntityCount;
     }
 
-    /** @return array<class-string, int> */
+    /** @return array<string, array<class-string, int>> */
     public function getManagedEntityCountByClass(): array
     {
         return $this->data['entityCounts'];

--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -17,6 +17,7 @@ use Throwable;
 
 use function array_map;
 use function array_sum;
+use function arsort;
 use function assert;
 use function count;
 use function usort;
@@ -68,9 +69,10 @@ class DoctrineDataCollector extends BaseCollector
     {
         parent::collect($request, $response, $exception);
 
-        $errors   = [];
-        $entities = [];
-        $caches   = [
+        $errors       = [];
+        $entities     = [];
+        $entityCounts = [];
+        $caches       = [
             'enabled' => false,
             'log_enabled' => false,
             'counts' => [
@@ -112,6 +114,10 @@ class DoctrineDataCollector extends BaseCollector
 
                     $errors[$name][$class->getName()] = $classErrors;
                 }
+            }
+
+            foreach ($em->getUnitOfWork()->getIdentityMap() as $className => $entityList) {
+                $entityCounts[$className] = ($entityCounts[$className] ?? 0) + count($entityList);
             }
 
             $emConfig   = $em->getConfiguration();
@@ -165,10 +171,14 @@ class DoctrineDataCollector extends BaseCollector
             }
         }
 
-        $this->data['entities'] = $entities;
-        $this->data['errors']   = $errors;
-        $this->data['caches']   = $caches;
-        $this->groupedQueries   = null;
+        // Sort entities by count (in descending order)
+        arsort($entityCounts);
+
+        $this->data['entities']     = $entities;
+        $this->data['errors']       = $errors;
+        $this->data['caches']       = $caches;
+        $this->data['entityCounts'] = $entityCounts;
+        $this->groupedQueries       = null;
     }
 
     /** @return array<string, array<class-string, array{class: class-string, file: false|string, line: false|int}>> */
@@ -226,6 +236,17 @@ class DoctrineDataCollector extends BaseCollector
     public function getInvalidEntityCount()
     {
         return $this->invalidEntityCount ??= array_sum(array_map('count', $this->data['errors']));
+    }
+
+    public function getManagedEntityCount(): int
+    {
+        return array_sum($this->data['entityCounts']);
+    }
+
+    /** @return array<class-string, int> */
+    public function getManagedEntityCountByClass(): array
+    {
+        return $this->data['entityCounts'];
     }
 
     /**

--- a/templates/Collector/db.html.twig
+++ b/templates/Collector/db.html.twig
@@ -396,7 +396,16 @@
         <div class="tab">
             <h3 class="tab-title">Managed Entities</h3>
             <div class="tab-content">
-                {{ helper.render_simple_table('Class', 'Amount of managed objects', collector.managedEntityCountByClass) }}
+                {% if not collector.managedEntityCountByClass %}
+                    <div class="empty">
+                        <p>No mapped entities.</p>
+                    </div>
+                {% else %}
+                    {% for manager, entityCounts in collector.managedEntityCountByClass %}
+                        <h3>{{ manager }} <small>entity manager</small></h3>
+                        {{ helper.render_simple_table('Class', 'Amount of managed objects', entityCounts) }}
+                    {% endfor %}
+                {% endif %}
             </div>
         </div>
 

--- a/templates/Collector/db.html.twig
+++ b/templates/Collector/db.html.twig
@@ -402,7 +402,7 @@
                     </div>
                 {% else %}
                     {% for manager, entityCounts in collector.managedEntityCountByClass %}
-                        <h3>{{ manager }} <small>entity manager</small></h3>
+                        <h4>{{ manager }} <small>entity manager</small></h4>
                         {{ helper.render_simple_table('Class', 'Amount of managed objects', entityCounts) }}
                     {% endfor %}
                 {% endif %}

--- a/templates/Collector/db.html.twig
+++ b/templates/Collector/db.html.twig
@@ -420,7 +420,7 @@
                 {% else %}
                     {% for manager, classes in collector.entities %}
                         {% if collector.managers|length > 1 %}
-                            <h3>{{ manager }} <small>entity manager</small></h3>
+                            <h4>{{ manager }} <small>entity manager</small></h4>
                         {% endif %}
 
                         {% if classes is empty %}

--- a/templates/Collector/db.html.twig
+++ b/templates/Collector/db.html.twig
@@ -44,6 +44,10 @@
                 <b>Invalid entities</b>
                 <span class="sf-toolbar-status {{ collector.invalidEntityCount > 0 ? 'sf-toolbar-status-red' : '' }}">{{ collector.invalidEntityCount }}</span>
             </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Managed entities</b>
+                <span class="sf-toolbar-status">{{ collector.managedEntityCount }}</span>
+            </div>
             {% if collector.cacheEnabled %}
                 <div class="sf-toolbar-info-piece">
                     <b>Cache hits</b>
@@ -136,6 +140,11 @@
             <div class="metric">
                 <span class="value">{{ collector.invalidEntityCount }}</span>
                 <span class="label">Invalid entities</span>
+            </div>
+
+            <div class="metric">
+                <span class="value">{{ collector.managedEntityCount }}</span>
+                <span class="label">Managed entities</span>
             </div>
         </div>
 
@@ -381,6 +390,13 @@
                         {% endif %}
                     {% endif %}
                 {% endif %}
+            </div>
+        </div>
+
+        <div class="tab">
+            <h3 class="tab-title">Managed Entities</h3>
+            <div class="tab-content">
+                {{ helper.render_simple_table('Class', 'Amount of managed objects', collector.managedEntityCountByClass) }}
             </div>
         </div>
 

--- a/templates/Collector/db.html.twig
+++ b/templates/Collector/db.html.twig
@@ -398,7 +398,7 @@
             <div class="tab-content">
                 {% if not collector.managedEntityCountByClass %}
                     <div class="empty">
-                        <p>No mapped entities.</p>
+                        <p>No managed entities.</p>
                     </div>
                 {% else %}
                     {% for manager, entityCounts in collector.managedEntityCountByClass %}

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -8,9 +8,11 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use stdClass;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,10 +30,11 @@ class DoctrineDataCollectorTest extends TestCase
             self::markTestSkipped('This test requires ORM');
         }
 
-        $manager   = $this->createMock(EntityManagerInterface::class);
-        $config    = $this->createMock(Configuration::class);
-        $factory   = $this->createMock(ClassMetadataFactory::class);
-        $collector = $this->createCollector(['default' => $manager], true, $this->createMock(DebugDataHolder::class));
+        $manager    = $this->createMock(EntityManagerInterface::class);
+        $config     = $this->createMock(Configuration::class);
+        $factory    = $this->createMock(ClassMetadataFactory::class);
+        $collector  = $this->createCollector(['default' => $manager], true, $this->createMock(DebugDataHolder::class));
+        $unitOfWork = $this->createMock(UnitOfWork::class);
 
         $manager->expects($this->any())
             ->method('getMetadataFactory')
@@ -39,6 +42,15 @@ class DoctrineDataCollectorTest extends TestCase
         $manager->expects($this->any())
             ->method('getConfiguration')
             ->will($this->returnValue($config));
+        $manager->expects($this->any())
+            ->method('getUnitOfWork')
+            ->will($this->returnValue($unitOfWork));
+        $unitOfWork->expects($this->any())
+            ->method('getIdentityMap')
+            ->will($this->returnValue([
+                self::FIRST_ENTITY => [new stdClass()],
+                self::SECOND_ENTITY => [new stdClass(), new stdClass()],
+            ]));
 
         $config->expects($this->once())
             ->method('isSecondLevelCacheEnabled')
@@ -58,6 +70,7 @@ class DoctrineDataCollectorTest extends TestCase
         $entities = $collector->getEntities();
         $this->assertArrayHasKey('default', $entities);
         $this->assertCount(2, $entities['default']);
+        $this->assertSame(3, $collector->getManagedEntityCount());
     }
 
     public function testDoesNotCollectEntities(): void
@@ -66,14 +79,21 @@ class DoctrineDataCollectorTest extends TestCase
             self::markTestSkipped('This test requires ORM');
         }
 
-        $manager   = $this->createMock(EntityManager::class);
-        $config    = $this->createMock(Configuration::class);
-        $collector = $this->createCollector(['default' => $manager], false, $this->createMock(DebugDataHolder::class));
+        $manager    = $this->createMock(EntityManager::class);
+        $config     = $this->createMock(Configuration::class);
+        $collector  = $this->createCollector(['default' => $manager], false, $this->createMock(DebugDataHolder::class));
+        $unitOfWork = $this->createMock(UnitOfWork::class);
 
         $manager->expects($this->never())
             ->method('getMetadataFactory');
         $manager->method('getConfiguration')
             ->will($this->returnValue($config));
+        $manager->expects($this->any())
+            ->method('getUnitOfWork')
+            ->will($this->returnValue($unitOfWork));
+        $unitOfWork->expects($this->any())
+            ->method('getIdentityMap')
+            ->will($this->returnValue([]));
 
         $collector->collect(new Request(), new Response());
 

--- a/tests/ProfilerTest.php
+++ b/tests/ProfilerTest.php
@@ -44,6 +44,7 @@ class ProfilerTest extends BaseTestCase
         $registry              = $this->getMockBuilder(ManagerRegistry::class)->getMock();
         $registry->method('getConnectionNames')->willReturn([]);
         $registry->method('getManagerNames')->willReturn([]);
+        $registry->method('getManagers')->willReturn([]);
         $this->collector = new DoctrineDataCollector($registry, true, $this->debugDataHolder);
 
         $twigLoaderFilesystem = new FilesystemLoader(__DIR__ . '/../templates/Collector');

--- a/tests/ProfilerTest.php
+++ b/tests/ProfilerTest.php
@@ -44,7 +44,6 @@ class ProfilerTest extends BaseTestCase
         $registry              = $this->getMockBuilder(ManagerRegistry::class)->getMock();
         $registry->method('getConnectionNames')->willReturn([]);
         $registry->method('getManagerNames')->willReturn([]);
-        $registry->method('getManagers')->willReturn([]);
         $this->collector = new DoctrineDataCollector($registry, true, $this->debugDataHolder);
 
         $twigLoaderFilesystem = new FilesystemLoader(__DIR__ . '/../templates/Collector');
@@ -120,5 +119,8 @@ class ProfilerTest extends BaseTestCase
             '.*',
             preg_quote('SELECT * FROM foo WHERE bar IN ( ? , ? )'),
         ) . '/', $output));
+
+        $this->assertStringContainsString('Managed entities', $output);
+        $this->assertStringContainsString('No managed entities.', $output);
     }
 }


### PR DESCRIPTION
## The Feature
Showing a list of entity classes and the amount of entities that are managed:
![image](https://github.com/user-attachments/assets/207d8aea-b256-4d6e-a0da-5de4f8edcb8d)

## The reasoning
Doctrine has a nice lazy loading feature of entities however I don't think many people realize that this can create a huge object graph in the entity manager. As flushing will go in and check all the entities for updates.