### PR TITLE
Conditionally deprecate proxy-related-settings

### DIFF
--- a/UPGRADE-2.19.md
+++ b/UPGRADE-2.19.md
@@ -1,0 +1,17 @@
+UPGRADE FROM 2.18 to 2.19
+=========================
+
+Configuration
+-------------
+
+### Proxy-related configuration settings are conditionally deprecated
+
+When using PHP 8.4 or higher in combination with Doctrine ORM 3.4 or
+higher, the following configuration settings are deprecated:
+
+- `auto_generate_proxy_classes`
+- `proxy_namespace`
+- `proxy_dir`
+
+Instead, they should be unset, and `enable_native_lazy_objects` should
+be set to `true`.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
 use Doctrine\Deprecations\Deprecation;
+use Doctrine\ORM\Configuration as OrmConfiguration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -44,6 +45,8 @@ use function strlen;
 use function strpos;
 use function strtoupper;
 use function substr;
+
+use const PHP_VERSION_ID;
 
 /**
  * This class contains the configuration information for the bundle
@@ -500,6 +503,15 @@ class Configuration implements ConfigurationInterface
                             ->info('Auto generate mode possible values are: "NEVER", "ALWAYS", "FILE_NOT_EXISTS", "EVAL", "FILE_NOT_EXISTS_OR_CHANGED", this option is ignored when the "enable_native_lazy_objects" option is true')
                             ->validate()
                                 ->ifTrue(function ($v) {
+                                    /** @phpstan-ignore function.alreadyNarrowedType */
+                                    if (PHP_VERSION_ID >= 80400 && method_exists(OrmConfiguration::class, 'enableNativeLazyObjects')) {
+                                        Deprecation::trigger(
+                                            'doctrine/doctrine-bundle',
+                                            'https://github.com/doctrine/DoctrineBundle/issues/2107',
+                                            'Not using native lazy objects with PHP 8.4+ and ORM 3.4+ is deprecated. In this case, the "auto_generate_proxy_classes" configuration key is deprecated as well.',
+                                        );
+                                    }
+
                                     $generationModes = $this->getAutoGenerateModes();
 
                                     if (is_int($v) && in_array($v, $generationModes['values']/*array(0, 1, 2, 3)*/)) {
@@ -536,10 +548,40 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('proxy_dir')
                             ->defaultValue('%kernel.build_dir%/doctrine/orm/Proxies')
                             ->info('Configures the path where generated proxy classes are saved when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true')
+                            ->beforeNormalization()
+                                ->ifTrue(static fn ($v): bool => true)
+                                ->then(static function ($v) {
+                                    /** @phpstan-ignore function.alreadyNarrowedType */
+                                    if (PHP_VERSION_ID >= 80400 && method_exists(OrmConfiguration::class, 'enableNativeLazyObjects')) {
+                                        Deprecation::trigger(
+                                            'doctrine/doctrine-bundle',
+                                            'https://github.com/doctrine/DoctrineBundle/issues/2107',
+                                            'Not using native lazy objects with PHP 8.4+ and ORM 3.4+ is deprecated. In this case, the "proxy_dir" configuration key is deprecated as well.',
+                                        );
+                                    }
+
+                                    return $v;
+                                })
+                            ->end()
                         ->end()
                         ->scalarNode('proxy_namespace')
                             ->defaultValue('Proxies')
                             ->info('Defines the root namespace for generated proxy classes when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true')
+                            ->beforeNormalization()
+                                ->ifTrue(static fn ($v): bool => true)
+                                ->then(static function ($v) {
+                                    /** @phpstan-ignore function.alreadyNarrowedType */
+                                    if (PHP_VERSION_ID >= 80400 && method_exists(OrmConfiguration::class, 'enableNativeLazyObjects')) {
+                                        Deprecation::trigger(
+                                            'doctrine/doctrine-bundle',
+                                            'https://github.com/doctrine/DoctrineBundle/issues/2107',
+                                            'Not using native lazy objects with PHP 8.4+ and ORM 3.4+ is deprecated. In this case, the "proxy_namespace" configuration key is deprecated as well.',
+                                        );
+                                    }
+
+                                    return $v;
+                                })
+                            ->end()
                         ->end()
                         ->arrayNode('controller_resolver')
                             ->canBeDisabled()

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -20,6 +20,7 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\MemcacheCache;
 use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\DBAL\Connection;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Logging\CacheLoggerChain;
@@ -39,11 +40,13 @@ use Doctrine\ORM\Mapping\Embeddable;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Generator;
 use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -72,8 +75,12 @@ use function method_exists;
 use function sprintf;
 use function sys_get_temp_dir;
 
+use const PHP_VERSION_ID;
+
 class DoctrineExtensionTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public function testAutowiringAlias(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {
@@ -445,18 +452,21 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals(CacheConfiguration::class, $container->getParameter('doctrine.orm.second_level_cache.cache_configuration.class'));
         $this->assertEquals(RegionsConfiguration::class, $container->getParameter('doctrine.orm.second_level_cache.regions_configuration.class'));
 
-        $config = BundleConfigurationBuilder::createBuilder()
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        $enableNativeLazyObjects = PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects');
+        $config                  = BundleConfigurationBuilder::createBuilder()
             ->addBaseConnection()
             ->addEntityManager([
-                'proxy_namespace' => 'MyProxies',
-                'auto_generate_proxy_classes' => true,
                 'default_entity_manager' => 'default',
                 'entity_managers' => [
                     'default' => [
                         'mappings' => ['XmlBundle' => []],
                     ],
                 ],
-            ])
+            ] + ($enableNativeLazyObjects ? [] : [
+                'auto_generate_proxy_classes' => true,
+                'proxy_namespace' => 'MyProxies',
+            ]))
             ->build();
 
         $container = $this->getContainer();
@@ -565,6 +575,44 @@ class DoctrineExtensionTest extends TestCase
         $this->assertTrue($calls[0][1][0]);
     }
 
