### PR TITLE
Update configuration.rst: Adding identity_generation_preferences:

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -221,6 +221,8 @@ Configuration Reference
                 proxy_namespace:              Proxies
                 # Enables the new implementation of proxies based on lazy ghosts instead of using the legacy implementation
                 enable_lazy_ghost_objects:    false
+                identity_generation_preferences:
+                    Doctrine\DBAL\Platforms\PostgreSQLPlatform: identity
 
                 entity_managers:
 


### PR DESCRIPTION
Adding missing documentation of https://github.com/doctrine/DoctrineBundle/pull/1813

For PHP, it's this syntax, right?:
```php
$entityManager->identityGenerationPreference(PostgreSQLPlatform::class, ClassMetadata::GENERATOR_TYPE_IDENTITY);
```