### PR TITLE
Remove branchName from unmaintained branches

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,187 +6,156 @@
   "versions": [
     {
       "name": "3.0",
-      "branchName": "3.0.x",
       "slug": "latest",
       "upcoming": true
     },
     {
       "name": "2.17",
-      "branchName": "2.17.x",
       "slug": "2.17",
       "upcoming": true
     },
     {
       "name": "2.16",
-      "branchName": "2.16.x",
       "slug": "latest",
       "current": true
     },
     {
       "name": "2.15",
-      "branchName": "2.15.x",
       "slug": "2.15",
       "maintained": false
     },
     {
       "name": "2.14",
-      "branchName": "2.14.x",
       "slug": "2.14",
       "maintained": false
     },
     {
       "name": "2.13",
-      "branchName": "2.13.x",
       "slug": "2.13",
       "maintained": false
     },
     {
       "name": "2.12",
-      "branchName": "2.12.x",
       "slug": "2.12",
       "maintained": false
     },
     {
       "name": "2.11",
-      "branchName": "2.11.x",
       "slug": "2.11",
       "maintained": false
     },
     {
       "name": "2.10",
-      "branchName": "2.10.x",
       "slug": "2.10",
       "maintained": false
     },
     {
       "name": "2.9",
-      "branchName": "2.9.x",
       "slug": "2.9",
       "maintained": false
     },
     {
       "name": "2.8",
-      "branchName": "2.8.x",
       "slug": "2.8",
       "maintained": false
     },
     {
       "name": "2.7",
-      "branchName": "2.7.x",
       "slug": "2.7",
       "maintained": false
     },
     {
       "name": "2.6",
-      "branchName": "2.6.x",
       "slug": "2.6",
       "maintained": false
     },
     {
       "name": "2.5",
-      "branchName": "2.5.x",
       "slug": "2.5",
       "maintained": false
     },
     {
       "name": "2.4",
-      "branchName": "2.4.x",
       "slug": "2.4",
       "maintained": false
     },
     {
       "name": "2.3",
-      "branchName": "2.3.x",
       "slug": "2.3",
       "maintained": false
     },
     {
       "name": "2.2",
-      "branchName": "2.2.x",
       "slug": "2.2",
       "maintained": false
     },
     {
       "name": "2.1",
-      "branchName": "2.1.x",
       "slug": "2.1",
       "maintained": false
     },
     {
       "name": "2.0",
-      "branchName": "2.0.x",
       "slug": "2.0",
       "maintained": false
     },
     {
       "name": "1.12",
-      "branchName": "1.12.x",
       "slug": "1.12",
       "maintained": false
     },
     {
       "name": "1.11",
-      "branchName": "1.11.x",
       "slug": "1.11",
       "maintained": false
     },
     {
       "name": "1.10",
-      "branchName": "1.10.x",
       "slug": "1.10",
       "maintained": false
     },
     {
       "name": "1.9",
-      "branchName": "1.9.x",
       "slug": "1.9",
       "maintained": false
     },
     {
       "name": "1.8",
-      "branchName": "1.8.x",
       "slug": "1.8",
       "maintained": false
     },
     {
       "name": "1.7",
-      "branchName": "1.7.x",
       "slug": "1.7",
       "maintained": false
     },
     {
       "name": "1.6",
-      "branchName": "1.6.x",
       "slug": "1.6",
       "maintained": false
     },
     {
       "name": "1.5",
-      "branchName": "1.5.x",
       "slug": "1.5",
       "maintained": false
     },
     {
       "name": "1.4",
-      "branchName": "1.4.x",
       "slug": "1.4",
       "maintained": false
     },
     {
       "name": "1.3",
-      "branchName": "1.3.x",
       "slug": "1.3",
       "maintained": false
     },
     {
       "name": "1.2",
-      "branchName": "1.2.x",
       "slug": "1.2",
       "maintained": false
     },
     {
       "name": "1.1",
-      "branchName": "1.1.x",
       "slug": "1.1",
       "maintained": false
     }


### PR DESCRIPTION
Since doctrine/doctrine-website#372, they are no
longer necessary, it's possible to rely on tags. Once this is merged, the branches can be removed.