### PR TITLE
Fix attribute driver mapping pass compatibility with ORM 3

### DIFF
--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -180,6 +180,8 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
     public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [], bool $reportFieldsWhereDeclared = false)
     {
         $driverArgs = [$directories];
+
+        // Add additional args for ORM <3.0
         if (method_exists(AttributeDriver::class, 'getReader')) {
             $driverArgs[] = $reportFieldsWhereDeclared;
         }

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -16,6 +16,8 @@ use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPas
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
+use function method_exists;
+
 /**
  * Class for Symfony bundles to configure mappings for model classes not in the
  * auto-mapped folder.
@@ -177,7 +179,12 @@ class DoctrineOrmMappingsPass extends RegisterMappingsPass
      */
     public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [], bool $reportFieldsWhereDeclared = false)
     {
-        $driver = new Definition(AttributeDriver::class, [$directories, $reportFieldsWhereDeclared]);
+        $driverArgs = [$directories];
+        if (method_exists(AttributeDriver::class, 'getReader')) {
+            $driverArgs[] = $reportFieldsWhereDeclared;
+        }
+
+        $driver = new Definition(AttributeDriver::class, $driverArgs);
 
         return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }

--- a/tests/DependencyInjection/Compiler/DoctrineOrmMappingsPassTest.php
+++ b/tests/DependencyInjection/Compiler/DoctrineOrmMappingsPassTest.php
@@ -7,12 +7,14 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCase;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 use function assert;
+use function interface_exists;
 use function realpath;
 
 class DoctrineOrmMappingsPassTest extends TestCase
@@ -40,6 +42,10 @@ class DoctrineOrmMappingsPassTest extends TestCase
 
     public function testAttributeDriverIsRegistered(): void
     {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
         $driverNamespace = 'DoctrineBundle\Entity';
         $container       = $this->createXmlBundleTestContainer(
             static function (ContainerBuilder $containerBuilder) use ($driverNamespace): void {

--- a/tests/DependencyInjection/Compiler/DoctrineOrmMappingsPassTest.php
+++ b/tests/DependencyInjection/Compiler/DoctrineOrmMappingsPassTest.php
@@ -7,7 +7,13 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\Tests\TestCase;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+use function assert;
+use function realpath;
 
 class DoctrineOrmMappingsPassTest extends TestCase
 {
@@ -30,5 +36,25 @@ class DoctrineOrmMappingsPassTest extends TestCase
             ['App\\Entity'],
             ['/path/to/entities'],
         );
+    }
+
+    public function testAttributeDriverIsRegistered(): void
+    {
+        $driverNamespace = 'DoctrineBundle\Entity';
+        $container       = $this->createXmlBundleTestContainer(
+            static function (ContainerBuilder $containerBuilder) use ($driverNamespace): void {
+                $containerBuilder->addCompilerPass(DoctrineOrmMappingsPass::createAttributeMappingDriver(
+                    [$driverNamespace],
+                    [realpath(__DIR__ . '/Entity')],
+                    reportFieldsWhereDeclared: true,
+                ));
+            },
+        );
+
+        $metadataDriver = $container->get('doctrine.orm.default_metadata_driver');
+        assert($metadataDriver instanceof MappingDriverChain);
+
+        $driver = $metadataDriver->getDrivers()[$driverNamespace];
+        $this->assertTrue($driver instanceof AttributeDriver);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,7 +22,7 @@ use function uniqid;
 
 class TestCase extends BaseTestCase
 {
-    public function createXmlBundleTestContainer(): ContainerBuilder
+    public function createXmlBundleTestContainer(callable|null $func = null): ContainerBuilder
     {
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.debug' => false,
@@ -90,6 +90,11 @@ class TestCase extends BaseTestCase
         $compilerPassConfig->addPass(new CacheCompatibilityPass());
         // make all Doctrine services public, so we can fetch them in the test
         $compilerPassConfig->addPass(new TestCaseAllPublicCompilerPass());
+
+        if ($func !== null) {
+            $func($container);
+        }
+
         $container->compile();
 
         return $container;


### PR DESCRIPTION
I'm not completely happy with my method of detecting ORM v2 (it uses the presence of a removed method in v3), but it works. Fixes #1844.