### PR TITLE
chore: show parameters in name of CI jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,4 @@
-
-name: "Continuous Integration"
+name: "CI: PHPUnit"
 
 on:
   pull_request:
@@ -27,7 +26,15 @@ on:
 
 jobs:
   phpunit:
-    name: "PHPUnit"
+    name: >
+      ${{ format('PHP {0} - Sf {1} - deps {2} - stab. {3}',
+        matrix.php-version || 'Ø',
+        matrix.symfony-require || 'Ø',
+        matrix.dependencies || 'Ø',
+        matrix.stability || 'Ø'
+      ) }}
+      ${{ matrix.remove-orm && ' - remove ORM' }}
+      ${{ matrix.remove-doctrine-messenger && ' - remove Messenger' }}
     runs-on: "ubuntu-latest"
     env:
       SYMFONY_REQUIRE: ${{matrix.symfony-require}}


### PR DESCRIPTION
Extracted from:

- GH-2140

The goal is to make the list more readable, before this PR it looked like this:

> <img width="711" height="298" alt="image" src="https://github.com/user-attachments/assets/f5a98ed0-11fb-42e9-9926-e09d0a111df5" />

It display from 3 to 5 parameters, the first one can be the Symfony version or the PHP version, which is not easy to read.

With this PR, it looks like this:

> <img width="711" height="299" alt="image" src="https://github.com/user-attachments/assets/a0ce156b-98b9-410b-a644-ed22aecc253f" />
