### PR TITLE
Revert "Deprecate passing an event manager to CF::createConnection()"

### DIFF
--- a/UPGRADE-2.17.md
+++ b/UPGRADE-2.17.md
@@ -26,20 +26,3 @@ deprecated. You should stop using it as soon as you upgrade to Doctrine DBAL 4.
 
 This option is a no-op when using `doctrine/dbal` 4 and has been conditionally
 deprecated. You should stop using it as soon as you upgrade to Doctrine DBAL 4.
-
-ConnectionFactory::createConnection() signature change
-------------------------------------------------------
-
-The signature of `ConnectionFactory::createConnection()` will change with
-version 3.0 of the bundle.
-
-As soon as you upgrade to Doctrine DBAL 4, you should use stop passing an event
-manager argument.
-
-```diff
-- $connectionFactory->createConnection($params, $config, $eventManager, $mappingTypes)
-+ $connectionFactory->createConnection($params, $config, $mappingTypes)
-```
-
-As a small breaking change, it is no longer fully possible to use named
-arguments with that method until 3.0.

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -24,8 +24,6 @@ use InvalidArgumentException;
 
 use function array_merge;
 use function class_exists;
-use function func_num_args;
-use function is_array;
 use function is_subclass_of;
 use function method_exists;
 
@@ -63,50 +61,16 @@ class ConnectionFactory
     /**
      * Create a connection by name.
      *
-     * @param mixed[]                                 $params
-     * @param EventManager|array<string, string>|null $eventManagerOrMappingTypes
-     * @param array<string, string>                   $deprecatedMappingTypes
+     * @param mixed[]               $params
+     * @param array<string, string> $mappingTypes
      * @phpstan-param Params $params
      *
      * @return Connection
-     *
-     * @no-named-arguments
      */
-    public function createConnection(
-        array $params,
-        Configuration|null $config = null,
-        EventManager|array|null $eventManagerOrMappingTypes = [],
-        array $deprecatedMappingTypes = [],
-    ) {
-        if (! method_exists(Connection::class, 'getEventManager') && $eventManagerOrMappingTypes instanceof EventManager) {
+    public function createConnection(array $params, Configuration|null $config = null, EventManager|null $eventManager = null, array $mappingTypes = [])
+    {
+        if (! method_exists(Connection::class, 'getEventManager') && $eventManager !== null) {
             throw new InvalidArgumentException('Passing an EventManager instance is not supported with DBAL > 3');
-        }
-
-        if (is_array($eventManagerOrMappingTypes) && func_num_args() === 4) {
-            throw new InvalidArgumentException('Passing mapping types both as 3rd and 4th argument makes no sense.');
-        }
-
-        if ($eventManagerOrMappingTypes instanceof EventManager) {
-            // DBAL 3
-            $eventManager = $eventManagerOrMappingTypes;
-            $mappingTypes = $deprecatedMappingTypes;
-        } elseif (is_array($eventManagerOrMappingTypes)) {
-            // Future signature
-            $eventManager = null;
-            $mappingTypes = $eventManagerOrMappingTypes;
-        } else {
-            // Legacy signature
-            if (! method_exists(Connection::class, 'getEventManager')) {
-                Deprecation::trigger(
-                    'doctrine/doctrine-bundle',
-                    'https://github.com/doctrine/DoctrineBundle/pull/1976',
-                    'Passing mapping types as 4th argument to %s is deprecated when using DBAL 4 and will not be supported in version 3.0 of the bundle. Pass them as 3rd argument instead.',
-                    __METHOD__,
-                );
-            }
-
-            $eventManager = null;
-            $mappingTypes = $deprecatedMappingTypes;
         }
 
         if (! $this->initialized) {

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -695,12 +695,13 @@ class DoctrineExtension extends Extension
         $def = $container
             ->setDefinition($connectionId, new ChildDefinition('doctrine.dbal.connection'))
             ->setPublic(true)
-            ->setArguments(array_merge(
-                [$options, new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name))],
-                // event manager must only be passed for DBAL < 4
-                method_exists(Connection::class, 'getEventManager') ? [new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $name))] : [],
-                [$connection['mapping_types']],
-            ));
+            ->setArguments([
+                $options,
+                new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name)),
+                // event manager is only supported on DBAL < 4
+                method_exists(Connection::class, 'getEventManager') ? new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $name)) : null,
+                $connection['mapping_types'],
+            ]);
 
         $container
             ->registerAliasForArgument($connectionId, Connection::class, sprintf('%s.connection', $name))

