### PR TITLE
Do not enable the proxy autoloader or cache warmer when using native lazy objects

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -220,6 +220,8 @@ Configuration Reference
                 proxy_namespace:              Proxies
                 # Enables the new implementation of proxies based on lazy ghosts instead of using the legacy implementation
                 enable_lazy_ghost_objects:    false
+                # Enables the new native implementation of PHP lazy objects instead of generated proxies
+                enable_native_lazy_objects:   false
                 identity_generation_preferences:
                     Doctrine\DBAL\Platforms\PostgreSQLPlatform: identity
 
@@ -257,8 +259,6 @@ Configuration Reference
                         class_metadata_factory_name:  Doctrine\ORM\Mapping\ClassMetadataFactory
                         default_repository_class:     Doctrine\ORM\EntityRepository
                         auto_mapping:                 false
-                        # Opt-in to PHP native lazy objects
-                        enable_native_lazy_objects:   false
                         # Opt-in to new mapping driver mode as of Doctrine ORM 2.16, https://github.com/doctrine/orm/pull/10455
                         report_fields_where_declared: false
                         # 0pt-in to the new mapping driver mode as of Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -428,6 +428,7 @@ class Configuration implements ConfigurationInterface
             'default_entity_manager' => true,
             'auto_generate_proxy_classes' => true,
             'enable_lazy_ghost_objects' => true,
+            'enable_native_lazy_objects' => true,
             'proxy_dir' => true,
             'proxy_namespace' => true,
             'resolve_target_entities' => true,
@@ -505,6 +506,10 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enable_lazy_ghost_objects')
                             ->defaultValue(! method_exists(ProxyFactory::class, 'resetUninitializedProxy'))
                             ->info('Enables the new implementation of proxies based on lazy ghosts instead of using the legacy implementation')
+                        ->end()
+                        ->booleanNode('enable_native_lazy_objects')
+                            ->defaultFalse()
+                            ->info('Enables the new native implementation of PHP lazy objects instead of generated proxies')
                         ->end()
                         ->scalarNode('proxy_dir')
                             ->defaultValue('%kernel.build_dir%/doctrine/orm/Proxies')
@@ -658,10 +663,6 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('class_metadata_factory_name')->defaultValue(ClassMetadataFactory::class)->end()
                     ->scalarNode('default_repository_class')->defaultValue(EntityRepository::class)->end()
                     ->scalarNode('auto_mapping')->defaultFalse()->end()
-                    ->booleanNode('enable_native_lazy_objects')
-                        ->defaultFalse()
-                        ->info('Enables the new native implementation of PHP lazy objects instead of generated proxies')
-                    ->end()
                     ->scalarNode('naming_strategy')->defaultValue('doctrine.orm.naming_strategy.default')->end()
                     ->scalarNode('quote_strategy')->defaultValue('doctrine.orm.quote_strategy.default')->end()
                     ->scalarNode('typed_field_mapper')->defaultValue('doctrine.orm.typed_field_mapper.default')->end()

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
+use Doctrine\ORM\Configuration as ORMConfiguration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\AbstractIdGenerator;
@@ -71,8 +72,10 @@ use Symfony\Component\VarExporter\ProxyHelper;
 use function array_intersect_key;
 use function array_keys;
 use function array_merge;
+use function assert;
 use function class_exists;
 use function interface_exists;
+use function is_bool;
 use function is_dir;
 use function method_exists;
 use function reset;
@@ -577,7 +580,19 @@ class DoctrineExtension extends AbstractDoctrineExtension
             trigger_deprecation('doctrine/doctrine-bundle', '2.11', 'Not setting "doctrine.orm.enable_lazy_ghost_objects" to true is deprecated.');
         }
 
-        $options = ['auto_generate_proxy_classes', 'enable_lazy_ghost_objects', 'proxy_dir', 'proxy_namespace'];
+        if ($config['enable_native_lazy_objects'] ?? false) {
+            /** @phpstan-ignore function.alreadyNarrowedType */
+            if (! method_exists(ORMConfiguration::class, 'enableNativeLazyObjects')) {
+                throw new LogicException(
+                    'Native lazy objects are not supported with your installed version of the ORM. Please upgrade to "doctrine/orm:^3.4".',
+                );
+            }
+        } elseif (! class_exists(AnnotationDriver::class)) {
+            // Only emit the deprecation notice for ORM 3 users
+            trigger_deprecation('doctrine/doctrine-bundle', '2.16', 'Not setting "doctrine.orm.enable_native_lazy_objects" to true is deprecated.');
+        }
+
+        $options = ['auto_generate_proxy_classes', 'enable_lazy_ghost_objects', 'enable_native_lazy_objects', 'proxy_dir', 'proxy_namespace'];
         foreach ($options as $key) {
             $container->setParameter('doctrine.orm.' . $key, $config[$key]);
         }
