### PR TITLE
Make DependencyInjection namespace internal

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -155,6 +155,13 @@ You should use stop passing an event manager argument.
 + $connectionFactory->createConnection($params, $config, $mappingTypes)
 ```
 
+DependencyInjection namespace becomes internal
+----------------------------------------------
+
+The `Doctrine\Bundle\DoctrineBundle\DependencyInjection` namespace is now
+considered internal, and all classes inside it are marked as final.
+Don't reference any classes from this namespace directly.
+
 `Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventListenerInterface` has been removed
 ----------------------------------------------------------------------------------------
 

--- a/src/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
+++ b/src/DependencyInjection/Compiler/CacheSchemaSubscriberPass.php
@@ -14,9 +14,9 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * Must be run later after ResolveChildDefinitionsPass.
  *
- * @final since 2.9
+ * @internal
  */
-class CacheSchemaSubscriberPass implements CompilerPassInterface
+final class CacheSchemaSubscriberPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Compiler/DbalSchemaFilterPass.php
+++ b/src/DependencyInjection/Compiler/DbalSchemaFilterPass.php
@@ -14,9 +14,9 @@ use function sprintf;
 /**
  * Processes the doctrine.dbal.schema_filter
  *
- * @final since 2.9
+ * @internal
  */
-class DbalSchemaFilterPass implements CompilerPassInterface
+final class DbalSchemaFilterPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -17,9 +17,9 @@ use Symfony\Component\DependencyInjection\Reference;
  * Class for Symfony bundles to configure mappings for model classes not in the
  * auto-mapped folder.
  *
- * @final since 2.9
+ * @internal
  */
-class DoctrineOrmMappingsPass extends RegisterMappingsPass
+final class DoctrineOrmMappingsPass extends RegisterMappingsPass
 {
     /**
      * You should not directly instantiate this class but use one of the

--- a/src/DependencyInjection/Compiler/EntityListenerPass.php
+++ b/src/DependencyInjection/Compiler/EntityListenerPass.php
@@ -23,9 +23,9 @@ use function usort;
 /**
  * Class for Symfony bundles to register entity listeners
  *
- * @final since 2.9
+ * @internal
  */
-class EntityListenerPass implements CompilerPassInterface
+final class EntityListenerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Compiler/IdGeneratorPass.php
+++ b/src/DependencyInjection/Compiler/IdGeneratorPass.php
@@ -18,6 +18,7 @@ use function array_keys;
 use function array_map;
 use function sprintf;
 
+/** @internal */
 final class IdGeneratorPass implements CompilerPassInterface
 {
     public const string ID_GENERATOR_TAG  = 'doctrine.id_generator';

--- a/src/DependencyInjection/Compiler/MiddlewaresPass.php
+++ b/src/DependencyInjection/Compiler/MiddlewaresPass.php
@@ -18,6 +18,7 @@ use function is_subclass_of;
 use function sprintf;
 use function usort;
 
+/** @internal */
 final class MiddlewaresPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/src/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -13,6 +13,7 @@ use function array_combine;
 use function array_keys;
 use function array_map;
 
+/** @internal */
 final class ServiceRepositoryCompilerPass implements CompilerPassInterface
 {
     public const string REPOSITORY_SERVICE_TAG = 'doctrine.repository_service';

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,9 +39,9 @@ use function strtoupper;
  * This information is solely responsible for how the different configuration
  * sections are normalized, and merged.
  *
- * @final since 2.9
+ * @internal
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /** @param bool $debug Whether to use the debug mode */
     public function __construct(private bool $debug)

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -88,7 +88,8 @@ use const GLOB_NOSORT;
 /**
  * DoctrineExtension is an extension for the Doctrine DBAL and ORM library.
  *
- * @final since 2.9
+ * @internal
+ *
  * @phpstan-type DBALConfig = array{
  *      connections: array<string, array{logging: bool, profiling: bool, profiling_collect_backtrace: bool, idle_connection_ttl: int}>,
  *      driver_schemes: array<string, string>,
@@ -96,7 +97,7 @@ use const GLOB_NOSORT;
  *      types: array<string, string>,
  *  }
  */
-class DoctrineExtension extends Extension
+final class DoctrineExtension extends Extension
 {
     /**
      * Used inside metadata driver method to simplify aggregation of data.


### PR DESCRIPTION
Nobody is supposed to use types inside that namespace (see #1984), so let us make it internal, it should make changes easier to do.

I also marked classes inside the namespace as hard final, despite my previous PR making many types final being rejected, because I think it makes sense for types that are marked with `@internal`.