### PR TITLE
Improve named autowiring targets

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -309,7 +309,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ]);
 
         $container
-            ->registerAliasForArgument($connectionId, Connection::class, sprintf('%sConnection', $name))
+            ->registerAliasForArgument($connectionId, Connection::class, sprintf('%s.connection', $name))
             ->setPublic(false);
 
         // Set class in case "wrapper_class" option was used to assist IDEs
@@ -786,7 +786,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ->setConfigurator([new Reference($managerConfiguratorName), 'configure']);
 
         $container
-            ->registerAliasForArgument($entityManagerId, EntityManagerInterface::class, sprintf('%sEntityManager', $entityManager['name']))
+            ->registerAliasForArgument($entityManagerId, EntityManagerInterface::class, sprintf('%s.entity_manager', $entityManager['name']))
             ->setPublic(false);
 
         $container->setAlias(


### PR DESCRIPTION
This change provides better hints for `#[Target]` attributes, without changing anything else.

When running debug:autowiring:

![image](https://github.com/user-attachments/assets/25998480-fce3-4da6-b7ae-b14307227a19)


And in the code, this allows:

```php
function __construct(#[Target('default.entity_manager') EntityManagerInterface $em)
```