### PR TITLE
Switch entirely to doctrine/deprecations 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         "symfony/config": "^6.4 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/deprecation-contracts": "^2.1 || ^3",
         "symfony/doctrine-bridge": "^6.4.3 || ^7.0.3",
         "symfony/framework-bundle": "^6.4 || ^7.0",
         "symfony/service-contracts": "^2.5 || ^3"

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require": {
         "php": "^8.1",
         "doctrine/dbal": "^3.7.0 || ^4.0",
+        "doctrine/deprecations": "^1.0",
         "doctrine/persistence": "^3.1 || ^4",
         "doctrine/sql-formatter": "^1.0.1",
         "symfony/cache": "^6.4 || ^7.0",
@@ -46,7 +47,6 @@
         "doctrine/annotations": "^1 || ^2",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/coding-standard": "^13",
-        "doctrine/deprecations": "^1.0",
         "doctrine/orm": "^2.17 || ^3.1",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "phpstan/phpstan": "2.1.1",

--- a/src/Command/Proxy/DoctrineCommandHelper.php
+++ b/src/Command/Proxy/DoctrineCommandHelper.php
@@ -2,13 +2,13 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 use function assert;
-use function trigger_deprecation;
 
 /**
  * Provides some helper and convenience methods to configure doctrine commands in the context of bundles
@@ -31,9 +31,9 @@ abstract class DoctrineCommandHelper
         /* @phpstan-ignore class.notFound, argument.type (ORM < 3 specific) */
         $helperSet->set(new EntityManagerHelper($em), 'em');
 
