### PR TITLE
Register doctrine:mapping:describe command

### DIFF
--- a/config/orm.xml
+++ b/config/orm.xml
@@ -241,6 +241,11 @@
             <tag name="console.command" command="doctrine:mapping:info" />
         </service>
 
+        <service id="doctrine.mapping_describe_command" class="Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand">
+            <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
+            <tag name="console.command" command="doctrine:mapping:describe" />
+        </service>
+
         <service id="doctrine.clear_query_region_command" class="Doctrine\ORM\Tools\Console\Command\ClearCache\QueryRegionCommand">
             <argument type="service" id="doctrine.orm.command.entity_manager_provider" />
             <tag name="console.command" command="doctrine:cache:clear-query-region" />

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\Command\InfoCommand;
+use Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -63,6 +64,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ManagerRegistry::class, $container->get('doctrine'));
         $this->assertInstanceOf(UniqueEntityValidator::class, $container->get('doctrine.orm.validator.unique'));
         $this->assertInstanceOf(InfoCommand::class, $container->get('doctrine.mapping_info_command'));
+        $this->assertInstanceOf(MappingDescribeCommand::class, $container->get('doctrine.mapping_describe_command'));
         $this->assertInstanceOf(UpdateCommand::class, $container->get('doctrine.schema_update_command'));
 
         $this->assertTrue(Type::hasType('test'));


### PR DESCRIPTION
Registers the orm:mapping:describe command as `doctrine:mapping:describe <entity>` for consistency with other debug commands.

Relates to #1883 

