### PR TITLE
Introduce polyfill for Application::addCommand()

### DIFF
--- a/tests/Command/CreateDatabaseDoctrineTest.php
+++ b/tests/Command/CreateDatabaseDoctrineTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand;
+use Doctrine\Bundle\DoctrineBundle\Tests\Polyfill\SymfonyApp;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
@@ -10,7 +11,6 @@ use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -37,8 +37,8 @@ class CreateDatabaseDoctrineTest extends TestCase
 
         $container = $this->getMockContainer($connectionName, $params);
 
-        $application = new Application();
-        $application->add(new CreateDatabaseDoctrineCommand($container->get('doctrine')));
+        $application = new SymfonyApp();
+        $application->addCommand(new CreateDatabaseDoctrineCommand($container->get('doctrine')));
 
         $command = $application->find('doctrine:database:create');
 

--- a/tests/Command/DropDatabaseDoctrineTest.php
+++ b/tests/Command/DropDatabaseDoctrineTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
+use Doctrine\Bundle\DoctrineBundle\Tests\Polyfill\SymfonyApp;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
@@ -12,7 +13,6 @@ use Doctrine\Persistence\ManagerRegistry;
 use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -41,8 +41,8 @@ class DropDatabaseDoctrineTest extends TestCase
         /** @psalm-suppress InvalidArgument Need to be compatible with DBAL < 4, which still has `$params['url']` */
         $container = $this->getMockContainer($connectionName, $params);
 
-        $application = new Application();
-        $application->add(new DropDatabaseDoctrineCommand($container->get('doctrine')));
+        $application = new SymfonyApp();
+        $application->addCommand(new DropDatabaseDoctrineCommand($container->get('doctrine')));
 
         $command = $application->find('doctrine:database:drop');
 
@@ -84,8 +84,8 @@ class DropDatabaseDoctrineTest extends TestCase
 
         $container = $this->getMockContainer($connectionName, $params);
 
-        $application = new Application();
-        $application->add(new DropDatabaseDoctrineCommand($container->get('doctrine')));
+        $application = new SymfonyApp();
+        $application->addCommand(new DropDatabaseDoctrineCommand($container->get('doctrine')));
 
         $command = $application->find('doctrine:database:drop');
 

--- a/tests/Polyfill/SymfonyApp.php
+++ b/tests/Polyfill/SymfonyApp.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\Polyfill;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+
+use function method_exists;
+
+/**
+ * Necessary until support for Symfony < 7.4 is dropped.
+ */
+final class SymfonyApp extends Application
+{
+    public function addCommand(callable|Command $command): Command|null
+    {
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (method_exists(parent::class, 'addCommand')) {
+            return parent::addCommand($command);
+        }
+
+        return $this->add($command);
+    }
+
+    /** Needs to exist to pass this test:
+     * https://github.com/symfony/console/blob/525f69f6840d00b195ffeaea6c3ba1ec6cd87476/Application.php#L1356
+     */
+    public function add(Command $command): Command
+    {
+        return parent::add($command);
+    }
+}


### PR DESCRIPTION
This avoids several direct deprecations when running the test suite.