### PR TITLE
Fix autowiring alias target name

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -307,7 +307,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ]);
 
         $container
-            ->registerAliasForArgument($connectionId, Connection::class, sprintf('%sConnection', $name))
+            ->registerAliasForArgument($name, Connection::class, sprintf('%sConnection', $name))
             ->setPublic(false);
 
         // Set class in case "wrapper_class" option was used to assist IDEs
@@ -777,7 +777,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ->setConfigurator([new Reference($managerConfiguratorName), 'configure']);
 
         $container
-            ->registerAliasForArgument($entityManagerId, EntityManagerInterface::class, sprintf('%sEntityManager', $entityManager['name']))
+            ->registerAliasForArgument($entityManager['name'], EntityManagerInterface::class, sprintf('%sEntityManager', $entityManager['name']))
             ->setPublic(false);
 
         $container->setAlias(


### PR DESCRIPTION
The service id is not meant to be used as a target. The name is.