@@ -703,11 +718,15 @@ class DoctrineExtension extends AbstractDoctrineExtension
         ];
 
         if (PHP_VERSION_ID >= 80400 && class_exists(LegacyReflectionFields::class)) {
-            $methods['enableNativeLazyObjects'] = $entityManager['enable_native_lazy_objects'];
+            $enableNativeLazyObjects = $container->getParameter('doctrine.orm.enable_native_lazy_objects');
+
+            assert(is_bool($enableNativeLazyObjects));
+
+            $methods['enableNativeLazyObjects'] = $enableNativeLazyObjects;
 
             // Do not set deprecated proxy configurations when native lazy objects are enabled with `doctrine/orm:^3.5`
             /** @phpstan-ignore function.alreadyNarrowedType */
-            if ($entityManager['enable_native_lazy_objects'] && method_exists(ORMSetup::class, 'createAttributeMetadataConfig')) {
+            if ($enableNativeLazyObjects && method_exists(ORMSetup::class, 'createAttributeMetadataConfig')) {
                 unset(
                     $methods['setProxyDir'],
                     $methods['setProxyNamespace'],

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -587,6 +587,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
                     'Native lazy objects are not supported with your installed version of the ORM. Please upgrade to "doctrine/orm:^3.4".',
                 );
             }
+
+            $container->removeDefinition('doctrine.orm.proxy_cache_warmer');
         } elseif (! class_exists(AnnotationDriver::class)) {
             // Only emit the deprecation notice for ORM 3 users
             trigger_deprecation('doctrine/doctrine-bundle', '2.16', 'Not setting "doctrine.orm.enable_native_lazy_objects" to true is deprecated.');

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -588,6 +588,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 );
             }
 
+            if (PHP_VERSION_ID < 80400) {
+                throw new LogicException('Using native lazy objects require PHP 8.4 or higher.');
+            }
+
             $container->removeDefinition('doctrine.orm.proxy_cache_warmer');
         } elseif (! class_exists(AnnotationDriver::class)) {
             // Only emit the deprecation notice for ORM 3 users

--- a/src/DoctrineBundle.php
+++ b/src/DoctrineBundle.php
@@ -84,8 +84,12 @@ class DoctrineBundle extends Bundle
 
     public function boot(): void
     {
-        // Register an autoloader for proxies to avoid issues when unserializing them
-        // when the ORM is used.
+        // Register an autoloader for proxies when native lazy objects are not in use
+        // to avoid issues when unserializing them when the ORM is used.
+        if ($this->container->hasParameter('doctrine.orm.enable_native_lazy_objects') && $this->container->getParameter('doctrine.orm.enable_native_lazy_objects')) {
+            return;
+        }
+
         if (! $this->container->hasParameter('doctrine.orm.proxy_namespace')) {
             return;
         }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -60,12 +60,15 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(EntityManager::class, $container->get('doctrine.orm.entity_manager'));
         $this->assertInstanceOf(EventManager::class, $container->get('doctrine.orm.default_entity_manager.event_manager'));
         $this->assertInstanceOf(EventManager::class, $container->get('doctrine.dbal.event_manager'));
-        $this->assertInstanceOf(ProxyCacheWarmer::class, $container->get('doctrine.orm.proxy_cache_warmer'));
         $this->assertInstanceOf(ManagerRegistry::class, $container->get('doctrine'));
         $this->assertInstanceOf(UniqueEntityValidator::class, $container->get('doctrine.orm.validator.unique'));
         $this->assertInstanceOf(InfoCommand::class, $container->get('doctrine.mapping_info_command'));
         $this->assertInstanceOf(MappingDescribeCommand::class, $container->get('doctrine.mapping_describe_command'));
         $this->assertInstanceOf(UpdateCommand::class, $container->get('doctrine.schema_update_command'));
+
+        if (! $container->getParameter('doctrine.orm.enable_native_lazy_objects')) {
+            $this->assertInstanceOf(ProxyCacheWarmer::class, $container->get('doctrine.orm.proxy_cache_warmer'));
+        }
 
         $this->assertTrue(Type::hasType('test'));
 

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -1509,10 +1509,9 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
             self::markTestSkipped('This test requires PHP 8.3 or less');
         }
 
-        $container     = $this->loadContainer('orm_native_lazy_objects_enable');
-        $entityManager = $container->get('doctrine.orm.entity_manager');
-
-        $this->assertFalse($entityManager->getConfiguration()->isNativeLazyObjectsEnabled());
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Using native lazy objects require PHP 8.4 or higher.');
+        $this->loadContainer('orm_native_lazy_objects_enable');
     }
 
     /** @param list<string> $bundles */

