### PR TITLE
Update Symfony bundle metadata

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -14,6 +14,11 @@ branches:
 maintained_branches:
     - "2.15.x"
     - "2.16.x"
-doc_dir: { "2.12.x": "docs/", "2.13.x": "docs/en/" }
+doc_dir:
+    "2.12.x": docs/
+    "2.13.x": docs/en/
+    "2.14.x": docs/en/
+    "2.15.x": docs/en/
+    "2.16.x": docs/en/
 current_branch: "2.15.x"
 dev_branch: "2.16.x"

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -14,11 +14,6 @@ branches:
 maintained_branches:
     - "2.15.x"
     - "2.16.x"
-doc_dir:
-    "2.12.x": docs/
-    "2.13.x": docs/en/
-    "2.14.x": docs/en/
-    "2.15.x": docs/en/
-    "2.16.x": docs/en/
+doc_dir: "docs/en/"
 current_branch: "2.15.x"
 dev_branch: "2.16.x"


### PR DESCRIPTION
The `doc_dir` section must configure each version explicitly. We didn't include 2.15 and 2.16 branches, so the doc build was failing and the docs at https://symfony.com/bundles/DoctrineBundle/current/index.html were not visible anymore. Thanks.