### PR TITLE
Drop old major versions

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -7,6 +7,14 @@ Compatibility
 Configuring caching options to use services backed by `doctrine/cache` is no
 longer supported. Migrate to PSR-6 services instead.
 
+Support for the following major versions of the following packages has been dropped:
+
+- `doctrine/dbal` 3
+- `doctrine/persistence` 3
+- `doctrine/orm` 2
+- `psr/log` 1 and 2
+- `twig/twig` 2
+
 Configuration
 -------------
 

--- a/composer.json
+++ b/composer.json
@@ -30,29 +30,29 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^8.1",
-        "doctrine/dbal": "^3.7.0 || ^4.0",
-        "doctrine/persistence": "^3.1 || ^4",
+        "doctrine/dbal": "^4.0",
+        "doctrine/persistence": "^4",
         "doctrine/sql-formatter": "^1.0.1",
         "symfony/cache": "^6.4 || ^7.0",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/deprecation-contracts": "^2.1 || ^3",
+        "symfony/deprecation-contracts": "^3",
         "symfony/doctrine-bridge": "^6.4.3 || ^7.0.3",
         "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/service-contracts": "^2.5 || ^3"
+        "symfony/service-contracts": "^3"
     },
     "require-dev": {
-        "doctrine/annotations": "^1 || ^2",
+        "doctrine/annotations": "^2",
         "doctrine/coding-standard": "^13",
         "doctrine/deprecations": "^1.0",
-        "doctrine/orm": "^2.17 || ^3.1",
+        "doctrine/orm": "^3.1",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "phpstan/phpstan": "2.1.1",
         "phpstan/phpstan-phpunit": "2.0.3",
         "phpstan/phpstan-strict-rules": "^2",
         "phpunit/phpunit": "^9.6.22",
-        "psr/log": "^1.1.4 || ^2.0 || ^3.0",
+        "psr/log": "^3.0",
         "symfony/doctrine-messenger": "^6.4 || ^7.0",
         "symfony/messenger": "^6.4 || ^7.0",
         "symfony/phpunit-bridge": "^7.2",
@@ -65,13 +65,13 @@
         "symfony/var-exporter": "^6.4.1 || ^7.0.1",
         "symfony/web-profiler-bundle": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",
-        "twig/twig": "^2.13 || ^3.0.4"
+        "twig/twig": "^3.0.4"
     },
     "conflict": {
         "doctrine/annotations": ">=3.0",
-        "doctrine/orm": "<2.17 || >=4.0",
+        "doctrine/orm": "<3.0 || >=4.0",
         "symfony/var-exporter": "< 6.4.1 || 7.0.0",
-        "twig/twig": "<2.13 || >=3.0 <3.0.4"
+        "twig/twig": "<3.0.4"
     },
     "suggest": {
         "ext-pdo": "*",


### PR DESCRIPTION
This should cause a drop in code coverage, producing a lot of dead code. Subsequent changes removing said dead code should not impact the coverage in terms of number of lines covered, and would be way too substantial to be reviewed in one go.

Support for Symfony LTS is kept.
 I propose that we work on removing things like support for YML mapping separately. I'm taking this example because it's just one part of dropping support for ORM 2, and there should IMO be several PRs to drop support for ORM 2 completely.