### PR TITLE
Remove type and method existence based checks

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -62,6 +62,17 @@ Auto mapping used any route parameter that matches with a field name of the Enti
 
 If you were relying on this functionality, you will need to update your code to use explicit mapped route parameters instead.
 
+ConnectionFactory::createConnection() signature change
+------------------------------------------------------
+
+The signature of `ConnectionFactory::createConnection()` changed.
+You should use stop passing an event manager argument.
+
+```diff
+- $connectionFactory->createConnection($params, $config, $eventManager, $mappingTypes)
++ $connectionFactory->createConnection($params, $config, $mappingTypes)
+```
+
 Types
 -----
 

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -113,13 +113,9 @@ class ConnectionFactory
             $connection = DriverManager::getConnection($params, $config);
             $params     = $this->addDatabaseSuffix(array_merge($connection->getParams(), $overriddenOptions));
             $driver     = $connection->getDriver();
-            /** @phpstan-ignore arguments.count (DBAL < 4.x doesn't accept an argument) */
-            $platform = $driver->getDatabasePlatform(
-                ...(class_exists(StaticServerVersionProvider::class)
-                    ? [new StaticServerVersionProvider($params['serverVersion'] ?? $params['primary']['serverVersion'] ?? '')]
-                    : []
-                ),
-            );
+            $platform   = $driver->getDatabasePlatform(new StaticServerVersionProvider(
+                $params['serverVersion'] ?? $params['primary']['serverVersion'] ?? '',
+            ));
 
             if (! isset($params['charset'])) {
                 if ($platform instanceof AbstractMySQLPlatform) {
@@ -168,10 +164,7 @@ class ConnectionFactory
         try {
             return $connection->getDatabasePlatform();
         } catch (DriverException $driverException) {
-            $class = class_exists(DBALException::class) ? DBALException::class : ConnectionException::class;
-
-            /* @phpstan-ignore new.interface */
-            throw new $class(
+            throw new ConnectionException(
                 'An exception occurred while establishing a connection to figure out your platform version.' . PHP_EOL .
                 "You can circumvent this by setting a 'server_version' configuration value" . PHP_EOL . PHP_EOL .
                 'For further information have a look at:' . PHP_EOL .
@@ -264,11 +257,7 @@ class ConnectionFactory
         // If a schemeless connection URL is given, we require a default driver or default custom driver
         // as connection parameter.
         if (! isset($params['driverClass']) && ! isset($params['driver'])) {
-            if (class_exists(DriverRequired::class)) {
-                throw DriverRequired::new($params['url']);
-            }
-
-            throw DBALException::driverRequired($params['url']);
+            throw DriverRequired::new($params['url']);
         }
 
         unset($params['url']);

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Bundle\DoctrineBundle;
 
-use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connection\StaticServerVersionProvider;
@@ -17,15 +16,10 @@ use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Tools\DsnParser;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
-use InvalidArgumentException;
 
 use function array_merge;
 use function class_exists;
-use function func_num_args;
-use function is_array;
 use function is_subclass_of;
-use function method_exists;
 use function trigger_deprecation;
 
 use const PHP_EOL;
@@ -62,52 +56,17 @@ class ConnectionFactory
     /**
      * Create a connection by name.
      *
-     * @param mixed[]                                 $params
-     * @param EventManager|array<string, string>|null $eventManagerOrMappingTypes
-     * @param array<string, string>                   $deprecatedMappingTypes
+     * @param mixed[]               $params
+     * @param array<string, string> $mappingTypes
      * @phpstan-param Params $params
      *
      * @return Connection
-     *
-     * @no-named-arguments
      */
     public function createConnection(
         array $params,
         Configuration|null $config = null,
-        EventManager|array|null $eventManagerOrMappingTypes = [],
-        array $deprecatedMappingTypes = [],
+        array $mappingTypes = [],
     ) {
-        if (! method_exists(Connection::class, 'getEventManager') && $eventManagerOrMappingTypes instanceof EventManager) {
-            throw new InvalidArgumentException('Passing an EventManager instance is not supported with DBAL > 3');
-        }
-
-        if (is_array($eventManagerOrMappingTypes) && func_num_args() === 4) {
-            throw new InvalidArgumentException('Passing mapping types both as 3rd and 4th argument makes no sense.');
-        }
-
-        if ($eventManagerOrMappingTypes instanceof EventManager) {
-            // DBAL 3
-            $eventManager = $eventManagerOrMappingTypes;
-            $mappingTypes = $deprecatedMappingTypes;
-        } elseif (is_array($eventManagerOrMappingTypes)) {
-            // Future signature
-            $eventManager = null;
-            $mappingTypes = $eventManagerOrMappingTypes;
-        } else {
-            // Legacy signature
-            if (! method_exists(Connection::class, 'getEventManager')) {
-                Deprecation::trigger(
-                    'doctrine/doctrine-bundle',
-                    'https://github.com/doctrine/DoctrineBundle/pull/1976',
-                    'Passing mapping types as 4th argument to %s is deprecated when using DBAL 4 and will not be supported in version 3.0 of the bundle. Pass them as 3rd argument instead.',
-                    __METHOD__,
-                );
-            }
-
-            $eventManager = null;
-            $mappingTypes = $deprecatedMappingTypes;
-        }
-
         if (! $this->initialized) {
             $this->initializeTypes();
         }
@@ -151,7 +110,7 @@ class ConnectionFactory
                 $params['wrapperClass'] = null;
             }
 
-            $connection = DriverManager::getConnection(...array_merge([$params, $config], $eventManager ? [$eventManager] : []));
+            $connection = DriverManager::getConnection($params, $config);
             $params     = $this->addDatabaseSuffix(array_merge($connection->getParams(), $overriddenOptions));
             $driver     = $connection->getDriver();
             /** @phpstan-ignore arguments.count (DBAL < 4.x doesn't accept an argument) */
@@ -179,9 +138,9 @@ class ConnectionFactory
                 $wrapperClass = Connection::class;
             }
 
-            $connection = new $wrapperClass($params, $driver, $config, $eventManager);
+            $connection = new $wrapperClass($params, $driver, $config);
         } else {
-            $connection = DriverManager::getConnection(...array_merge([$params, $config], $eventManager ? [$eventManager] : []));
+            $connection = DriverManager::getConnection($params, $config);
         }
 
         if (! empty($mappingTypes)) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,7 +31,6 @@ use function is_bool;
 use function is_int;
 use function is_string;
 use function key;
-use function method_exists;
 use function reset;
 use function sprintf;
 use function strlen;
@@ -496,7 +495,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                         ->booleanNode('enable_lazy_ghost_objects')
-                            ->defaultValue(! method_exists(ProxyFactory::class, 'resetUninitializedProxy'))
+                            ->defaultValue(true)
                             ->info('Enables the new implementation of proxies based on lazy ghosts instead of using the legacy implementation')
                         ->end()
                         ->booleanNode('enable_native_lazy_objects')

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -30,7 +30,6 @@ use Doctrine\ORM\Mapping\LegacyReflectionFields;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\Autoloader;
-use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -299,12 +298,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $def = $container
             ->setDefinition($connectionId, new ChildDefinition('doctrine.dbal.connection'))
             ->setPublic(true)
-            ->setArguments(array_merge(
-                [$options, new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name))],
-                // event manager must only be passed for DBAL < 4
-                method_exists(Connection::class, 'getEventManager') ? [new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $name))] : [],
-                [$connection['mapping_types']],
-            ));
+            ->setArguments([
+                $options,
+                new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name)),
+                $connection['mapping_types'],
+            ]);
 
         $container
             ->registerAliasForArgument($connectionId, Connection::class, sprintf('%s.connection', $name))
