### PR TITLE
Display coverage for default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Doctrine DBAL & ORM Bundle for the Symfony Framework.
 
-[![Continuous Integration](https://github.com/doctrine/DoctrineBundle/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/DoctrineBundle/actions/workflows/continuous-integration.yml) [![codecov](https://codecov.io/gh/doctrine/DoctrineBundle/branch/master/graph/badge.svg?token=qtm3EQ3WgV)](https://codecov.io/gh/doctrine/DoctrineBundle)
+[![Continuous Integration](https://github.com/doctrine/DoctrineBundle/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/DoctrineBundle/actions/workflows/continuous-integration.yml)
+[![codecov](https://codecov.io/gh/doctrine/DoctrineBundle/graph/badge.svg?token=qtm3EQ3WgV)](https://codecov.io/gh/doctrine/DoctrineBundle)
 
 ## What is Doctrine?
 


### PR DESCRIPTION
Currently, the coverage badge displays a value of 76%, because of at least 2 reasons:

- It was directly referring to master.
- Even if we were referring to the default branch, the default branch was set to master.

master no longer exists, so I've set 2.16.x as the default branch in Codecov.