### PR TITLE
feat: merge URL driverOption rather than just replace defaults

### DIFF
--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -275,6 +275,13 @@ class ConnectionFactory
             unset($params['driverClass']);
         }
 
+        // If both the URL and the default parameters define driverOptions,
+        // then merge them rather than discard all defaults.
+        // Options from the URL take precedence.
+        if (isset($params['driverOptions']) && isset($parsedParams['driverOptions'])) {
+            $parsedParams['driverOptions'] = array_merge($params['driverOptions'], $parsedParams['driverOptions']);
+        }
+
         $params = array_merge($params, $parsedParams);
 
         // If a schemeless connection URL is given, we require a default driver or default custom driver

--- a/tests/ConnectionFactoryTest.php
+++ b/tests/ConnectionFactoryTest.php
@@ -107,6 +107,32 @@ class ConnectionFactoryTest extends TestCase
         $this->assertEquals($params, array_intersect_key($connection->getParams(), $params));
     }
 
+    public function testUrlDriverOptionsOverrideNotReplace(): void
+    {
+        $driverOptions = [
+            'defaultOnlyParam' => 'defaultOnlyValue',
+            'overridenParam' => 'defaultValue',
+        ];
+
+        /** @psalm-suppress InvalidArgument We should adjust when https://github.com/vimeo/psalm/issues/8984 is fixed */
+        $connection = (new ConnectionFactory([]))->createConnection(
+            [
+                'url' => 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8&driverOptions[overridenParam]=overriddenValue&driverOptions[urlOnlyParam]=urlOnlyValue',
+                'driverOptions' => $driverOptions,
+            ],
+            $this->configuration,
+        );
+
+        $this->assertEquals(
+            [
+                'defaultOnlyParam' => 'defaultOnlyValue',
+                'overridenParam' => 'overriddenValue',
+                'urlOnlyParam' => 'urlOnlyValue',
+            ],
+            $connection->getParams()['driverOptions'],
+        );
+    }
+
     public function testConnectionCharsetFromUrl()
     {
         /** @psalm-suppress InvalidArgument Need to be compatible with DBAL < 4, which still has `$params['url']` */


### PR DESCRIPTION
### Current behaviour
If the connection URL contains `driverOptions`, they completely replace the defaults.

```dotenv
# .env.local
DATABASE_URL=sqlsrv://db?driverOptions[TrustServerCertificate]=1
```
```yaml
# doctrine.yaml
doctrine:
    dbal:
        options:
            FormatDecimals: true
```

Result: `FormatDecimals` is discarded.

###  Proposed change
`driverOptions` from the URL are merged into the defaults, allowing environment-independant settings to be defined (e.g., I always want my decimals formatted, regardless of the environment) as well as allowing _additional_ settings, and even overrides, per environment (e.g., only in my dev env do I not have a proper certificate)

Desired result: both `FormatDecimals` and `TrustServerCertificate` are applied.