--- a/tests/ConnectionFactoryTest.php
+++ b/tests/ConnectionFactoryTest.php
@@ -10,11 +10,9 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 use function array_intersect_key;
-use function method_exists;
 
 class ConnectionFactoryTest extends TestCase
 {
@@ -166,34 +164,6 @@ class ConnectionFactoryTest extends TestCase
 
         $this->assertSame('primary_test', $parsedParams['primary']['dbname']);
         $this->assertSame('replica_test', $parsedParams['replica']['replica1']['dbname']);
-    }
-
-    public function testItThrowsWhenPassingMappingTypesTwice(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        (new ConnectionFactory())->createConnection(['driver' => 'pdo_sqlite'], null, [], []);
-    }
-
-    #[IgnoreDeprecations]
-    public function testPassingMappingTypesAsFourthArgumentIsDeprecatedWithDbal4(): void
-    {
-        if (method_exists(Connection::class, 'getEventManager')) {
-            $this->markTestSkipped('DBAL 3 does not trigger the deprecation.');
-        }
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/1976');
-        (new ConnectionFactory())->createConnection(['driver' => 'pdo_sqlite'], null, null, []);
-    }
-
-    public function testPassingMappingTypesAsFourthArgumentIsFineWithDbal3(): void
-    {
-        if (! method_exists(Connection::class, 'getEventManager')) {
-            $this->markTestSkipped('DBAL 4 triggers the deprecation.');
-        }
-
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/1976');
-        (new ConnectionFactory())->createConnection(['driver' => 'pdo_sqlite'], null, null, []);
     }
 }
 

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -349,17 +349,24 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
 
-        $this->assertDICConstructorArguments($definition, $this->getFactoryArguments([
-            'dbname' => 'db',
-            'host' => 'localhost',
-            'port' => null,
-            'user' => 'root',
-            'password' => null,
-            'driver' => 'pdo_mysql',
-            'driverOptions' => [],
-            'defaultTableOptions' => [],
-            'idle_connection_ttl' => 600,
-        ]));
+        $this->assertDICConstructorArguments($definition, [
+            [
+                'dbname' => 'db',
+                'host' => 'localhost',
+                'port' => null,
+                'user' => 'root',
+                'password' => null,
+                'driver' => 'pdo_mysql',
+                'driverOptions' => [],
+                'defaultTableOptions' => [],
+                'idle_connection_ttl' => 600,
+            ],
+            new Reference('doctrine.dbal.default_connection.configuration'),
+            method_exists(Connection::class, 'getEventManager')
+                ? new Reference('doctrine.dbal.default_connection.event_manager')
+                : null,
+            [],
+        ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -383,9 +390,8 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
 
         $container = $this->loadContainer('orm_service_simple_single_entity_manager_without_dbname');
 
-        $this->assertDICConstructorArguments(
-            $container->getDefinition('doctrine.dbal.default_connection'),
-            $this->getFactoryArguments([
+        $this->assertDICConstructorArguments($container->getDefinition('doctrine.dbal.default_connection'), [
+            [
                 'host' => 'localhost',
                 'port' => null,
                 'user' => 'root',
@@ -394,8 +400,13 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
                 'driverOptions' => [],
                 'defaultTableOptions' => [],
                 'idle_connection_ttl' => 600,
-            ]),
-        );
+            ],
+            new Reference('doctrine.dbal.default_connection.configuration'),
+            method_exists(Connection::class, 'getEventManager')
+                ? new Reference('doctrine.dbal.default_connection.event_manager')
+                : null,
+            [],
+        ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -417,18 +428,25 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
 
-        $this->assertDICConstructorArguments($definition, $this->getFactoryArguments([
-            'host' => 'localhost',
-            'driver' => 'pdo_sqlite',
-            'driverOptions' => [],
-            'user' => 'sqlite_user',
-            'port' => null,
-            'password' => 'sqlite_s3cr3t',
-            'dbname' => 'sqlite_db',
-            'memory' => true,
-            'defaultTableOptions' => [],
-            'idle_connection_ttl' => 600,
-        ]));
+        $this->assertDICConstructorArguments($definition, [
+            [
+                'host' => 'localhost',
+                'driver' => 'pdo_sqlite',
+                'driverOptions' => [],
+                'user' => 'sqlite_user',
+                'port' => null,
+                'password' => 'sqlite_s3cr3t',
+                'dbname' => 'sqlite_db',
+                'memory' => true,
+                'defaultTableOptions' => [],
+                'idle_connection_ttl' => 600,
+            ],
+            new Reference('doctrine.dbal.default_connection.configuration'),
+            method_exists(Connection::class, 'getEventManager')
+                ? new Reference('doctrine.dbal.default_connection.event_manager')
+                : null,
+            [],
+        ]);
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getClass());
@@ -1751,26 +1769,6 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         $passConfig->setRemovingPasses([]);
         $passConfig->addPass(new CacheCompatibilityPass());
         $container->compile();
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     *
-     * @return list<mixed> The expected arguments to the connection factory
-     */
-    private function getFactoryArguments(array $params): array
-    {
-        $args = [
-            $params,
-            new Reference('doctrine.dbal.default_connection.configuration'),
-        ];
-        if (method_exists(Connection::class, 'getEventManager')) {
-            $args[] = new Reference('doctrine.dbal.default_connection.event_manager');
-        }
-
-        $args[] = [];
-
-        return $args;
     }
 }
 


### PR DESCRIPTION
This reverts commit 7f0164e89174ceff929e1985972e31dc4f7d10a6, that contains a breaking change.

```diff
-public function createConnection(array $params, Configuration|null $config = null, EventManager|null $eventManager = null, array $mappingTypes = [])
+public function createConnection(array $params, Configuration|null $config = null, EventManager|array|null $eventManagerOrMappingTypes = [], array $deprecatedMappingTypes = [],
```

Fixes #2091