### PR TITLE
Fix detection of errors

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/bootstrap.php"
          colors="true"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          displayDetailsOnTestsThatTriggerDeprecations="true"

--- a/tests/Command/Proxy/InfoDoctrineCommandTest.php
+++ b/tests/Command/Proxy/InfoDoctrineCommandTest.php
@@ -9,6 +9,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 use function interface_exists;
+use function restore_exception_handler;
 
 class InfoDoctrineCommandTest extends TestCase
 {
@@ -36,5 +37,7 @@ class InfoDoctrineCommandTest extends TestCase
             'Found 3 mapped entities',
             $commandTester->getDisplay(),
         );
+
+        restore_exception_handler();
     }
 }

--- a/tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 use function interface_exists;
+use function restore_exception_handler;
 
 class CacheCompatibilityPassTest extends TestCase
 {
@@ -80,6 +81,8 @@ class CacheCompatibilityPassTest extends TestCase
         })->boot();
 
         $this->addToAssertionCount(1);
+
+        restore_exception_handler();
     }
 
     #[DoesNotPerformAssertions]
@@ -106,6 +109,8 @@ class CacheCompatibilityPassTest extends TestCase
                 });
             }
         })->boot();
+
+        restore_exception_handler();
     }
 
     #[IgnoreDeprecations]
@@ -130,6 +135,8 @@ class CacheCompatibilityPassTest extends TestCase
                 });
             }
         })->boot();
+
+        restore_exception_handler();
     }
 }
 

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\VarExporter\LazyObjectInterface;
 
 use function assert;
 use function interface_exists;
+use function restore_exception_handler;
 
 use const PHP_VERSION_ID;
 
@@ -207,5 +208,7 @@ class RegistryTest extends TestCase
         $this->assertFalse($repository->getEntityManager()->getUnitOfWork()->isEntityScheduled($entity));
 
         $entityManager->flush();
+
+        restore_exception_handler();
     }
 }

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -151,7 +151,7 @@ class RegistryTest extends TestCase
         $registry->reset();
     }
 
-    /** @requires PHP < 8.4 */
+    #[RequiresPhp('8.4')]
     public function testResetLazyObject(): void
     {
         if (! interface_exists(EntityManagerInterface::class) || ! interface_exists(LazyObjectInterface::class)) {

--- a/tests/Repository/ServiceEntityRepositoryTest.php
+++ b/tests/Repository/ServiceEntityRepositoryTest.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
@@ -38,6 +39,7 @@ EXCEPTION);
         $repo->getClassName();
     }
 
+    #[IgnoreDeprecations]
     #[RequiresMethod(ProxyHelper::class, 'generateLazyGhost')]
     #[RequiresPhp('8.4')]
     public function testConstructInitializesWhenImplementingLazyObjectInterface(): void

--- a/tests/Repository/ServiceEntityRepositoryTest.php
+++ b/tests/Repository/ServiceEntityRepositoryTest.php
@@ -6,9 +6,12 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarExporter\LazyGhostTrait;
 use Symfony\Component\VarExporter\LazyObjectInterface;
+use Symfony\Component\VarExporter\ProxyHelper;
 
 use function interface_exists;
 
@@ -35,10 +38,8 @@ EXCEPTION);
         $repo->getClassName();
     }
 
-    /**
-     * @requires function \Symfony\Component\VarExporter\ProxyHelper::generateLazyGhost
-     * @requires PHP < 8.4
-     */
+    #[RequiresMethod(ProxyHelper::class, 'generateLazyGhost')]
+    #[RequiresPhp('8.4')]
     public function testConstructInitializesWhenImplementingLazyObjectInterface(): void
     {
         $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();

--- a/tests/UrlOverrideTest.php
+++ b/tests/UrlOverrideTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 use function array_intersect_key;
+use function restore_exception_handler;
 
 class UrlOverrideTest extends TestCase
 {
@@ -28,6 +29,8 @@ class UrlOverrideTest extends TestCase
                 $expectedParams,
             ),
         );
+
+        restore_exception_handler();
     }
 
     /** @return array<string, array{0: array<string, (bool|string|null)>, 1:  array<string, (bool|string|null)>}> */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Symfony\Component\ErrorHandler\ErrorHandler;
-
-ErrorHandler::register(null, false);


### PR DESCRIPTION
I just noticed that PHPUnit was fine with me removing `#[IgnoreDeprecation]`. This was caused by an earlier commit, let's fix that.