### PR TITLE
Rely even less on YML in tests

### DIFF
--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -549,8 +549,8 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         ]);
 
         $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', [
-            new Reference('doctrine.orm.default_yml_metadata_driver'),
-            'Fixtures\Bundles\YamlBundle\Entity',
+            new Reference('doctrine.orm.default_xml_metadata_driver'),
+            'Fixtures\Bundles\XmlBundle\Entity',
         ]);
 
         $this->assertDICDefinitionMethodCallAt(2, $definition, 'addDriver', [
@@ -564,11 +564,6 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
                 __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'AttributesBundle' . DIRECTORY_SEPARATOR . 'Entity',
             ],
             ! class_exists(AnnotationDriver::class),
-        ]);
-
-        $ymlDef = $container->getDefinition('doctrine.orm.default_yml_metadata_driver');
-        $this->assertDICConstructorArguments($ymlDef, [
-            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'YamlBundle' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'doctrine' => 'Fixtures\Bundles\YamlBundle\Entity'],
         ]);
 
         $xmlDef = $container->getDefinition('doctrine.orm.default_xml_metadata_driver');
@@ -599,18 +594,13 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         ]);
 
         $this->assertDICDefinitionMethodCallAt(0, $def2, 'addDriver', [
-            new Reference('doctrine.orm.em2_yml_metadata_driver'),
-            'Fixtures\Bundles\YamlBundle\Entity',
+            new Reference('doctrine.orm.em2_xml_metadata_driver'),
+            'Fixtures\Bundles\XmlBundle\Entity',
         ]);
 
         $this->assertDICDefinitionMethodCallAt(1, $def2, 'addDriver', [
             new Reference('doctrine.orm.em2_xml_metadata_driver'),
             'Fixtures\Bundles\XmlBundle',
-        ]);
-
-        $ymlDef = $container->getDefinition('doctrine.orm.em2_yml_metadata_driver');
-        $this->assertDICConstructorArguments($ymlDef, [
-            [__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR . 'YamlBundle' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'doctrine' => 'Fixtures\Bundles\YamlBundle\Entity'],
         ]);
 
         $xmlDef = $container->getDefinition('doctrine.orm.em2_xml_metadata_driver');
@@ -1222,7 +1212,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
             self::markTestSkipped('This test requires ORM');
         }
 
-        $container = $this->loadContainer('orm_entity_listener_resolver', ['YamlBundle'], new EntityListenerPass());
+        $container = $this->loadContainer('orm_entity_listener_resolver', ['XmlBundle'], new EntityListenerPass());
 
         $definition = $container->getDefinition('doctrine.orm.em1_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityListenerResolver', ['doctrine.orm.em1_entity_listener_resolver']);
@@ -1279,7 +1269,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
             self::markTestSkipped('This test requires ORM');
         }
 
-        $container = $this->getContainer(['YamlBundle']);
+        $container = $this->getContainer(['XmlBundle']);
         $loader    = new DoctrineExtension();
         $container->registerExtension($loader);
         $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass('doctrine.connections', 'doctrine.dbal.%s_connection.event_manager', 'doctrine'));
