### PR TITLE
Fix escapeFunction throwing exception if float returned

### DIFF
--- a/src/Twig/DoctrineExtension.php
+++ b/src/Twig/DoctrineExtension.php
@@ -57,7 +57,7 @@ class DoctrineExtension extends AbstractExtension
      *
      * @internal
      */
-    public static function escapeFunction(mixed $parameter): string|int
+    public static function escapeFunction(mixed $parameter): string|int|float
     {
         $result = $parameter;
 

--- a/tests/Twig/DoctrineExtensionTest.php
+++ b/tests/Twig/DoctrineExtensionTest.php
@@ -113,6 +113,11 @@ class DoctrineExtensionTest extends TestCase
     {
         $this->assertEquals('1', DoctrineExtension::escapeFunction(true));
     }
+
+    public function testNoEscapeFloatParameter(): void
+    {
+        $this->assertEquals(1.1, DoctrineExtension::escapeFunction(1.1));
+    }
 }
 
 class DummyClass


### PR DESCRIPTION
`DoctrineExtension::escapeFunction`  throws exception if float is returned

```
{
    "error": {
        "title": "Ошибка сервера",
        "status": 500,
        "errorCode": null,
        "detail": "An exception has been thrown during the rendering of a template (\"Doctrine\\Bundle\\DoctrineBundle\\Twig\\DoctrineExtension::escapeFunction(): Return value must be of type string|int, float returned\") in \"@Doctrine\/Collector\/db.html.twig\" at line 265."
    },
    "meta": {
        "file": "\/var\/www\/vendor\/doctrine\/doctrine-bundle\/templates\/Collector\/db.html.twig",
        "line": 265,
        "trace": "#0 \/var\/www\/var\/cache\/local\/twig\/a5\/a570303d6d14690a00b0367b85abf85f.php(319): Twig\\Template->yieldBlock()\n#1 \/var\/www\/vendor\/twig\/twig\/src\/Template.php(446): __TwigTemplate_ed7730bcbc01e4a03d2a62f70335dcf5->block_panel()\n#2 \/var\/www\/var\/cache\/local\/twig\/6b\/6b6b8bd8ac42f71f951179919cda7e80.php(110): Twig\\Template->yieldBlock()\n#3 \/var\/www\/vendor\/twig\/twig\/src\/Template.php(446): __TwigTemplate_4b5c3d116bbd5225f54217bf1f595ad6->block_body()\n#4 \/var\/www\/var\/cache\/local\/twig\/39\/394fcd57f85f22050131dc40810628e1.php(116): Twig\\Template->yieldBlock()\n#5 \/var\/www\/vendor\/twig\/twig\/src\/Template.php(402): __TwigTemplate_dd764fd292e5141d17108e49edb78b98->doDisplay()\n#6 \/var\/www\/var\/cache\/local\/twig\/6b\/6b6b8bd8ac42f71f951179919cda7e80.php(57): Twig\\Template->yield()\n#7 \/var\/www\/vendor\/twig\/twig\/src\/Template.php(402): __TwigTemplate_4b5c3d116bbd5225f54217bf1f595ad6->doDisplay()\n#8 \/var\/www\/var\/cache\/local\/twig\/a5\/a570303d6d14690a00b0367b85abf85f.php(58): Twig\\Template->yield()\n#9 \/var\/www\/vendor\/twig\/twig\/src\/Template.php(402): __TwigTemplate_ed7730bcbc01e4a03d2a62f70335dcf5->doDisplay()\n#10 \/var\/www\/vendor\/twig\/twig\/src\/Template.php(358): Twig\\Template->yield()\n#11 \/var\/www\/vendor\/twig\/twig\/src\/Template.php(373): Twig\\Template->display()\n#12 \/var\/www\/vendor\/twig\/twig\/src\/TemplateWrapper.php(51): Twig\\Template->render()\n#13 \/var\/www\/vendor\/twig\/twig\/src\/Environment.php(333): Twig\\TemplateWrapper->render()\n#14 \/var\/www\/vendor\/symfony\/web-profiler-bundle\/Controller\/ProfilerController.php(428): Twig\\Environment->render()\n#15 \/var\/www\/vendor\/symfony\/web-profiler-bundle\/Controller\/ProfilerController.php(105): Symfony\\Bundle\\WebProfilerBundle\\Controller\\ProfilerController->renderWithCspNonces()\n#16 \/var\/www\/vendor\/symfony\/http-kernel\/HttpKernel.php(183): Symfony\\Bundle\\WebProfilerBundle\\Controller\\ProfilerController->panelAction()\n#17 \/var\/www\/vendor\/symfony\/http-kernel\/HttpKernel.php(76): Symfony\\Component\\HttpKernel\\HttpKernel->handleRaw()\n#18 \/var\/www\/vendor\/symfony\/http-kernel\/Kernel.php(182): Symfony\\Component\\HttpKernel\\HttpKernel->handle()\n#19 \/var\/www\/vendor\/symfony\/runtime\/Runner\/Symfony\/HttpKernelRunner.php(35): Symfony\\Component\\HttpKernel\\Kernel->handle()\n#20 \/var\/www\/vendor\/autoload_runtime.php(29): Symfony\\Component\\Runtime\\Runner\\Symfony\\HttpKernelRunner->run()\n#21 \/var\/www\/public\/index.php(7): require_once('...')\n#22 {main}"
    }
}
```