### PR TITLE
fix phpunit deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
          colors="true"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnPhpunitDeprecations="true"
          failOnDeprecation="true"
 >
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
          failOnDeprecation="true"
+         failOnPhpunitDeprecation="true"
 >
     <testsuites>
         <testsuite name="DoctrineBundle for the Symfony Framework">

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -152,7 +152,7 @@ class RegistryTest extends TestCase
         $registry->reset();
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>= 8.4')]
     public function testResetLazyObject(): void
     {
         if (! interface_exists(EntityManagerInterface::class) || ! interface_exists(LazyObjectInterface::class)) {

--- a/tests/Repository/ServiceEntityRepositoryTest.php
+++ b/tests/Repository/ServiceEntityRepositoryTest.php
@@ -41,7 +41,7 @@ EXCEPTION);
 
     #[IgnoreDeprecations]
     #[RequiresMethod(ProxyHelper::class, 'generateLazyGhost')]
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>= 8.4')]
     public function testConstructInitializesWhenImplementingLazyObjectInterface(): void
     {
         $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();


### PR DESCRIPTION
```
There were 2 PHPUnit test runner deprecations:

1) Test method Doctrine\Bundle\DoctrineBundle\Tests\RegistryTest::testResetLazyObject has attribute with version constraint string argument without explicit version comparison operator ("8.4")

2) Test method Doctrine\Bundle\DoctrineBundle\Tests\Repository\ServiceEntityRepositoryTest::testConstructInitializesWhenImplementingLazyObjectInterface has attribute with version constraint string argument without explicit version comparison operator ("8.4")