-        trigger_deprecation(
+        Deprecation::trigger(
             'doctrine/doctrine-bundle',
-            '2.7',
+            'https://github.com/doctrine/DoctrineBundle/pull/1513',
             'Providing an EntityManager using "%s" is deprecated. Use an instance of "%s" instead.',
             /* @phpstan-ignore class.notFound */
             EntityManagerHelper::class,

--- a/src/Command/Proxy/OrmProxyCommand.php
+++ b/src/Command/Proxy/OrmProxyCommand.php
@@ -2,11 +2,10 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-
-use function trigger_deprecation;
 
 /**
  * @internal
@@ -19,9 +18,9 @@ trait OrmProxyCommand
     ) {
         parent::__construct($entityManagerProvider);
 
-        trigger_deprecation(
+        Deprecation::trigger(
             'doctrine/doctrine-bundle',
-            '2.8',
+            'https://github.com/doctrine/DoctrineBundle/pull/1581',
             'Class "%s" is deprecated. Use "%s" instead.',
             self::class,
             parent::class,

--- a/src/Command/Proxy/RunSqlDoctrineCommand.php
+++ b/src/Command/Proxy/RunSqlDoctrineCommand.php
@@ -3,10 +3,9 @@
 namespace Doctrine\Bundle\DoctrineBundle\Command\Proxy;
 
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
+use Doctrine\Deprecations\Deprecation;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-
-use function trigger_deprecation;
 
 /**
  * Execute a SQL query and output the results.
@@ -31,9 +30,9 @@ EOT);
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        trigger_deprecation(
+        Deprecation::trigger(
             'doctrine/doctrine-bundle',
-            '2.2',
+            'https://github.com/doctrine/DoctrineBundle/pull/1231',
             'The "%s" (doctrine:query:sql) is deprecated, use dbal:run-sql command instead.',
             self::class,
         );

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -24,7 +24,6 @@ use function array_merge;
 use function class_exists;
 use function is_subclass_of;
 use function method_exists;
-use function trigger_deprecation;
 
 use const PHP_EOL;
 
@@ -79,7 +78,11 @@ class ConnectionFactory
         $overriddenOptions = [];
         /** @phpstan-ignore isset.offset (We should adjust when https://github.com/phpstan/phpstan/issues/12414 is fixed) */
         if (isset($params['connection_override_options'])) {
-            trigger_deprecation('doctrine/doctrine-bundle', '2.4', 'The "connection_override_options" connection parameter is deprecated');
+            Deprecation::trigger(
+                'doctrine/doctrine-bundle',
+                'https://github.com/doctrine/DoctrineBundle/pull/1342',
+                'The "connection_override_options" connection parameter is deprecated',
+            );
             $overriddenOptions = $params['connection_override_options'];
             unset($params['connection_override_options']);
         }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
 use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -40,7 +41,6 @@ use function strlen;
 use function strpos;
 use function strtoupper;
 use function substr;
-use function trigger_deprecation;
 
 /**
  * This class contains the configuration information for the bundle
@@ -292,9 +292,9 @@ class Configuration implements ConfigurationInterface
 
                 if ($urlConflictingValues) {
                     $tail = count($urlConflictingValues) > 1 ? sprintf('or "%s" options', array_pop($urlConflictingValues)) : 'option';
-                    trigger_deprecation(
+                    Deprecation::trigger(
                         'doctrine/doctrine-bundle',
-                        '2.4',
+                        'https://github.com/doctrine/DoctrineBundle/pull/1342',
                         'Setting the "doctrine.dbal.%s" %s while the "url" one is defined is deprecated',
                         implode('", "', $urlConflictingValues),
                         $tail,

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Configuration as ORMConfiguration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
@@ -81,7 +82,6 @@ use function method_exists;
 use function reset;
 use function sprintf;
 use function str_replace;
-use function trigger_deprecation;
 
 use const PHP_VERSION_ID;
 
@@ -506,12 +506,20 @@ class DoctrineExtension extends AbstractDoctrineExtension
         }
 
         if ($config['controller_resolver']['auto_mapping'] === null) {
-            trigger_deprecation('doctrine/doctrine-bundle', '2.12', 'The default value of "doctrine.orm.controller_resolver.auto_mapping" will be changed from `true` to `false`. Explicitly configure `true` to keep existing behaviour.');
+            Deprecation::trigger(
+                'doctrine/doctrine-bundle',
+                'https://github.com/doctrine/DoctrineBundle/pull/1762',
+                'The default value of "doctrine.orm.controller_resolver.auto_mapping" will be changed from `true` to `false`. Explicitly configure `true` to keep existing behaviour.',
+            );
             $config['controller_resolver']['auto_mapping'] = true;
         }
 
         if ($config['controller_resolver']['auto_mapping'] === true) {
-            trigger_deprecation('doctrine/doctrine-bundle', '2.13', 'Enabling the controller resolver automapping feature has been deprecated. Symfony Mapped Route Parameters should be used as replacement.');
+            Deprecation::trigger(
+                'doctrine/doctrine-bundle',
+                'https://github.com/doctrine/DoctrineBundle/pull/1804',
+                'Enabling the controller resolver automapping feature has been deprecated. Symfony Mapped Route Parameters should be used as replacement.',
+            );
         }
 
         if (! $config['controller_resolver']['auto_mapping']) {
@@ -577,7 +585,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 'Lazy ghost objects cannot be disabled for ORM 3.',
             );
         } else {
-            trigger_deprecation('doctrine/doctrine-bundle', '2.11', 'Not setting "doctrine.orm.enable_lazy_ghost_objects" to true is deprecated.');
+            Deprecation::trigger(
+                'doctrine/doctrine-bundle',
+                'https://github.com/doctrine/DoctrineBundle/pull/1568',
+                'Not setting "doctrine.orm.enable_lazy_ghost_objects" to true is deprecated.',
+            );
         }
 
         if ($config['enable_native_lazy_objects'] ?? false) {
@@ -595,7 +607,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $container->removeDefinition('doctrine.orm.proxy_cache_warmer');
         } elseif (! class_exists(AnnotationDriver::class) && PHP_VERSION_ID >= 80400) {
             // Only emit the deprecation notice for ORM 3 and PHP 8.4+ users
-            trigger_deprecation('doctrine/doctrine-bundle', '2.16', 'Not setting "doctrine.orm.enable_native_lazy_objects" to true is deprecated.');
+            Deprecation::trigger(
+                'doctrine/doctrine-bundle',
+                'https://github.com/doctrine/DoctrineBundle/pull/1905',
+                'Not setting "doctrine.orm.enable_native_lazy_objects" to true is deprecated.',
+            );
         }
 
         $options = ['auto_generate_proxy_classes', 'enable_lazy_ghost_objects', 'enable_native_lazy_objects', 'proxy_dir', 'proxy_namespace'];

--- a/src/Repository/ContainerRepositoryFactory.php
+++ b/src/Repository/ContainerRepositoryFactory.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -16,7 +17,6 @@ use function get_debug_type;
 use function is_a;
 use function spl_object_hash;
 use function sprintf;
-use function trigger_deprecation;
 
 /**
  * Fetches repositories from the container or falls back to normal creation.
@@ -62,7 +62,14 @@ final class ContainerRepositoryFactory implements RepositoryFactory
                 }
 
                 if (! $repository instanceof EntityRepository) {
-                    trigger_deprecation('doctrine/doctrine-bundle', '2.11', 'The service "%s" of type "%s" should extend "%s", not doing so is deprecated.', $repositoryServiceId, get_debug_type($repository), EntityRepository::class);
+                    Deprecation::trigger(
+                        'doctrine/doctrine-bundle',
+                        'https://github.com/doctrine/DoctrineBundle/pull/1722',
+                        'The service "%s" of type "%s" should extend "%s", not doing so is deprecated.',
+                        $repositoryServiceId,
+                        get_debug_type($repository),
+                        EntityRepository::class,
+                    );
                 }
 
                 /** @phpstan-var ObjectRepository<T> */

--- a/src/Twig/DoctrineExtension.php
+++ b/src/Twig/DoctrineExtension.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Twig;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\SqlFormatter\HtmlHighlighter;
 use Doctrine\SqlFormatter\NullHighlighter;
 use Doctrine\SqlFormatter\SqlFormatter;
@@ -25,7 +26,6 @@ use function preg_replace_callback;
 use function sprintf;
 use function strtoupper;
 use function substr;
-use function trigger_deprecation;
 
 /**
  * This class contains the needed functions in order to do the query highlighting
@@ -154,9 +154,9 @@ class DoctrineExtension extends AbstractExtension
      */
     public function formatQuery($sql, $highlightOnly = false)
     {
-        trigger_deprecation(
+        Deprecation::trigger(
             'doctrine/doctrine-bundle',
-            '2.1',
+            'https://github.com/doctrine/DoctrineBundle/pull/1056',
             'The "%s()" method is deprecated and will be removed in doctrine-bundle 3.0.',
             __METHOD__,
         );


### PR DESCRIPTION
According to https://github.com/doctrine/DoctrineBundle/issues/1300#issuecomment-1568533564, this should be OK (meaning Symfony users should see the deprecations).

I'm doing this for 2 reasons:

- Having a link to the deprecation is great.
- consistency.