### PR TITLE
Avoid triggering unneeded CI jobs

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,9 +5,23 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/coding-standards.yml
+      - config/**
+      - composer.*
+      - phpcs.xml.dist
+      - src/**
+      - tests/**
   push:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/coding-standards.yml
+      - config/**
+      - composer.*
+      - phpcs.xml.dist
+      - src/**
+      - tests/**
 
 jobs:
   coding-standards:

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - "*.x"
     paths:
+      - .github/workflows/composer-lint.yml
       - "composer.json"
   push:
     branches:
       - "*.x"
     paths:
+      - .github/workflows/composer-lint.yml
       - "composer.json"
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,9 +5,25 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/continuous-integration.yml
+      - config/**
+      - composer.*
+      - phpunit.xml.dist
+      - src/**
+      - templates/**
+      - tests/**
   push:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/continuous-integration.yml
+      - config/**
+      - composer.*
+      - phpunit.xml.dist
+      - src/**
+      - templates/**
+      - tests/**
 
 jobs:
   phpunit:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,9 +5,23 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/static-analysis.yml
+      - config/**
+      - composer.*
+      - phpstan.neon.dist
+      - src/**
+      - tests/**
   push:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/static-analysis.yml
+      - config/**
+      - composer.*
+      - phpstan.neon.dist
+      - src/**
+      - tests/**
 
 jobs:
   static-analysis:


### PR DESCRIPTION
It's a pity when touching the docs causes many jobs, and it's even worse if they prevent a documentation contribution.