### PR TITLE
Shift query backtrace so that class->method corresponds to correct file

### DIFF
--- a/templates/Collector/db.html.twig
+++ b/templates/Collector/db.html.twig
@@ -287,12 +287,12 @@
                                                                 <td>{{ loop.index }}</td>
                                                                 <td>
                                                                             <span class="text-small">
-                                                                                {% set line_number = trace.line|default(1) %}
+                                                                                {% set line_number = trace.line|default(query.backtrace[loop.index].line|default(1)) %}
                                                                                 {% if trace.file is defined %}
                                                                                     <a href="{{ trace.file|file_link(line_number) }}">
                                                                                 {% endif %}
-                                                                                        {{- trace.class|default ~ (trace.class is defined ? trace.type|default('::')) -}}
-                                                                                    <span class="status-warning">{{ trace.function }}</span>
+                                                                                        {{- query.backtrace[loop.index].class|default ~ (query.backtrace[loop.index].class is defined ? trace.type|default('::')) -}}
+                                                                                    <span class="status-warning">{{ query.backtrace[loop.index].function|default(trace.function) }}</span>
                                                                                 {% if trace.file is defined %}
                                                                                     </a>
                                                                                 {% endif %}
@@ -440,8 +440,8 @@
                                     {% set contains_errors = collector.mappingErrors[manager] is defined and collector.mappingErrors[manager][class.class] is defined %}
                                     <tr class="{{ contains_errors ? 'status-error' }}">
                                         <td>
-                                <a href="{{ class.file|file_link(class.line) }}">{{ class. class}}</a>
-                            </td>
+                                            <a href="{{ class.file|file_link(class.line) }}">{{ class. class}}</a>
+                                        </td>
                                         <td class="font-normal">
                                             {% if contains_errors %}
                                                 <ul>


### PR DESCRIPTION
Fixes #1915


Before:
<img width="1414" height="1059" alt="image" src="https://github.com/user-attachments/assets/49b82f23-46e7-4d17-8b0b-093c36e06d65" />
After:
<img width="1414" height="1060" alt="image" src="https://github.com/user-attachments/assets/2d605125-d645-4e23-9962-81ecf64aacf2" />
