### PR TITLE
Update validate_xml_mapping info

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -714,7 +714,7 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The setting "report_fields_where_declared" cannot be disabled for ORM 3.')
                         ->end()
                     ->end()
-                    ->booleanNode('validate_xml_mapping')->defaultFalse()->info('Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728.')->end()
+                    ->booleanNode('validate_xml_mapping')->defaultFalse()->info('Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728.')->end()
                 ->end()
                 ->children()
                     ->arrayNode('second_level_cache')


### PR DESCRIPTION
The mentioned validation did not become mandatory in ORM 3.0, you can still opt out.