### PR TITLE
Switch assertion to doctrine/deprecations

### DIFF
--- a/src/DependencyInjection/Compiler/CacheCompatibilityPass.php
+++ b/src/DependencyInjection/Compiler/CacheCompatibilityPass.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Deprecations\Deprecation;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -14,7 +15,6 @@ use function array_keys;
 use function assert;
 use function in_array;
 use function is_a;
-use function trigger_deprecation;
 
 /** @internal  */
 final class CacheCompatibilityPass implements CompilerPassInterface
@@ -99,9 +99,9 @@ final class CacheCompatibilityPass implements CompilerPassInterface
             return null;
         }
 
-        trigger_deprecation(
+        Deprecation::trigger(
             'doctrine/doctrine-bundle',
-            '2.4',
+            'https://github.com/doctrine/DoctrineBundle/pull/1365',
             'Configuring doctrine/cache is deprecated. Please update the cache service "%s" to use a PSR-6 cache.',
             $definitionId,
         );

--- a/tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -5,9 +5,9 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\TestKernel;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCase;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,7 +18,7 @@ use function interface_exists;
 
 class CacheCompatibilityPassTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use VerifyDeprecations;
 
     public static function setUpBeforeClass(): void
     {
@@ -100,13 +100,10 @@ class CacheCompatibilityPassTest extends TestCase
         })->boot();
     }
 
-    /**
-     * @group legacy
-     * @doesNotPerformAssertions
-     */
+    /** @group legacy */
     public function testMetadataCacheConfigUsingNonPsr6ServiceDefinedByApplication(): void
     {
-        $this->expectDeprecation('Since doctrine/doctrine-bundle 2.4: Configuring doctrine/cache is deprecated. Please update the cache service "custom_cache_service" to use a PSR-6 cache.');
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/1365');
         (new class (false) extends TestKernel {
             public function registerContainerConfiguration(LoaderInterface $loader): void
             {


### PR DESCRIPTION
This was the only time that `ExpectDeprecationTrait` was used in this library. Switching this assertion (and the corresponding deprecation) to `doctrine/deprecations` removes the only reference to `symfony/phpunit-bridge` from the source code, making to switch to PHPUnit's native deprecation output system.

Extracted from #2005 