### PR TITLE
Remove unused method

### DIFF
--- a/src/Command/DoctrineCommand.php
+++ b/src/Command/DoctrineCommand.php
@@ -3,12 +3,8 @@
 namespace Doctrine\Bundle\DoctrineBundle\Command;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
-use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
-
-use function assert;
 
 /**
  * Base class for Doctrine console commands to extend from.
@@ -21,27 +17,6 @@ abstract class DoctrineCommand extends Command
         private readonly ManagerRegistry $doctrine,
     ) {
         parent::__construct();
-    }
-
-    /**
-     * Get a doctrine entity manager by symfony name.
-     *
-     * @param string   $name
-     * @param int|null $shardId
-     *
-     * @return EntityManagerInterface
-     */
-    protected function getEntityManager($name, $shardId = null)
-    {
-        $manager = $this->getDoctrine()->getManager($name);
-
-        if ($shardId !== null) {
-            throw new InvalidArgumentException('Shards are not supported anymore using doctrine/dbal >= 3');
-        }
-
-        assert($manager instanceof EntityManagerInterface);
-
-        return $manager;
     }
 
     /**


### PR DESCRIPTION
It is unused since 98f1a2d35f39d62b36e1b5d03192a4d93d47f31b.

This leaves us with a very small `DoctrineCommand` class… maybe we should remove it at some point :thinking: .