### PR TITLE
Remove useless comment

### DIFF
--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -72,11 +72,6 @@ use function sys_get_temp_dir;
 
 class DoctrineExtensionTest extends TestCase
 {
-    /**
-     * https://github.com/doctrine/orm/pull/7953 needed, otherwise ORM classes
-     * we define services for trigger deprecations
-     */
-    #[IgnoreDeprecations]
     public function testAutowiringAlias(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1510,8 +1510,6 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals(new MapEntity(null, null, null, [], null, null, null, true, true), $container->get('controller_resolver_defaults'));
     }
 
-    // phpcs:enable
-
     /** @param list<string> $bundles */
     private static function getContainer(array $bundles = ['XmlBundle'], string $vendor = ''): ContainerBuilder
     {


### PR DESCRIPTION
It is useless since 84d23e5706318cef3e548cd826d29a802c3ebc6f, when the counterpart `phpcs:disable` was removed.

Also, I removed an `IgnoreDeprecations` attribute that was is no longer needed.