### PR TITLE
Replace string with constant for CASE_LOWER

### DIFF
--- a/config/orm.php
+++ b/config/orm.php
@@ -230,7 +230,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('doctrine.orm.naming_strategy.underscore_number_aware', param('doctrine.orm.naming_strategy.underscore.class'))
             ->args([
-                'CASE_LOWER',
+                CASE_LOWER,
                 true,
             ])
 


### PR DESCRIPTION
UnderscoreNamingStrategy signature is `public function __construct(private int $case = CASE_LOWER)`, moving this to use the constant.

ping @nicolas-grekas as he worked on those changes too :)