### PR TITLE
Use stubs when possible

### DIFF
--- a/tests/Command/CreateDatabaseDoctrineTest.php
+++ b/tests/Command/CreateDatabaseDoctrineTest.php
@@ -62,37 +62,22 @@ class CreateDatabaseDoctrineTest extends TestCase
     private function getMockContainer(string $connectionName, array|null $params = null): MockObject
     {
         // Mock the container and everything you'll need here
-        $mockDoctrine = $this->getMockBuilder(ManagerRegistry::class)
-            ->getMock();
+        $mockDoctrine = $this->createStub(ManagerRegistry::class);
 
-        $mockDoctrine->expects($this->any())
-            ->method('getDefaultConnectionName')
-            ->withAnyParameters()
-            ->willReturn($connectionName);
+        $mockDoctrine->method('getDefaultConnectionName')->willReturn($connectionName);
 
         $config = (new Configuration())->setSchemaManagerFactory($this->createMock(SchemaManagerFactory::class));
 
-        $mockConnection = $this->createMock(Connection::class);
+        $mockConnection = $this->createStub(Connection::class);
         $mockConnection->method('getConfiguration')->willReturn($config);
-
-        $mockConnection->expects($this->any())
-            ->method('getParams')
-            ->withAnyParameters()
-            ->willReturn($params);
-
-        $mockDoctrine->expects($this->any())
-            ->method('getConnection')
-            ->withAnyParameters()
-            ->willReturn($mockConnection);
+        $mockConnection->method('getParams')->willReturn($params);
+        $mockDoctrine->method('getConnection')->willReturn($mockConnection);
 
         $mockContainer = $this->getMockBuilder(Container::class)
             ->onlyMethods(['get'])
             ->getMock();
 
-        $mockContainer->expects($this->any())
-            ->method('get')
-            ->with('doctrine')
-            ->willReturn($mockDoctrine);
+        $mockContainer->method('get')->with('doctrine')->willReturn($mockDoctrine);
 
         return $mockContainer;
     }

