### PR TITLE
Restore some more lines from v6 of the bridge

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -302,13 +302,22 @@ class DoctrineExtension extends Extension
             if ($container->hasDefinition($mappingService)) {
                 $mappingDriverDef = $container->getDefinition($mappingService);
                 $args             = $mappingDriverDef->getArguments();
-                if ($driverType === 'attribute') {
+                if ($driverType === 'annotation') {
                     $args[1] = array_merge(array_values($driverPaths), $args[1]);
                 } else {
                     $args[0] = array_merge(array_values($driverPaths), $args[0]);
                 }
 
                 $mappingDriverDef->setArguments($args);
+            } elseif ($driverType === 'attribute') {
+                $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
+                    array_values($driverPaths),
+                ]);
+            } elseif ($driverType === 'annotation') {
+                $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
+                    new Reference($this->getObjectManagerElementName('metadata.annotation_reader')),
+                    array_values($driverPaths),
+                ]);
             } else {
                 $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
                     array_values($driverPaths),


### PR DESCRIPTION
I am not sure how I messed this up, but I managed to omit these lines when copy/pasting from the diff I put at https://github.com/doctrine/DoctrineBundle/issues/2082#issuecomment-3384590648

Reported in https://github.com/doctrine/DoctrineBundle/issues/2082#issuecomment-3390175437 by @vitek-rostislav

# How can I test this?
```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/DoctrineBundle
composer require doctrine/doctrine-bundle "dev-broken-compat-2 as 2.17.1"
```

@vitek-rostislav can you please confirm it fixes your issue?
