### PR TITLE
Migrate more PHPUnit attributes

### DIFF
--- a/tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -82,7 +82,7 @@ class CacheCompatibilityPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testMetadataCacheConfigUsingPsr6ServiceDefinedByApplication(): void
     {
         (new class (false) extends TestKernel {

--- a/tests/DependencyInjection/Compiler/MiddlewarePassTest.php
+++ b/tests/DependencyInjection/Compiler/MiddlewarePassTest.php
@@ -133,7 +133,16 @@ class MiddlewarePassTest extends TestCase
         $this->assertMiddlewareInjected($container, 'conn2', $className);
     }
 
-    #[DataProvider('provideAddMiddleware')]
+    /** @return array<string, array{0: class-string}> */
+    public static function provideDontAddMiddleware(): array
+    {
+        return [
+            'not connection name aware' => [PHP7Middleware::class],
+            'connection name aware' => [ConnectionAwarePHP7Middleware::class],
+        ];
+    }
+
+    #[DataProvider('provideDontAddMiddleware')]
     public function testDontAddMiddlewareWhenDbalIsNotUsed(string $middlewareClass): void
     {
         $container = $this->createContainer(static function (ContainerBuilder $container) use ($middlewareClass) {

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -39,10 +39,14 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -603,10 +607,8 @@ class DoctrineExtensionTest extends TestCase
         ]);
     }
 
-    /**
-     * @testWith [[]]
-     *           [null]
-     */
+    #[TestWith([[]])]
+    #[TestWith([null])]
     public function testSingleEntityManagerWithEmptyConfiguration(array|null $ormConfiguration): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {
@@ -1410,7 +1412,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertArrayNotHasKey('doctrine.middleware', $abstractMiddlewareDefTags);
     }
 
-    /** @requires function Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver::__construct */
+    #[RequiresMethod(Driver::class, '__construct')]
     public function testDefinitionsIdleConnection(): void
     {
         $container = $this->getContainer();
@@ -1461,11 +1463,9 @@ class DoctrineExtensionTest extends TestCase
         $this->assertTrue(in_array(['connection' => 'conn2', 'priority' => 10], $idleConnectionMiddlewareTagAttributes, true), 'Tag with connection conn2 found for doctrine.dbal.idle_connection_middleware');
     }
 
-    /**
-     * @requires function \Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver::__construct
-     * @testWith [true]
-     *           [false]
-     */
+    #[RequiresMethod(EntityValueResolver::class, '__construct')]
+    #[TestWith([true])]
+    #[TestWith([false])]
     public function testControllerResolver(bool $simpleEntityManagerConfig): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/tests/LockStoreSchemaListenerTest.php
+++ b/tests/LockStoreSchemaListenerTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestWith;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -14,12 +15,9 @@ use function sys_get_temp_dir;
 
 class LockStoreSchemaListenerTest extends TestCase
 {
-    /**
-     * @param array<string, mixed> $config
-     *
-     * @testWith [{}, 0]
-     *           [{"lock": "flock"}, 1]
-     */
+    /** @param array<string, mixed> $config */
+    #[TestWith([[], 0])]
+    #[TestWith([['lock' => 'flock'], 1])]
     public function testLockStoreSchemaSubscriberWiring(array $config, int $expectedCount): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/tests/Middleware/IdleConnectionMiddlewareTest.php
+++ b/tests/Middleware/IdleConnectionMiddlewareTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\Middleware;
 use ArrayObject;
 use Doctrine\Bundle\DoctrineBundle\Middleware\IdleConnectionMiddleware;
 use Doctrine\DBAL\Driver;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver as IdleConnectionDriver;
 
@@ -12,7 +13,7 @@ use function time;
 
 class IdleConnectionMiddlewareTest extends TestCase
 {
-    /** @requires function Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver::__construct */
+    #[RequiresMethod(\Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver::class, '__construct')]
     public function testWrap()
     {
         /** @var ArrayObject<string, int> $connectionExpiries */


### PR DESCRIPTION
I managed to migrate 3.0.x on PHPUnit 12 locally, here is a part of what can be backported to 2.16.x