### PR TITLE
Target dependabot to 2.18.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
+    target-branch: "2.18.x"


### PR DESCRIPTION
Now that we released 3.0.0, the default branch is no longer the lowest branch.