### PR TITLE
Deprecate controller resolver auto mapping option

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -4,6 +4,10 @@ UPGRADE FROM 3.0 to 3.1
 Configuration
 -------------
 
+The `doctrine.orm.controller_resolver.auto_mapping` only accepts `false`
+as value since 3.0 and supplying the value explicitly is now marked as
+deprecated.
+
 The `doctrine.orm.entity_managers.some_em.enable_native_lazy_objects`
 configuration option is deprecated and will be removed in DoctrineBundle 4.0,
 as native lazy objects are now always enabled.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -425,6 +425,11 @@ final class Configuration implements ConfigurationInterface
                                         ->ifTrue(static fn ($v) => $v !== false)
                                         ->thenInvalid('The setting "controller_resolver.auto_mapping" can no longer be enabled and must be set to false')
                                     ->end()
+                                    ->setDeprecated(
+                                        'doctrine/doctrine-bundle',
+                                        '3.1',
+                                        'The "%node%" option is deprecated and will be removed in DoctrineBundle 4.0, as it only accepts `false` since 3.0.',
+                                    )
                                     ->info('Set to true to enable using route placeholders as lookup criteria when the primary key doesn\'t match the argument name')
                                 ->end()
                                 ->booleanNode('evict_cache')


### PR DESCRIPTION
Not much more context needed than in the title, see https://github.com/doctrine/DoctrineBundle/issues/1926 & https://github.com/doctrine/DoctrineBundle/pull/1924.