### PR TITLE
Deprecate use_savepoints when using DBAL 4

### DIFF
--- a/UPGRADE-2.17.md
+++ b/UPGRADE-2.17.md
@@ -14,6 +14,11 @@ deprecated. You should stop using it as soon as you upgrade to Doctrine ORM 3.
 This option is a no-op when using `doctrine/dbal` 4 and has been conditionally
 deprecated. You should stop using it as soon as you upgrade to Doctrine DBAL 4.
 
+### The `doctrine.dbal.connections.some_connection.use_savepoints` configuration option is deprecated
+
+This option is a no-op when using `doctrine/dbal` 4 and has been conditionally
+deprecated. You should stop using it as soon as you upgrade to Doctrine DBAL 4.
+
 ConnectionFactory::createConnection() signature change
 ------------------------------------------------------
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -390,7 +390,21 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('pooled')->info('True to use a pooled server with the oci8/pdo_oracle driver')->end()
                 ->booleanNode('MultipleActiveResultSets')->info('Configuring MultipleActiveResultSets for the pdo_sqlsrv driver')->end()
-                ->booleanNode('use_savepoints')->info('Use savepoints for nested transactions')->end()
+                ->booleanNode('use_savepoints')
+                    ->info('Use savepoints for nested transactions')
+                    ->beforeNormalization()
+                        ->ifTrue(static fn ($v): bool => isset($v) && ! method_exists(Connection::class, 'getEventManager'))
+                        ->then(static function ($v) {
+                            Deprecation::trigger(
+                                'doctrine/doctrine-bundle',
+                                'https://github.com/doctrine/DoctrineBundle/pull/2055',
+                                'The "use_savepoints" configuration key is deprecated when using DBAL 4 and will be removed in DoctrineBundle 3.0.',
+                            );
+
+                            return $v;
+                        })
+                    ->end()
+                ->end()
                 ->scalarNode('instancename')
                 ->info(
                     'Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection.' .

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -1020,6 +1020,27 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $this->loadContainer(fixture: 'dbal_disable_type_comments', withMinimalOrmConfig: false);
     }
 
+    #[IgnoreDeprecations]
+    public function testSettingUseSavepointsWithDbal4IsDeprecated(): void
+    {
+        if (method_exists(Connection::class, 'getEventManager')) {
+            self::markTestSkipped('This test requires DBAL 4.');
+        }
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/2055');
+        $this->loadContainer(fixture: 'dbal_use_savepoints', withMinimalOrmConfig: false);
+    }
+
+    public function testSettingUseSavepointsWithDbal3IsFine(): void
+    {
+        if (! method_exists(Connection::class, 'getEventManager')) {
+            self::markTestSkipped('This test requires DBAL 3.');
+        }
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/2055');
+        $this->loadContainer(fixture: 'dbal_use_savepoints', withMinimalOrmConfig: false);
+    }
+
     public function testResolveTargetEntity(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -276,6 +276,7 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $this->assertCount(0, $calls);
     }
 
+    #[IgnoreDeprecations]
     public function testDbalLoadDisableTypeComments(): void
     {
         $container = $this->loadContainer(fixture: 'dbal_disable_type_comments', withMinimalOrmConfig: false);

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -542,6 +542,7 @@ class DoctrineExtensionTest extends TestCase
         $this->assertSame(ArrayAdapter::class, $definition->getClass());
     }
 
+    #[IgnoreDeprecations]
     public function testUseSavePointsAddMethodCallToAddSavepointsToTheConnection(): void
     {
         $container = $this->getContainer();

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_use_savepoints.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_use_savepoints.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd
+           http://symfony.com/schema/dic/doctrine
+           https://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <doctrine:config>
+        <doctrine:dbal default-connection="savepoints">
+            <doctrine:connection name="savepoints" use-savepoints="true" />
+            <doctrine:connection name="notset" user="root" />
+        </doctrine:dbal>
+    </doctrine:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/config/xml/dbal_use_savepoints.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/dbal_use_savepoints.xml
@@ -2,15 +2,12 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services
-           https://symfony.com/schema/dic/services/services-1.0.xsd
-           http://symfony.com/schema/dic/doctrine
-           https://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+           http://symfony.com/schema/dic/doctrine https://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <doctrine:config>
         <doctrine:dbal default-connection="savepoints">
             <doctrine:connection name="savepoints" use-savepoints="true" />
-            <doctrine:connection name="notset" user="root" />
         </doctrine:dbal>
     </doctrine:config>
 </container>

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_use_savepoints.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_use_savepoints.yml
@@ -4,5 +4,3 @@ doctrine:
         connections:
             savepoints:
                 use_savepoints: true
-            notset:
-                user: root

--- a/tests/DependencyInjection/Fixtures/config/yml/dbal_use_savepoints.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/dbal_use_savepoints.yml
@@ -1,0 +1,8 @@
+doctrine:
+    dbal:
+        default_connection: savepoints
+        connections:
+            savepoints:
+                use_savepoints: true
+            notset:
+                user: root


### PR DESCRIPTION
It is a no-op and should ideally not be set according to an existing
exception thrown when setting it to false.

⚠️ AI disclosure: this change was done mostly by opencode + Claude Sonnet. I told it to do something similar to what I did in #2048