### PR TITLE
Bump versions

### DIFF
--- a/tests/ConnectionFactoryTest.php
+++ b/tests/ConnectionFactoryTest.php
@@ -98,7 +98,7 @@ class ConnectionFactoryTest extends TestCase
         /** @psalm-suppress InvalidArgument We should adjust when https://github.com/vimeo/psalm/issues/8984 is fixed */
         $connection = (new ConnectionFactory([]))->createConnection(
             [
-                'url' => 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8',
+                'url' => 'mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1',
                 'connection_override_options' => $params,
             ],
             $this->configuration,
@@ -123,7 +123,7 @@ class ConnectionFactoryTest extends TestCase
         /** @psalm-suppress InvalidArgument We should adjust when https://github.com/vimeo/psalm/issues/8984 is fixed */
         $connection = (new ConnectionFactory([]))->createConnection(
             [
-                'url' => 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8',
+                'url' => 'mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1',
                 'dbname_suffix' => '_test',
             ],
             $this->configuration,
@@ -139,12 +139,12 @@ class ConnectionFactoryTest extends TestCase
             [
                 'driver' => 'pdo_mysql',
                 'primary' => [
-                    'url' => 'mysql://root:password@database:3306/primary?serverVersion=mariadb-10.5.8',
+                    'url' => 'mysql://root:password@database:3306/primary?serverVersion=mariadb-12.1.1',
                     'dbname_suffix' => '_test',
                 ],
                 'replica' => [
                     'replica1' => [
-                        'url' => 'mysql://root:password@database:3306/replica?serverVersion=mariadb-10.5.8',
+                        'url' => 'mysql://root:password@database:3306/replica?serverVersion=mariadb-12.1.1',
                         'dbname_suffix' => '_test',
                     ],
                 ],

--- a/tests/ConnectionFactoryTest.php
+++ b/tests/ConnectionFactoryTest.php
@@ -43,7 +43,7 @@ class ConnectionFactoryTest extends TestCase
     public function testDefaultCharsetMySql(): void
     {
         $factory = new ConnectionFactory([]);
-        $params  = ['driver' => 'pdo_mysql', 'serverVersion' => '8.0.31'];
+        $params  = ['driver' => 'pdo_mysql', 'serverVersion' => '9.4.0'];
 
         $connection = $factory->createConnection($params, $this->configuration);
 
@@ -53,7 +53,7 @@ class ConnectionFactoryTest extends TestCase
     public function testDefaultCollationMySql(): void
     {
         $factory    = new ConnectionFactory([]);
-        $connection = $factory->createConnection(['driver' => 'pdo_mysql', 'serverVersion' => '8.0.31'], $this->configuration);
+        $connection = $factory->createConnection(['driver' => 'pdo_mysql', 'serverVersion' => '9.4.0'], $this->configuration);
 
         $this->assertSame(
             'utf8mb4_unicode_ci',
@@ -72,6 +72,7 @@ class ConnectionFactoryTest extends TestCase
             [
                 'driver' => 'pdo_mysql',
                 'defaultTableOptions' => ['collate' => 'my_collation'],
+                'serverVersion' => '9.4.0',
             ],
             $this->configuration,
         );
@@ -138,6 +139,7 @@ class ConnectionFactoryTest extends TestCase
         $connection = (new ConnectionFactory([]))->createConnection(
             [
                 'driver' => 'pdo_mysql',
+                'serverVersion' => '9.4.0',
                 'primary' => [
                     'url' => 'mysql://root:password@database:3306/primary?serverVersion=mariadb-12.1.1',
                     'dbname_suffix' => '_test',

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -140,7 +140,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $this->assertEquals('mysql_user', $config['user']);
         $this->assertEquals('mysql_db', $config['dbname']);
         $this->assertEquals('/path/to/mysqld.sock', $config['unix_socket']);
-        $this->assertEquals('5.6.20', $config['serverVersion']);
+        $this->assertEquals('9.4.0', $config['serverVersion']);
     }
 
     /** @group legacy */

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -149,7 +149,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $container = $this->loadContainer('dbal_allow_url_override');
         $config    = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
-        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
+        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1', $config['url']);
 
         $expectedOverrides = [
             'dbname' => 'main_test',
@@ -178,7 +178,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         ];
 
         $this->assertEquals($expectedDefaults, array_intersect_key($config, $expectedDefaults));
-        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
+        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1', $config['url']);
         $this->assertCount(1, $config['connection_override_options']);
         $this->assertSame('main_test', $config['connection_override_options']['dbname']);
         $this->assertFalse(isset($config['override_url']));
@@ -189,7 +189,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $container = $this->loadContainer('dbal_dbname_suffix');
         $config    = $container->getDefinition('doctrine.dbal.default_connection')->getArgument(0);
 
-        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8', $config['url']);
+        $this->assertSame('mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1', $config['url']);
         $this->assertSame('_test', $config['dbname_suffix']);
     }
 

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_allow_partial_url_override.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_allow_partial_url_override.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal override-url="true" dbname="main_test" url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8" />
+    <dbal override-url="true" dbname="main_test" url="mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1" />
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_allow_url_override.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_allow_url_override.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal override-url="true" dbname="main_test" user="tester" password="wordpass" host="localhost" port="4321" url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8" />
+        <dbal override-url="true" dbname="main_test" user="tester" password="wordpass" host="localhost" port="4321" url="mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1" />
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_dbname_suffix.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_dbname_suffix.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8" dbname-suffix="_test" />
+        <dbal url="mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1" dbname-suffix="_test" />
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_driver_schemes.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_driver_schemes.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal url="mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8">
+        <dbal url="mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1">
             <driver-scheme scheme="postgresql">pgsql</driver-scheme>
             <driver-scheme scheme="my-scheme">my_driver</driver-scheme>
         </dbal>

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_schema_filter.xml
@@ -8,9 +8,9 @@
 
     <config>
         <dbal default-connection="connection1">
-            <connection name="connection1" schema-filter="~^(?!t_)~" server-version="8.0.31" />
-            <connection name="connection2" server-version="8.0.31" />
-            <connection name="connection3" server-version="8.0.31" />
+            <connection name="connection1" schema-filter="~^(?!t_)~" server-version="9.4.0" />
+            <connection name="connection2" server-version="9.4.0" />
+            <connection name="connection3" server-version="9.4.0" />
         </dbal>
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_connection.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_connection.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal dbname="mysql_db" user="mysql_user" password="mysql_s3cr3t" unix-socket="/path/to/mysqld.sock" server-version="5.6.20" />
+        <dbal dbname="mysql_db" user="mysql_user" password="mysql_s3cr3t" unix-socket="/path/to/mysqld.sock" server-version="9.4.0" />
     </config>
 </srv:container>

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_caches.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_caches.xml
@@ -16,7 +16,7 @@
 
     <config>
         <dbal default-connection="default">
-            <connection name="default" dbname="db" />
+            <connection name="default" dbname="db" server-version="9.4.0" />
         </dbal>
 
         <orm default-entity-manager="metadata_cache_none">

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_filters.xml
@@ -8,7 +8,7 @@
 
     <config>
         <dbal default-connection="default">
-            <connection name="default" dbname="db" server-version="8.0.31" />
+            <connection name="default" dbname="db" server-version="9.4.0" />
         </dbal>
 
         <orm enable-lazy-ghost-objects="true">

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_native_lazy_objects_disable.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_native_lazy_objects_disable.xml
@@ -8,7 +8,7 @@
 
     <config>
         <dbal default-connection="default">
-            <connection name="default" dbname="db" server-version="8.0.31" />
+            <connection name="default" dbname="db" server-version="9.4.0" />
         </dbal>
 
         <orm enable-native-lazy-objects="false">

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_native_lazy_objects_enable.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_native_lazy_objects_enable.xml
@@ -8,7 +8,7 @@
 
     <config>
         <dbal default-connection="default">
-            <connection name="default" dbname="db" server-version="8.0.31" />
+            <connection name="default" dbname="db" server-version="9.4.0" />
         </dbal>
 
         <orm enable-native-lazy-objects="true">

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_allow_partial_url_override.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_allow_partial_url_override.yml
@@ -1,5 +1,5 @@
 doctrine:
     dbal:
         override_url: true
-        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1'
         dbname: main_test

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_allow_url_override.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_allow_url_override.yml
@@ -1,7 +1,7 @@
 doctrine:
     dbal:
         override_url: true
-        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1'
         dbname: main_test
         user: tester
         password: wordpass

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_dbname_suffix.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_dbname_suffix.yml
@@ -1,4 +1,4 @@
 doctrine:
     dbal:
-        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1'
         dbname_suffix: _test

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_driver_schemes.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_driver_schemes.yml
@@ -1,6 +1,6 @@
 doctrine:
     dbal:
-        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-10.5.8'
+        url: 'mysql://root:password@database:3306/main?serverVersion=mariadb-12.1.1'
         driver_schemes:
             postgresql: pgsql
             my-scheme: my_driver

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_schema_filter.yml
@@ -4,8 +4,8 @@ doctrine:
         connections:
             connection1:
                 schema_filter: ~^(?!t_)~
-                server_version: 8.0.31
+                server_version: 9.4.0
             connection2:
-                server_version: 8.0.31
+                server_version: 9.4.0
             connection3:
-                server_version: 8.0.31
+                server_version: 9.4.0

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_connection.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_connection.yml
@@ -4,4 +4,4 @@ doctrine:
         user: mysql_user
         password: mysql_s3cr3t
         unix_socket: /path/to/mysqld.sock
-        server_version: 5.6.20
+        server_version: 9.4.0

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_caches.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_caches.yml
@@ -12,6 +12,7 @@ doctrine:
         connections:
             default:
                 dbname: db
+                server_version: 9.4.0
 
     orm:
         default_entity_manager: metadata_cache_none

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_filters.yml
@@ -4,7 +4,7 @@ doctrine:
         connections:
             default:
                 dbname: db
-                server_version: 8.0.31
+                server_version: 9.4.0
 
     orm:
         enable_lazy_ghost_objects: true

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_native_lazy_objects_disable.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_native_lazy_objects_disable.yml
@@ -4,6 +4,7 @@ doctrine:
         connections:
             default:
                 dbname: db
+                server_version: 9.4.0
 
     orm:
         enable_native_lazy_objects: false

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_native_lazy_objects_enable.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_native_lazy_objects_enable.yml
@@ -4,6 +4,7 @@ doctrine:
         connections:
             default:
                 dbname: db
+                server_version: 9.4.0
 
     orm:
         enable_native_lazy_objects: true


### PR DESCRIPTION
We get direct deprecations from the DBAL because we are using old versions of MariaDB or MySQL