### PR TITLE
Avoid coverage upload for merge up pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,6 +111,8 @@ jobs:
   upload_coverage:
     name: "Upload coverage to Codecov"
     runs-on: "ubuntu-latest"
+    # Only run on PRs from forks or PRs from branches that do not match `*.x`
+    if: "github.event.pull_request.head.repo.full_name != github.repository || !contains(github.event.pull_request.head.ref, '.x')"
     needs:
       - "phpunit"
 


### PR DESCRIPTION
Copied from https://github.com/doctrine/orm/pull/11736 , issue spotted on #1999

When there are no conflicts between branches, we create pull requests where the head branch is a branch on the origin repository. That branch points to a commit that should already have coverage information provided by the build that happens after merging a regular pull request.

The thing is, coverage information provided by builds that happen before merging a pull request are associated with the commit of the head repository. This means that when merging up 1.2 into 1.3, the build produces coverage information that is the result of a merge between 1.2 and 1.3, and associates it with 1.2, although it is run on with a codebase that is much closer to 1.3 (and is in fact supposed to become 1.3 after the merge).

This means that when we create a merge up PR from 1.2 to anything else, the coverage information is going to be wrong until a PR targeting 1.2 gets merged.

I do not think we need coverage about conflictless merge up PRs more than we need accurate numbers, so I propose we disable the upload for those instead of, say, trying to associate them with the temporary merge commit.