### PR TITLE
Fix `doctrine.default_entity_manager` to be an empty `string` by default

### DIFF
--- a/config/dbal.php
+++ b/config/dbal.php
@@ -36,7 +36,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('doctrine.dbal.events.oracle_session_init.class', OracleSessionInit::class)
         ->set('doctrine.class', Registry::class)
         ->set('doctrine.entity_managers', [])
-        ->set('doctrine.default_entity_manager', null);
+        ->set('doctrine.default_entity_manager', '');
 
     $container->services()
 


### PR DESCRIPTION
See: https://github.com/doctrine/DoctrineBundle/pull/1914#discussion_r2325298090