### PR TITLE
Disallow conflicts between url and standalone options

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -72,6 +72,12 @@ Auto mapping used any route parameter that matches with a field name of the Enti
 
 If you were relying on this functionality, you will need to update your code to use explicit mapped route parameters instead.
 
+### URL overrides are no longer allowed
+
+When using the `doctrine.dbal.url` configuration option, you can no longer
+specify other configuration options that would conflict with it, such as
+`dbname`, `host`, etc.
+
 ConnectionFactory::createConnection() signature change
 ------------------------------------------------------
 

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -823,7 +823,7 @@ can configure. The following block shows all possible configuration keys:
 
         doctrine:
             dbal:
-                url:                      mysql://user:secret@localhost:1234/otherdatabase # this would override the values below
+                url:                      mysql://user:secret@localhost:1234/otherdatabase
                 dbname:                   database
                 host:                     localhost
                 port:                     1234

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -30,7 +31,6 @@ use function key;
 use function reset;
 use function sprintf;
 use function strtoupper;
-use function trigger_deprecation;
 
 /**
  * This class contains the configuration information for the bundle
@@ -284,13 +284,12 @@ class Configuration implements ConfigurationInterface
 
                 if ($urlConflictingValues) {
                     $tail = count($urlConflictingValues) > 1 ? sprintf('or "%s" options', array_pop($urlConflictingValues)) : 'option';
-                    trigger_deprecation(
-                        'doctrine/doctrine-bundle',
-                        '2.4',
-                        'Setting the "doctrine.dbal.%s" %s while the "url" one is defined is deprecated',
+
+                    throw new RuntimeException(sprintf(
+                        'Setting the "doctrine.dbal.%s" %s while the "url" one is defined is not allowed.',
                         implode('", "', $urlConflictingValues),
                         $tail,
-                    );
+                    ));
                 }
 
                 return $values;


### PR DESCRIPTION
This is a follow-up on https://github.com/doctrine/DoctrineBundle/pull/1995. Here, I think I'm removing the opposite case (when the url takes precedence over other options).