### PR TITLE
Address PHPUnit notices

### DIFF
--- a/tests/Command/CreateDatabaseDoctrineTest.php
+++ b/tests/Command/CreateDatabaseDoctrineTest.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\Persistence\ManagerRegistry;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
@@ -59,25 +59,23 @@ class CreateDatabaseDoctrineTest extends TestCase
      * @param mixed[]|null $params Connection parameters
      * @psalm-param Params $params
      *
-     * @return MockObject&Container
+     * @return Stub&Container
      */
-    private function getMockContainer(string $connectionName, array|null $params = null): MockObject
+    private function getMockContainer(string $connectionName, array|null $params = null): Stub
     {
         // Mock the container and everything you'll need here
         $mockDoctrine = $this->createStub(ManagerRegistry::class);
 
         $mockDoctrine->method('getDefaultConnectionName')->willReturn($connectionName);
 
-        $config = (new Configuration())->setSchemaManagerFactory($this->createMock(SchemaManagerFactory::class));
+        $config = (new Configuration())->setSchemaManagerFactory($this->createStub(SchemaManagerFactory::class));
 
         $mockConnection = $this->createStub(Connection::class);
         $mockConnection->method('getConfiguration')->willReturn($config);
         $mockConnection->method('getParams')->willReturn($params);
         $mockDoctrine->method('getConnection')->willReturn($mockConnection);
 
-        $mockContainer = $this->getMockBuilder(Container::class)
-            ->onlyMethods(['get'])
-            ->getMock();
+        $mockContainer = $this->createStub(Container::class);
 
         $mockContainer->method('get')->with('doctrine')->willReturn($mockDoctrine);
 

--- a/tests/Command/DropDatabaseDoctrineTest.php
+++ b/tests/Command/DropDatabaseDoctrineTest.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\Persistence\ManagerRegistry;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
@@ -137,9 +137,9 @@ class DropDatabaseDoctrineTest extends TestCase
      * @param list<mixed> $params Connection parameters
      * @psalm-param Params $params
      *
-     * @return MockObject&Container
+     * @return Stub&Container
      */
-    private function getMockContainer(string $connectionName, array $params): MockObject
+    private function getMockContainer(string $connectionName, array $params): Stub
     {
         // Mock the container and everything you'll need here
         $mockDoctrine = $this->createStub(ManagerRegistry::class);
@@ -148,18 +148,16 @@ class DropDatabaseDoctrineTest extends TestCase
 
         $config = (new Configuration())->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
 
-        $mockConnection = $this->createMock(Connection::class);
+        $mockConnection = $this->createStub(Connection::class);
         $mockConnection->method('getConfiguration')->willReturn($config);
         $mockConnection->method('getParams')->willReturn($params);
         $mockDoctrine->method('getConnection')->willReturn($mockConnection);
 
-        $mockContainer = $this->getMockBuilder(Container::class)
-            ->onlyMethods(['get'])
-            ->getMock();
+        $mockContainer = $this->createStub(Container::class);
 
         $mockContainer->method('get')
-            ->with('doctrine')
-            ->willReturn($mockDoctrine);
+           ->with('doctrine')
+           ->willReturn($mockDoctrine);
 
         return $mockContainer;
     }

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -35,8 +35,8 @@ class DoctrineDataCollectorTest extends TestCase
         $manager    = $this->createStub(EntityManagerInterface::class);
         $config     = $this->createMock(Configuration::class);
         $factory    = $this->createMock(ClassMetadataFactory::class);
-        $collector  = $this->createCollector(['default' => $manager], true, $this->createMock(DebugDataHolder::class));
-        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $collector  = $this->createCollector(['default' => $manager], true, $this->createStub(DebugDataHolder::class));
+        $unitOfWork = $this->createStub(UnitOfWork::class);
 
         $manager->method('getMetadataFactory')->willReturn($factory);
         $manager->method('getConfiguration')->willReturn($config);
@@ -74,8 +74,8 @@ class DoctrineDataCollectorTest extends TestCase
         }
 
         $manager    = $this->createMock(EntityManager::class);
-        $config     = $this->createMock(Configuration::class);
-        $collector  = $this->createCollector(['default' => $manager], false, $this->createMock(DebugDataHolder::class));
+        $config     = $this->createStub(Configuration::class);
+        $collector  = $this->createCollector(['default' => $manager], false, $this->createStub(DebugDataHolder::class));
         $unitOfWork = $this->createStub(UnitOfWork::class);
 
         $manager->expects($this->never())->method('getMetadataFactory');
