### PR TITLE
Test without symfony/doctrine-messenger

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,6 +48,8 @@ jobs:
           - ""
         remove-orm:
           - false
+        remove-doctrine-messenger:
+          - false
         include:
           # Tests the lowest set of dependencies
           - dependencies: "lowest"
@@ -64,6 +66,12 @@ jobs:
             dependencies: "highest"
             stability: "stable"
             remove-orm: true
+
+          # No Messenger integration
+          - php-version: "8.4"
+            dependencies: "highest"
+            stability: "stable"
+            remove-doctrine-messenger: true
 
           # Bleeding edge
           - php-version: "8.4"
@@ -92,6 +100,10 @@ jobs:
       - name: "Remove doctrine/orm"
         run: "composer remove doctrine/orm --dev --no-update"
         if: "${{ matrix.remove-orm }}"
+
+      - name: "Remove symfony/doctrine-messenger"
+        run: "composer remove symfony/doctrine-messenger --dev --no-update"
+        if: "${{ matrix.remove-doctrine-messenger }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"


### PR DESCRIPTION
We have code that checks the presence of that library, and a test that covers the case when it is missing.