### PR TITLE
Remove deprecated cache classes from test fixtures

### DIFF
--- a/tests/DependencyInjection/Fixtures/config/xml/orm_second_level_cache.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_second_level_cache.xml
@@ -15,10 +15,10 @@
             <srv:argument>3600</srv:argument>
         </srv:service>
 
-        <srv:service id="my_service_region_driver" class="Doctrine\Common\Cache\ArrayCache" />
+        <srv:service id="my_service_region_driver" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
 
         <srv:service id="my_factory_config" class="Doctrine\ORM\Cache\CacheConfiguration"/>
-        <srv:service id="my_factory_driver" class="Doctrine\Common\Cache\ArrayCache"/>
+        <srv:service id="my_factory_driver" class="Symfony\Component\Cache\Adapter\ArrayAdapter"/>
         <srv:service id="my_factory" class="Doctrine\ORM\Cache\DefaultCacheFactory">
             <srv:argument type="service" id="my_factory_config"/>
             <srv:argument type="service" id="my_factory_driver"/>

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_second_level_cache.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_second_level_cache.yml
@@ -1,6 +1,6 @@
 services:
     my_service_region_driver:
-        class: Doctrine\Common\Cache\ArrayCache
+        class: Symfony\Component\Cache\Adapter\ArrayAdapter
 
     my_service_logger1:
         class: Doctrine\ORM\Cache\Logging\StatisticsCacheLogger
@@ -16,7 +16,7 @@ services:
         class: Doctrine\ORM\Cache\CacheConfiguration
 
     my_factory_driver:
-        class: Doctrine\Common\Cache\ArrayCache
+        class: Symfony\Component\Cache\Adapter\ArrayAdapter
 
     my_factory:
         class: Doctrine\ORM\Cache\DefaultCacheFactory


### PR DESCRIPTION
Those classes don't exist anymore. 🤷🏻‍♂️ 