--- a/tests/Command/DropDatabaseDoctrineTest.php
+++ b/tests/Command/DropDatabaseDoctrineTest.php
@@ -140,35 +140,22 @@ class DropDatabaseDoctrineTest extends TestCase
     private function getMockContainer(string $connectionName, array $params): MockObject
     {
         // Mock the container and everything you'll need here
-        $mockDoctrine = $this->getMockBuilder(ManagerRegistry::class)
-            ->getMock();
+        $mockDoctrine = $this->createStub(ManagerRegistry::class);
 
-        $mockDoctrine->expects($this->any())
-            ->method('getDefaultConnectionName')
-            ->withAnyParameters()
-            ->willReturn($connectionName);
+        $mockDoctrine->method('getDefaultConnectionName')->willReturn($connectionName);
 
         $config = (new Configuration())->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
 
         $mockConnection = $this->createMock(Connection::class);
         $mockConnection->method('getConfiguration')->willReturn($config);
-
-        $mockConnection->expects($this->any())
-            ->method('getParams')
-            ->withAnyParameters()
-            ->willReturn($params);
-
-        $mockDoctrine->expects($this->any())
-            ->method('getConnection')
-            ->withAnyParameters()
-            ->willReturn($mockConnection);
+        $mockConnection->method('getParams')->willReturn($params);
+        $mockDoctrine->method('getConnection')->willReturn($mockConnection);
 
         $mockContainer = $this->getMockBuilder(Container::class)
             ->onlyMethods(['get'])
             ->getMock();
 
-        $mockContainer->expects($this->any())
-            ->method('get')
+        $mockContainer->method('get')
             ->with('doctrine')
             ->willReturn($mockDoctrine);
 

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -46,7 +46,7 @@ class DoctrineDataCollectorTest extends TestCase
 
         $config->expects($this->once())
             ->method('isSecondLevelCacheEnabled')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $metadatas = [
             $this->createEntityMetadata(self::FIRST_ENTITY),

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -30,27 +30,19 @@ class DoctrineDataCollectorTest extends TestCase
             self::markTestSkipped('This test requires ORM');
         }
 
-        $manager    = $this->createMock(EntityManagerInterface::class);
+        $manager    = $this->createStub(EntityManagerInterface::class);
         $config     = $this->createMock(Configuration::class);
         $factory    = $this->createMock(ClassMetadataFactory::class);
         $collector  = $this->createCollector(['default' => $manager], true, $this->createMock(DebugDataHolder::class));
         $unitOfWork = $this->createMock(UnitOfWork::class);
 
-        $manager->expects($this->any())
-            ->method('getMetadataFactory')
-            ->willReturn($factory);
-        $manager->expects($this->any())
-            ->method('getConfiguration')
-            ->willReturn($config);
-        $manager->expects($this->any())
-            ->method('getUnitOfWork')
-            ->willReturn($unitOfWork);
-        $unitOfWork->expects($this->any())
-            ->method('getIdentityMap')
-            ->willReturn([
-                self::FIRST_ENTITY => [new stdClass()],
-                self::SECOND_ENTITY => [new stdClass(), new stdClass()],
-            ]);
+        $manager->method('getMetadataFactory')->willReturn($factory);
+        $manager->method('getConfiguration')->willReturn($config);
+        $manager->method('getUnitOfWork')->willReturn($unitOfWork);
+        $unitOfWork->method('getIdentityMap')->willReturn([
+            self::FIRST_ENTITY => [new stdClass()],
+            self::SECOND_ENTITY => [new stdClass(), new stdClass()],
+        ]);
 
         $config->expects($this->once())
             ->method('isSecondLevelCacheEnabled')
@@ -82,18 +74,12 @@ class DoctrineDataCollectorTest extends TestCase
         $manager    = $this->createMock(EntityManager::class);
         $config     = $this->createMock(Configuration::class);
         $collector  = $this->createCollector(['default' => $manager], false, $this->createMock(DebugDataHolder::class));
-        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $unitOfWork = $this->createStub(UnitOfWork::class);
 
-        $manager->expects($this->never())
-            ->method('getMetadataFactory');
-        $manager->method('getConfiguration')
-            ->willReturn($config);
-        $manager->expects($this->any())
-            ->method('getUnitOfWork')
-            ->willReturn($unitOfWork);
-        $unitOfWork->expects($this->any())
-            ->method('getIdentityMap')
-            ->willReturn([]);
+        $manager->expects($this->never())->method('getMetadataFactory');
+        $manager->method('getConfiguration')->willReturn($config);
+        $manager->method('getUnitOfWork')->willReturn($unitOfWork);
+        $unitOfWork->method('getIdentityMap')->willReturn([]);
 
         $collector->collect(new Request(), new Response());
 
@@ -163,19 +149,12 @@ class DoctrineDataCollectorTest extends TestCase
         bool $shouldValidateSchema = true,
         DebugDataHolder|null $debugDataHolder = null,
     ): DoctrineDataCollector {
-        $registry = $this->createMock(ManagerRegistry::class);
-        $registry
-            ->expects($this->any())
-            ->method('getConnectionNames')
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getConnectionNames')
             ->willReturn(['default' => 'doctrine.dbal.default_connection']);
-        $registry
-            ->expects($this->any())
-            ->method('getManagerNames')
+        $registry->method('getManagerNames')
             ->willReturn(['default' => 'doctrine.orm.default_entity_manager']);
-        $registry
-            ->expects($this->any())
-            ->method('getManagers')
-            ->willReturn($managers);
+        $registry->method('getManagers')->willReturn($managers);
 
         return new DoctrineDataCollector($registry, $shouldValidateSchema, $debugDataHolder);
     }

--- a/tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/tests/Repository/ContainerRepositoryFactoryTest.php
@@ -169,13 +169,11 @@ EXCEPTION);
             $classMetadatas[$entityClass] = $metadata;
         }
 
-        $em = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
-        $em->expects($this->any())
-            ->method('getClassMetadata')
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getClassMetadata')
             ->willReturnCallback(static fn (string $class) => $classMetadatas[$class]);
 
-        $em->expects($this->any())
-            ->method('getConfiguration')
+        $em->method('getConfiguration')
             ->willReturn(new Configuration());
 
         return $em;


### PR DESCRIPTION
It clarifies the intent. Also, it forces us to remove expressions that
do nothing such as `->expects($this->any())`