### PR TITLE
Lower priority for messenger.doctrine_schema_listener

### DIFF
--- a/config/messenger.xml
+++ b/config/messenger.xml
@@ -53,8 +53,8 @@
 
         <service id="doctrine.orm.messenger.doctrine_schema_listener" class="Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaListener">
             <argument type="tagged_iterator" tag="messenger.receiver" />
-            <tag name="doctrine.event_listener" event="postGenerateSchema" />
-            <tag name="doctrine.event_listener" event="onSchemaCreateTable" />
+            <tag name="doctrine.event_listener" event="postGenerateSchema" priority="-1" />
+            <tag name="doctrine.event_listener" event="onSchemaCreateTable" priority="-1" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
The default priority resulted in an error when building the Symfony container in some cases:

  You must configure a hydrator directory. See docs for details.

Fixes https://github.com/doctrine/DoctrineBundle/issues/1911