### PR TITLE
feat: add explicit null check in XMLSchemaTest (PHPStan Level 8)

### DIFF
--- a/tests/DependencyInjection/XMLSchemaTest.php
+++ b/tests/DependencyInjection/XMLSchemaTest.php
@@ -41,7 +41,7 @@ class XMLSchemaTest extends TestCase
 
         $dbalElements = $dom->getElementsByTagNameNS($xmlns, 'dbal');
         if ($dbalElements->length) {
-            $dbalDom    = new DOMDocument('1.0', 'UTF-8');
+            $dbalDom     = new DOMDocument('1.0', 'UTF-8');
             $dbalElement = $dbalElements->item(0);
             if ($dbalElement !== null) {
                 $dbalNode   = $dbalDom->importNode($dbalElement);

--- a/tests/DependencyInjection/XMLSchemaTest.php
+++ b/tests/DependencyInjection/XMLSchemaTest.php
@@ -42,27 +42,33 @@ class XMLSchemaTest extends TestCase
         $dbalElements = $dom->getElementsByTagNameNS($xmlns, 'dbal');
         if ($dbalElements->length) {
             $dbalDom    = new DOMDocument('1.0', 'UTF-8');
-            $dbalNode   = $dbalDom->importNode($dbalElements->item(0));
-            $configNode = $dbalDom->createElementNS($xmlns, 'config');
-            $configNode->appendChild($dbalNode);
-            $dbalDom->appendChild($configNode);
+            $dbalElement = $dbalElements->item(0);
+            if ($dbalElement !== null) {
+                $dbalNode   = $dbalDom->importNode($dbalElement);
+                $configNode = $dbalDom->createElementNS($xmlns, 'config');
+                $configNode->appendChild($dbalNode);
+                $dbalDom->appendChild($configNode);
 
-            $ret = $dbalDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
-            $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
-            $found = true;
+                $ret = $dbalDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
+                $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
+                $found = true;
+            }
         }
 
         $ormElements = $dom->getElementsByTagNameNS($xmlns, 'orm');
         if ($ormElements->length) {
             $ormDom     = new DOMDocument('1.0', 'UTF-8');
-            $ormNode    = $ormDom->importNode($ormElements->item(0));
-            $configNode = $ormDom->createElementNS($xmlns, 'config');
-            $configNode->appendChild($ormNode);
-            $ormDom->appendChild($configNode);
+            $ormElement = $ormElements->item(0);
+            if ($ormElement !== null) {
+                $ormNode    = $ormDom->importNode($ormElement);
+                $configNode = $ormDom->createElementNS($xmlns, 'config');
+                $configNode->appendChild($ormNode);
+                $ormDom->appendChild($configNode);
 
-            $ret = $ormDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
-            $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
-            $found = true;
+                $ret = $ormDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
+                $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
+                $found = true;
+            }
         }
 
         $this->assertTrue($found, 'Neither <doctrine:orm> nor <doctrine:dbal> elements found in given XML. Are namespaces configured correctly?');


### PR DESCRIPTION
Improves the robustness of the `testValidateSchema` method in `XMLSchemaTest.php` by adding null checks before importing XML nodes. This prevents potential errors when the expected XML elements are not present.

Test robustness improvements:

* Added checks to ensure that `dbal` and `orm` elements are not null before attempting to import them with `importNode`, preventing possible exceptions if these elements are missing. 

```
 vendor/bin/phpstan analyze --level=8 tests/DependencyInjection/XMLSchemaTest.php
 ------ ------------------------------------------------------------------------------------------------ 
  Line   tests/DependencyInjection/XMLSchemaTest.php                                                     
 ------ ------------------------------------------------------------------------------------------------ 
  :45    Parameter #1 $node of method DOMDocument::importNode() expects DOMNode, DOMElement|null given.  
         🪪  argument.type                                                                               
  :58    Parameter #1 $node of method DOMDocument::importNode() expects DOMNode, DOMElement|null given.  
         🪪  argument.type                                                                               
 ------ ------------------------------------------------------------------------------------------------ 

```