### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -11,15 +11,21 @@
       "upcoming": true
     },
     {
+      "name": "2.18",
+      "branchName": "2.18.x",
+      "slug": "2.18",
+      "upcoming": true
+    },
+    {
       "name": "2.17",
       "branchName": "2.17.x",
       "slug": "2.17",
-      "upcoming": true
+      "current": true
     },
     {
       "name": "2.16",
       "slug": "2.16",
-      "current": true
+      "maintained": false
     },
     {
       "name": "2.15",

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -12,9 +12,10 @@ branches:
     - "2.15.x"
     - "2.16.x"
     - "2.17.x"
+    - "2.18.x"
 maintained_branches:
-    - "2.16.x"
     - "2.17.x"
+    - "2.18.x"
 doc_dir: "docs/en/"
-current_branch: "2.16.x"
-dev_branch: "2.17.x"
+current_branch: "2.17.x"
+dev_branch: "2.18.x"


### PR DESCRIPTION
2.18.x has been created, so:

- 2.16.x is no longer maintained;
- 2.17.x becomes the current branch;
- 2.18.x is the next minor branch.