### PR TITLE
Sort middleware without maintaining index association

### DIFF
--- a/src/DependencyInjection/Compiler/MiddlewaresPass.php
+++ b/src/DependencyInjection/Compiler/MiddlewaresPass.php
@@ -14,7 +14,7 @@ use function array_map;
 use function array_values;
 use function is_subclass_of;
 use function sprintf;
-use function uasort;
+use function usort;
 
 final class MiddlewaresPass implements CompilerPassInterface
 {
@@ -77,7 +77,7 @@ final class MiddlewaresPass implements CompilerPassInterface
                 array_keys($middlewareRefs),
                 array_values($middlewareRefs),
             );
-            uasort($middlewareRefs, static fn (array $a, array $b): int => $b[0] <=> $a[0] ?: $a[1] <=> $b[1]);
+            usort($middlewareRefs, static fn (array $a, array $b): int => $b[0] <=> $a[0] ?: $a[1] <=> $b[1]);
             $middlewareRefs = array_map(static fn (array $value): Reference => $value[2], $middlewareRefs);
 
             $container


### PR DESCRIPTION
While debugging an issue with a custom DBAL Driver with Xdebug, I noticed that the order of the middleware was not with what I was expecting.

It turns out this was an issue with Xdebug, because I had the option "Sort Variables Alphabetically" enabled.

But it lead me to discover this.

The MiddlewarePass sorts the middleware based on priority. And it works as expected.

But it sorts it while maintaining index association. There is no point in keeping that. It only confuses others.