--- a/tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
+++ b/tests/DependencyInjection/Compiler/IdGeneratorPassTest.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheCompatibili
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\CustomIdGenerator;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Fixtures\Bundles\AttributesBundle\AttributesBundle;
 use Fixtures\Bundles\AttributesBundle\Entity\TestCustomIdGeneratorEntity as AttributeCustomIdGeneratorEntity;
@@ -16,8 +17,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 use function assert;
 use function interface_exists;
+use function method_exists;
 use function sys_get_temp_dir;
 use function uniqid;
+
+use const PHP_VERSION_ID;
 
 class IdGeneratorPassTest extends TestCase
 {
@@ -88,6 +92,8 @@ class IdGeneratorPassTest extends TestCase
                     'mappings' => $mappings,
                     'report_fields_where_declared' => true,
                     'enable_lazy_ghost_objects' => true,
+                    /** @phpstan-ignore function.alreadyNarrowedType */
+                    'enable_native_lazy_objects' => PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects'),
                 ],
             ],
         ], $container);

--- a/tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/tests/DependencyInjection/Fixtures/TestKernel.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\ORM\Configuration;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -11,8 +12,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
 use function md5;
+use function method_exists;
 use function mt_rand;
 use function sys_get_temp_dir;
+
+use const PHP_VERSION_ID;
 
 class TestKernel extends Kernel
 {
@@ -51,6 +55,8 @@ class TestKernel extends Kernel
                     'report_fields_where_declared' => true,
                     'auto_generate_proxy_classes' => true,
                     'enable_lazy_ghost_objects' => true,
+                    /** @phpstan-ignore function.alreadyNarrowedType */
+                    'enable_native_lazy_objects' => PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects'),
                     'mappings' => [
                         'RepositoryServiceBundle' => [
                             'type' => 'attribute',

--- a/tests/ServiceRepositoryTest.php
+++ b/tests/ServiceRepositoryTest.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheCompatibili
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
@@ -22,8 +23,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 use function class_exists;
 use function interface_exists;
+use function method_exists;
 use function sys_get_temp_dir;
 use function uniqid;
+
+use const PHP_VERSION_ID;
 
 class ServiceRepositoryTest extends TestCase
 {
@@ -87,6 +91,8 @@ class ServiceRepositoryTest extends TestCase
                 'orm' => [
                     'report_fields_where_declared' => true,
                     'enable_lazy_ghost_objects' => true,
+                    /** @phpstan-ignore function.alreadyNarrowedType */
+                    'enable_native_lazy_objects' => PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects'),
                     'mappings' => [
                         'RepositoryServiceBundle' => [
                             'type' => 'attribute',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheCompatibili
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Configuration;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
@@ -15,8 +16,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 use function class_exists;
+use function method_exists;
 use function sys_get_temp_dir;
 use function uniqid;
+
+use const PHP_VERSION_ID;
 
 class TestCase extends BaseTestCase
 {
@@ -72,6 +76,8 @@ class TestCase extends BaseTestCase
                         ],
                     ],
                     'resolve_target_entities' => [UserInterface::class => 'stdClass'],
+                    /** @phpstan-ignore function.alreadyNarrowedType */
+                    'enable_native_lazy_objects' => PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects'),
                 ],
             ],
         ], $container);

--- a/tests/baseline-ignore
+++ b/tests/baseline-ignore
@@ -1,2 +1,3 @@
 %"doctrine.orm.controller_resolver.auto_mapping" will be changed from `true` to `false`.%
 %Enabling the controller resolver automapping feature has been deprecated.%
+%Not setting "doctrine.orm.enable_native_lazy_objects" to true is deprecated.%


### PR DESCRIPTION
(Builds on top of https://github.com/doctrine/DoctrineBundle/pull/1905 and only the second commit is relevant to this PR).

This will fully resolve https://github.com/doctrine/DoctrineBundle/issues/1895 by no longer enabling the deprecated proxy autoloader when native lazy objects are in use.

As well, the proxy cache warmer will no longer be registered when native lazy objects are in use as the warmer doesn't really have a use when proxies aren't in use and it errors out when not configuring the deprecated proxy options (see https://github.com/doctrine/DoctrineBundle/pull/1898#issuecomment-3068208293 and follow-on comments for more here).

Lastly, some of the tests are updated to run with native lazy objects enabled where the environment supports it.

Closes #1895