+    /** @param array<string, mixed> $settings */
+    #[IgnoreDeprecations]
+    #[RequiresPhp('>=8.4')]
+    #[RequiresMethod(Configuration::class, 'enableNativeLazyObjects')]
+    #[DataProvider('proxySettingsProvider')]
+    public function testProxySettingsAreConditionallyDeprecated(array $settings): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/issues/2107');
+
+        $config = BundleConfigurationBuilder::createBuilder()
+            ->addBaseConnection()
+            ->addEntityManager([
+                'default_entity_manager' => 'default',
+                'entity_managers' => [
+                    'default' => [],
+                ],
+            ] + $settings)
+            ->build();
+
+        $extension->load([$config], $container);
+    }
+
+    /** @return Generator<string, array{array<string, mixed>}> */
+    public static function proxySettingsProvider(): Generator
+    {
+        yield 'auto_generate_proxy_classes' => [['auto_generate_proxy_classes' => true]];
+        yield 'proxy_namespace' => [['proxy_namespace' => 'MyProxies']];
+        yield 'proxy_dir' => [['proxy_dir' => sys_get_temp_dir()]];
+    }
+
+    #[IgnoreDeprecations]
     public function testAutoGenerateProxyClasses(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/tests/DependencyInjection/Fixtures/TestKernel.php
@@ -50,6 +50,8 @@ class TestKernel extends Kernel
                 'php_errors' => ['log' => true],
                 'handle_all_throwables' => true,
             ]);
+            /** @phpstan-ignore function.alreadyNarrowedType */
+            $enableNativeLazyObjects = PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects');
             $container->loadFromExtension('doctrine', [
                 'dbal' => [
                     'driver' => 'pdo_sqlite',
@@ -57,10 +59,8 @@ class TestKernel extends Kernel
                 ],
                 'orm' => [
                     'controller_resolver' => ['auto_mapping' => false],
-                    'auto_generate_proxy_classes' => true,
                     'enable_lazy_ghost_objects' => true,
-                    /** @phpstan-ignore function.alreadyNarrowedType */
-                    'enable_native_lazy_objects' => PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects'),
+                    'enable_native_lazy_objects' => $enableNativeLazyObjects,
                     'mappings' => [
                         'RepositoryServiceBundle' => [
                             'type' => 'attribute',
@@ -68,7 +68,8 @@ class TestKernel extends Kernel
                             'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Entity',
                         ],
                     ],
-                ] + (class_exists(AnnotationDriver::class) ? ['report_fields_where_declared' => true] : []),
+                ] + (class_exists(AnnotationDriver::class) ? ['report_fields_where_declared' => true] : [])
+                + ($enableNativeLazyObjects ? [] : ['auto_generate_proxy_classes' => true]),
             ]);
 
             // Register a NullLogger to avoid getting the stderr default logger of FrameworkBundle


### PR DESCRIPTION
There is no indication that they should be removed, even after enabling native lazy objects.