@@ -1517,7 +1507,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
     /** @param list<string> $bundles */
     private function loadContainer(
         string $fixture,
-        array $bundles = ['YamlBundle'],
+        array $bundles = ['XmlBundle'],
         CompilerPassInterface|null $compilerPass = null,
     ): ContainerBuilder {
         $container = $this->getContainer($bundles);

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_functions.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_functions.xml
@@ -13,7 +13,7 @@
 
         <orm default-entity-manager="default">
             <entity-manager name="default">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
                 <dql>
                     <string-function name="test_string">Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction</string-function>
                     <numeric-function name="test_numeric">Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestNumericFunction</numeric-function>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_hydration_mode.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_hydration_mode.xml
@@ -14,7 +14,7 @@
         <orm default-entity-manager="default">
             <entity-manager name="default">
                 <hydrator name="test_hydrator">Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator</hydrator>
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_identity_generation_preferences.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_identity_generation_preferences.xml
@@ -13,12 +13,12 @@
 
         <orm default-entity-manager="em1">
             <entity-manager name="em1">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
                 <identity-generation-preference platform="Doctrine\DBAL\Platforms\PostgreSQLPlatform">identity</identity-generation-preference>
             </entity-manager>
             <entity-manager name="em2">
                 <identity-generation-preference platform="Doctrine\DBAL\Platforms\PostgreSQLPlatform">sequence</identity-generation-preference>
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
@@ -16,7 +16,7 @@
             default-entity-manager="default"
         >
             <entity-manager name="default">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
@@ -16,7 +16,7 @@
                 <mapping name="AttributesBundle" type="attribute" />
             </entity-manager>
             <entity-manager name="em2" validate-xml-mapping="true">
-                <mapping name="YamlBundle" dir="Resources/config/doctrine" alias="yml" />
+                <mapping name="XmlBundle" dir="Resources/config/doctrine" alias="yml" />
                 <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
                     dir="%kernel.root_dir%/tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine"
                     alias="TestAlias"

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_namingstrategy.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_namingstrategy.xml
@@ -13,10 +13,10 @@
 
         <orm default-entity-manager="em1">
             <entity-manager name="em1" naming-strategy="doctrine.orm.naming_strategy.default">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
             <entity-manager name="em2" naming-strategy="doctrine.orm.naming_strategy.underscore">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_quotestrategy.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_quotestrategy.xml
@@ -13,10 +13,10 @@
 
         <orm default-entity-manager="em1">
             <entity-manager name="em1" quote-strategy="doctrine.orm.quote_strategy.default">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
             <entity-manager name="em2" quote-strategy="doctrine.orm.quote_strategy.ansi">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
@@ -30,10 +30,10 @@
 
         <orm default-entity-manager="em2" auto-generate-proxy-classes="true">
             <entity-manager name="em1" connection="conn1">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
             <entity-manager name="em2" connection="conn2">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager.xml
@@ -12,7 +12,7 @@
         </dbal>
 
         <orm default-entity-manager="default">
-            <mapping name="YamlBundle" />
+            <mapping name="XmlBundle" />
         </orm>
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager_without_dbname.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager_without_dbname.xml
@@ -12,7 +12,7 @@
         </dbal>
 
         <orm default-entity-manager="default">
-            <mapping name="YamlBundle" />
+            <mapping name="XmlBundle" />
         </orm>
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
@@ -26,7 +26,7 @@
                 auto-generate-proxy-classes="true"
             >
             <entity-manager name="default" connection="default" default-repository-class="Acme\Doctrine\Repository">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
@@ -13,7 +13,7 @@
 
         <orm validate-xml-mapping="true">
             <mapping name="AttributesBundle" type="attribute" />
-            <mapping name="YamlBundle" dir="Resources/config/doctrine" alias="yml" />
+            <mapping name="XmlBundle" dir="Resources/config/doctrine" alias="yml" />
             <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
                 dir="%kernel.root_dir%/tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine"
                 alias="TestAlias"

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_default_table_options.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_single_em_default_table_options.xml
@@ -17,7 +17,7 @@
 
         <orm>
             <mapping name="AttributesBundle" type="attribute" />
-            <mapping name="YamlBundle" dir="Resources/config/doctrine" alias="yml" />
+            <mapping name="XmlBundle" dir="Resources/config/doctrine" alias="yml" />
             <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
                 dir="%kernel.root_dir%/tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine"
                 alias="TestAlias"

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_typedfieldmapper.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_typedfieldmapper.xml
@@ -13,7 +13,7 @@
 
         <orm default-entity-manager="default">
             <entity-manager name="default" typed-field-mapper="doctrine.orm.typed_field_mapper.default">
-                <mapping name="YamlBundle" />
+                <mapping name="XmlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_functions.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_functions.yml
@@ -9,7 +9,7 @@ doctrine:
         entity_managers:
             default:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 dql:
                     string_functions:
                         test_string: Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_hydration_mode.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_hydration_mode.yml
@@ -11,4 +11,4 @@ doctrine:
                 hydrators:
                     test_hydrator: Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_identity_generation_preferences.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_identity_generation_preferences.yml
@@ -10,11 +10,11 @@ doctrine:
         entity_managers:
             em1:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 identity_generation_preferences:
                     Doctrine\DBAL\Platforms\PostgreSQLPlatform: identity
             em2:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 identity_generation_preferences:
                     Doctrine\DBAL\Platforms\PostgreSQLPlatform: sequence

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
@@ -11,4 +11,4 @@ doctrine:
         entity_managers:
             default:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
@@ -15,9 +15,9 @@ doctrine:
             em2:
                 validate_xml_mapping: true
                 mappings:
-                    YamlBundle:
+                    XmlBundle:
                         dir: Resources/config/doctrine
-                        alias: yml
+                        alias: xml
                     manual:
                         type: xml
                         prefix: Fixtures\Bundles\XmlBundle

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_namingstrategy.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_namingstrategy.yml
@@ -10,9 +10,9 @@ doctrine:
         entity_managers:
             em1:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 naming_strategy: doctrine.orm.naming_strategy.default
             em2:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_quotestrategy.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_quotestrategy.yml
@@ -10,9 +10,9 @@ doctrine:
         entity_managers:
             em1:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 quote_strategy: doctrine.orm.quote_strategy.default
             em2:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 quote_strategy: doctrine.orm.quote_strategy.ansi

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_service_multiple_entity_managers.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_service_multiple_entity_managers.yml
@@ -25,8 +25,8 @@ doctrine:
             em1:
                 connection: conn1
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
             em2:
                 connection: conn2
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager.yml
@@ -8,4 +8,4 @@ doctrine:
     orm:
         default_entity_manager: default
         mappings:
-            YamlBundle: ~
+            XmlBundle: ~

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager_without_dbname.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager_without_dbname.yml
@@ -7,4 +7,4 @@ doctrine:
     orm:
         default_entity_manager: default
         mappings:
-            YamlBundle: ~
+            XmlBundle: ~

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
@@ -18,4 +18,4 @@ doctrine:
                 connection: default
                 default_repository_class: Acme\Doctrine\Repository
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
@@ -10,9 +10,9 @@ doctrine:
         mappings:
             AttributesBundle:
                 type: attribute
-            YamlBundle:
+            XmlBundle:
                 dir: Resources/config/doctrine
-                alias: yml
+                alias: xml
             manual:
                 type: xml
                 prefix: Fixtures\Bundles\XmlBundle

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_default_table_options.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_single_em_default_table_options.yml
@@ -12,9 +12,9 @@ doctrine:
     orm:
         mappings:
             AttributesBundle: ~
-            YamlBundle:
+            XmlBundle:
                 dir: Resources/config/doctrine
-                alias: yml
+                alias: xml
             manual:
                 type: xml
                 prefix: Fixtures\Bundles\XmlBundle

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_typedfieldmapper.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_typedfieldmapper.yml
@@ -10,5 +10,5 @@ doctrine:
         entity_managers:
             default:
                 mappings:
-                    YamlBundle: ~
+                    XmlBundle: ~
                 typed_field_mapper: doctrine.orm.typed_field_mapper.default


### PR DESCRIPTION
While [working on removing YML on the next major branch](https://github.com/doctrine/DoctrineBundle/pull/1958), I found a lot more places where I do not think it needs to be used.