@@ -316,13 +314,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         if (isset($connection['use_savepoints'])) {
-            // DBAL >= 4 always has savepoints enabled. So we only need to call "setNestTransactionsWithSavepoints" for DBAL < 4
-            if (method_exists(Connection::class, 'getEventManager')) {
-                if ($connection['use_savepoints']) {
-                    $def->addMethodCall('setNestTransactionsWithSavepoints', [$connection['use_savepoints']]);
-                }
-            } elseif (! $connection['use_savepoints']) {
-                throw new LogicException('The "use_savepoints" option can only be set to "true" and should ideally not be set when using DBAL >= 4');
+            if (! $connection['use_savepoints']) {
+                throw new LogicException('The "use_savepoints" option can only be set to "true" and should ideally not be set');
             }
         }
 
@@ -528,19 +521,17 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $container->setParameter('doctrine.default_entity_manager', $config['default_entity_manager']);
 
-        if ($config['enable_lazy_ghost_objects'] ?? false) {
-            if (! class_exists(ProxyHelper::class)) {
-                throw new LogicException(
-                    'Lazy ghost objects cannot be enabled because the "symfony/var-exporter" library'
-                    . ' is not installed. Please run "composer require symfony/var-exporter".',
-                );
-            }
-        } elseif (! method_exists(ProxyFactory::class, 'resetUninitializedProxy')) {
+        if (! ($config['enable_lazy_ghost_objects'] ?? false)) {
             throw new LogicException(
                 'Lazy ghost objects cannot be disabled for ORM 3.',
             );
-        } else {
-            trigger_deprecation('doctrine/doctrine-bundle', '2.11', 'Not setting "doctrine.orm.enable_lazy_ghost_objects" to true is deprecated.');
+        }
+
+        if (! class_exists(ProxyHelper::class)) {
+            throw new LogicException(
+                'Lazy ghost objects cannot be enabled because the "symfony/var-exporter" library'
+                . ' is not installed. Please run "composer require symfony/var-exporter".',
+            );
         }
 
         if ($config['enable_native_lazy_objects'] ?? false) {

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -30,7 +30,6 @@ use Doctrine\ORM\Mapping\LegacyReflectionFields;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\Autoloader;
-use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
@@ -502,10 +501,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         // Symfony 7.3 and higher expose type alias support in the EntityValueResolver
         $valueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
-
-        if (! class_exists(ClassMetadataExporter::class)) {
-            $container->removeDefinition('doctrine.mapping_import_command');
-        }
 
         $entityManagers = [];
         foreach (array_keys($config['entity_managers']) as $name) {

--- a/tests/ConnectionFactoryTest.php
+++ b/tests/ConnectionFactoryTest.php
@@ -8,10 +8,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
-use InvalidArgumentException;
 
 use function array_intersect_key;
-use function method_exists;
 
 class ConnectionFactoryTest extends TestCase
 {
@@ -138,34 +136,6 @@ class ConnectionFactoryTest extends TestCase
 
         $this->assertSame('primary_test', $parsedParams['primary']['dbname']);
         $this->assertSame('replica_test', $parsedParams['replica']['replica1']['dbname']);
-    }
-
-    public function testItThrowsWhenPassingMappingTypesTwice(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        (new ConnectionFactory())->createConnection(['driver' => 'pdo_sqlite'], null, [], []);
-    }
-
-    /** @group legacy */
-    public function testPassingMappingTypesAsFourthArgumentIsDeprecatedWithDbal4(): void
-    {
-        if (method_exists(Connection::class, 'getEventManager')) {
-            $this->markTestSkipped('DBAL 3 does not trigger the deprecation.');
-        }
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/1976');
-        (new ConnectionFactory())->createConnection(['driver' => 'pdo_sqlite'], null, null, []);
-    }
-
-    public function testPassingMappingTypesAsFourthArgumentIsFineWithDbal3(): void
-    {
-        if (! method_exists(Connection::class, 'getEventManager')) {
-            $this->markTestSkipped('DBAL 4 triggers the deprecation.');
-        }
-
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/1976');
-        (new ConnectionFactory())->createConnection(['driver' => 'pdo_sqlite'], null, null, []);
     }
 }
 

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -232,26 +232,6 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $this->assertEquals(['engine' => 'InnoDB'], $param['defaultTableOptions']);
     }
 
-    public function testDbalLoadSavepointsForNestedTransactions(): void
-    {
-        if (! method_exists(Connection::class, 'getEventManager')) {
-            self::markTestSkipped('This test requires DBAL < 4');
-        }
-
-        $container = $this->loadContainer('dbal_savepoints');
-
-        $calls = $container->getDefinition('doctrine.dbal.savepoints_connection')->getMethodCalls();
-        $this->assertCount(1, $calls);
-        $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
-        $this->assertTrue($calls[0][1][0]);
-
-        $calls = $container->getDefinition('doctrine.dbal.nosavepoints_connection')->getMethodCalls();
-        $this->assertCount(0, $calls);
-
-        $calls = $container->getDefinition('doctrine.dbal.notset_connection')->getMethodCalls();
-        $this->assertCount(0, $calls);
-    }
-
     public function testDbalLoadDisableTypeComments(): void
     {
         $container = $this->loadContainer('dbal_disable_type_comments');

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -8,7 +8,6 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPa
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\InvokableEntityListener;
 use Doctrine\DBAL\Configuration;
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManager;
@@ -16,7 +15,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use Doctrine\ORM\Mapping\LegacyReflectionFields;
-use Doctrine\ORM\Proxy\ProxyFactory;
 use Generator;
 use InvalidArgumentException;
 use LogicException;
@@ -44,7 +42,6 @@ use function class_exists;
 use function end;
 use function interface_exists;
 use function is_dir;
-use function method_exists;
 use function sprintf;
 use function sys_get_temp_dir;
 use function uniqid;
@@ -300,17 +297,21 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
 
-        $this->assertDICConstructorArguments($definition, $this->getFactoryArguments([
-            'dbname' => 'db',
-            'host' => 'localhost',
-            'port' => null,
-            'user' => 'root',
-            'password' => null,
-            'driver' => 'pdo_mysql',
-            'driverOptions' => [],
-            'defaultTableOptions' => [],
-            'idle_connection_ttl' => 600,
-        ]));
+        $this->assertDICConstructorArguments($definition, [
+            [
+                'dbname' => 'db',
+                'host' => 'localhost',
+                'port' => null,
+                'user' => 'root',
+                'password' => null,
+                'driver' => 'pdo_mysql',
+                'driverOptions' => [],
+                'defaultTableOptions' => [],
+                'idle_connection_ttl' => 600,
+            ],
+            new Reference('doctrine.dbal.default_connection.configuration'),
+            [],
+        ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -336,16 +337,20 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
 
         $this->assertDICConstructorArguments(
             $container->getDefinition('doctrine.dbal.default_connection'),
-            $this->getFactoryArguments([
-                'host' => 'localhost',
-                'port' => null,
-                'user' => 'root',
-                'password' => null,
-                'driver' => 'pdo_mysql',
-                'driverOptions' => [],
-                'defaultTableOptions' => [],
-                'idle_connection_ttl' => 600,
-            ]),
+            [
+                [
+                    'host' => 'localhost',
+                    'port' => null,
+                    'user' => 'root',
+                    'password' => null,
+                    'driver' => 'pdo_mysql',
+                    'driverOptions' => [],
+                    'defaultTableOptions' => [],
+                    'idle_connection_ttl' => 600,
+                ],
+                new Reference('doctrine.dbal.default_connection.configuration'),
+                [],
+            ],
         );
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
@@ -368,18 +373,22 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
 
-        $this->assertDICConstructorArguments($definition, $this->getFactoryArguments([
-            'host' => 'localhost',
-            'driver' => 'pdo_sqlite',
-            'driverOptions' => [],
-            'user' => 'sqlite_user',
-            'port' => null,
-            'password' => 'sqlite_s3cr3t',
-            'dbname' => 'sqlite_db',
-            'memory' => true,
-            'defaultTableOptions' => [],
-            'idle_connection_ttl' => 600,
-        ]));
+        $this->assertDICConstructorArguments($definition, [
+            [
+                'host' => 'localhost',
+                'driver' => 'pdo_sqlite',
+                'driverOptions' => [],
+                'user' => 'sqlite_user',
+                'port' => null,
+                'password' => 'sqlite_s3cr3t',
+                'dbname' => 'sqlite_db',
+                'memory' => true,
+                'defaultTableOptions' => [],
+                'idle_connection_ttl' => 600,
+            ],
+            new Reference('doctrine.dbal.default_connection.configuration'),
+            [],
+        ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -409,10 +418,6 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $this->assertEquals('localhost', $args[0]['host']);
         $this->assertEquals('sqlite_user', $args[0]['user']);
         $this->assertEquals('doctrine.dbal.conn1_connection.configuration', (string) $args[1]);
-        if (method_exists(Connection::class, 'getEventManager')) {
-            $this->assertEquals('doctrine.dbal.conn1_connection.event_manager', (string) $args[2]);
-        }
-
         $this->assertEquals('doctrine.orm.em2_entity_manager', (string) $container->getAlias('doctrine.orm.entity_manager'));
 
         $definition = $container->getDefinition('doctrine.orm.em1_entity_manager');
@@ -431,9 +436,6 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $this->assertEquals('localhost', $args[0]['host']);
         $this->assertEquals('sqlite_user', $args[0]['user']);
         $this->assertEquals('doctrine.dbal.conn2_connection.configuration', (string) $args[1]);
-        if (method_exists(Connection::class, 'getEventManager')) {
-            $this->assertEquals('doctrine.dbal.conn2_connection.event_manager', (string) $args[2]);
-        }
 
         $definition = $container->getDefinition('doctrine.orm.em2_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -856,10 +858,6 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
     {
         if (! interface_exists(EntityManagerInterface::class)) {
             self::markTestSkipped('This test requires ORM');
-        }
-
-        if (method_exists(ProxyFactory::class, 'resetUninitializedProxy')) {
-            self::markTestSkipped('This test requires ORM 3.');
         }
 
         $this->expectException(LogicException::class);
@@ -1555,26 +1553,6 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $passConfig->setOptimizationPasses([new ResolveChildDefinitionsPass()]);
         $passConfig->setRemovingPasses([]);
         $container->compile();
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     *
-     * @return list<mixed> The expected arguments to the connection factory
-     */
-    private function getFactoryArguments(array $params): array
-    {
-        $args = [
-            $params,
-            new Reference('doctrine.dbal.default_connection.configuration'),
-        ];
-        if (method_exists(Connection::class, 'getEventManager')) {
-            $args[] = new Reference('doctrine.dbal.default_connection.event_manager');
-        }
-
-        $args[] = [];
-
-        return $args;
     }
 }
 

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -441,10 +441,6 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals('localhost', $args[0]['host']);
         $this->assertEquals('root', $args[0]['user']);
         $this->assertEquals('doctrine.dbal.default_connection.configuration', (string) $args[1]);
-        if (method_exists(Connection::class, 'getEventManager')) {
-            $this->assertEquals('doctrine.dbal.default_connection.event_manager', (string) $args[2]);
-        }
-
         $this->assertCount(0, $definition->getMethodCalls());
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
@@ -513,16 +509,8 @@ class DoctrineExtensionTest extends TestCase
             ],
         ], $container);
 
-        $isUsingDBAL3 = method_exists(Connection::class, 'getEventManager');
-
         $calls = $container->getDefinition('doctrine.dbal.default_connection')->getMethodCalls();
-        $this->assertCount((int) $isUsingDBAL3, $calls);
-        if (! $isUsingDBAL3) {
-            return;
-        }
-
-        $this->assertEquals('setNestTransactionsWithSavepoints', $calls[0][0]);
-        $this->assertTrue($calls[0][1][0]);
+        $this->assertCount(0, $calls);
     }
 
     public function testAutoGenerateProxyClasses(): void


### PR DESCRIPTION
I looked for tests for DBAL 3 / ORM 2 in the codebase and removed corresponding code.