### PR TITLE
Fix the tag definition for the 'doctrine.orm.entity_value_resolver' service

### DIFF
--- a/config/orm.php
+++ b/config/orm.php
@@ -262,7 +262,7 @@ return static function (ContainerConfigurator $container): void {
                 service('doctrine'),
                 service('doctrine.orm.entity_value_resolver.expression_language')->ignoreOnInvalid(),
             ])
-            ->tag('controller.argument_value_resolver', ['priority' => 110])
+            ->tag('controller.argument_value_resolver', ['priority' => 110, 'name' => EntityValueResolver::class])
 
         ->set('doctrine.orm.entity_value_resolver.expression_language', ExpressionLanguage::class)
 


### PR DESCRIPTION
Regression from #1914; we're getting test failures with the below message, and this will get the tag definition back in sync with the XML definition.

```log
request.CRITICAL: Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\ResolverNotFoundException: "You have requested a non-existent resolver "Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver". Did you mean one of these: "Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\QueryParameterValueResolver", "Symfony\Component\Security\Http\Controller\UserValueResolver", "Symfony\Component\Security\Http\Controller\SecurityTokenValueResolver", "doctrine.orm.entity_value_resolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\UidValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver", "Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolver"?" at ArgumentResolver.php line 72
```