@@ -91,7 +91,7 @@ class DoctrineDataCollectorTest extends TestCase
 
     public function testGetGroupedQueries(): void
     {
-        $debugDataHolder = $this->createMock(DebugDataHolder::class);
+        $debugDataHolder = $this->createStub(DebugDataHolder::class);
 
         $queries = [
             'default' => [

--- a/tests/Mapping/DisconnectedMetadataFactoryTest.php
+++ b/tests/Mapping/DisconnectedMetadataFactoryTest.php
@@ -30,7 +30,7 @@ class DisconnectedMetadataFactoryTest extends TestCase
         $class      = new ClassMetadata(self::class);
         $collection = new ClassMetadataCollection([$class]);
 
-        $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
+        $registry = $this->createStub(ManagerRegistry::class);
         $factory  = new DisconnectedMetadataFactory($registry);
 
         $this->expectException(RuntimeException::class);

--- a/tests/Middleware/IdleConnectionMiddlewareTest.php
+++ b/tests/Middleware/IdleConnectionMiddlewareTest.php
@@ -25,7 +25,7 @@ class IdleConnectionMiddlewareTest extends TestCase
         $middleware = new IdleConnectionMiddleware($connectionExpiries, $ttlByConnection);
         $middleware->setConnectionName('connectionone');
 
-        $driverMock    = $this->createMock(Driver::class);
+        $driverMock    = $this->createStub(Driver::class);
         $wrappedDriver = $middleware->wrap($driverMock);
 
         $this->assertInstanceOf(IdleConnectionDriver::class, $wrappedDriver);

--- a/tests/ProfilerTest.php
+++ b/tests/ProfilerTest.php
@@ -43,7 +43,7 @@ class ProfilerTest extends BaseTestCase
     public function setUp(): void
     {
         $this->debugDataHolder = new DebugDataHolder();
-        $registry              = $this->getMockBuilder(ManagerRegistry::class)->getMock();
+        $registry              = $this->createStub(ManagerRegistry::class);
         $registry->method('getConnectionNames')->willReturn([]);
         $registry->method('getManagerNames')->willReturn([]);
         $registry->method('getManagers')->willReturn([]);
@@ -53,14 +53,12 @@ class ProfilerTest extends BaseTestCase
         $twigLoaderFilesystem->addPath(__DIR__ . '/../vendor/symfony/web-profiler-bundle/Resources/views', 'WebProfiler');
         $this->twig = new Environment($twigLoaderFilesystem, ['debug' => true, 'strict_variables' => true]);
 
-        $fragmentHandler = $this->getMockBuilder(FragmentHandler::class);
-        $fragmentHandler->disableOriginalConstructor();
-        $fragmentHandler = $fragmentHandler->getMock();
+        $fragmentHandler = $this->createStub(FragmentHandler::class);
         $fragmentHandler->method('render')->willReturn('');
 
         $kernelRuntime = new HttpKernelRuntime($fragmentHandler);
 
-        $urlGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->getMock();
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
         $urlGenerator->method('generate')->willReturn('');
 
         if (class_exists(CodeExtension::class)) {

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -43,7 +43,7 @@ class RegistryTest extends TestCase
 
     public function testGetDefaultConnection(): void
     {
-        $conn      = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $conn      = $this->createStub(Connection::class);
         $container = new Container();
         $container->set('doctrine.dbal.default_connection', $conn);
 
@@ -54,7 +54,7 @@ class RegistryTest extends TestCase
 
     public function testGetConnection(): void
     {
-        $conn      = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $conn      = $this->createStub(Connection::class);
         $container = new Container();
         $container->set('doctrine.dbal.default_connection', $conn);
 
@@ -81,7 +81,7 @@ class RegistryTest extends TestCase
 
     public function testGetDefaultEntityManager(): void
     {
-        $em        = $this->createMock(ObjectManager::class);
+        $em        = $this->createStub(ObjectManager::class);
         $container = new Container();
         $container->set('doctrine.orm.default_entity_manager', $em);
 
@@ -92,7 +92,7 @@ class RegistryTest extends TestCase
 
     public function testGetEntityManager(): void
     {
-        $em        = $this->createMock(ObjectManager::class);
+        $em        = $this->createStub(ObjectManager::class);
         $container = new Container();
         $container->set('doctrine.orm.default_entity_manager', $em);
 

--- a/tests/Repository/ServiceEntityRepositoryTest.php
+++ b/tests/Repository/ServiceEntityRepositoryTest.php
@@ -31,7 +31,7 @@ class ServiceEntityRepositoryTest extends TestCase
 
     public function testConstructorThrowsExceptionWhenNoManagerFound(): void
     {
-        $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
+        $registry = $this->createStub(ManagerRegistry::class);
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(<<<'EXCEPTION'
 Could not find the entity manager for class "Doctrine\Bundle\DoctrineBundle\Tests\Repository\TestEntity". Check your Doctrine configuration to make sure it is configured to load this entity’s metadata.
@@ -46,7 +46,7 @@ EXCEPTION);
     #[RequiresPhp('>= 8.4')]
     public function testConstructInitializesWhenImplementingLazyObjectInterface(): void
     {
-        $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
+        $registry = $this->createStub(ManagerRegistry::class);
         $this->expectException(LogicException::class);
 
         /* @phpstan-ignore class.notFound, expr.resultUnused */


### PR DESCRIPTION
They were all about using stubs rather than mocks when not adding any expectations.