### PR TITLE
Set branchname for versions without tags

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,17 +6,19 @@
   "versions": [
     {
       "name": "3.0",
+      "branchName": "3.0.x",
       "slug": "latest",
       "upcoming": true
     },
     {
       "name": "2.17",
+      "branchName": "2.17.x",
       "slug": "2.17",
       "upcoming": true
     },
     {
       "name": "2.16",
-      "slug": "latest",
+      "slug": "2.16",
       "current": true
     },
     {


### PR DESCRIPTION
The website build is failing due to missing `branchName` for those versions, that don't have any tags yet.

:information_source: If `branchName` is omitted, the newest tag will be used to create the documentation of a version.