### PR TITLE
feat(test): correct type hint for connection parameters in DropDatabaseDoctrineTest (PHPStan Level 8)

### DIFF
--- a/tests/Command/DropDatabaseDoctrineTest.php
+++ b/tests/Command/DropDatabaseDoctrineTest.php
@@ -134,7 +134,7 @@ class DropDatabaseDoctrineTest extends TestCase
     }
 
     /**
-     * @param list<mixed> $params Connection parameters
+     * @param array{url?: string, path?: string, driver: string} $params Connection parameters
      * @psalm-param Params $params
      *
      * @return Stub&Container


### PR DESCRIPTION
Updates the type annotation for the `$params` parameter in the `provideIncompatibleDriverOptions` method to be more precise, specifying the expected keys and their types. This helps improve static analysis and code clarity.

- **Type annotation improvement:**
  * Refined the `$params` parameter type in the `provideIncompatibleDriverOptions` method to `array{url?: string, path?: string, driver: string}` for better static analysis and documentation. (`tests/Command/DropDatabaseDoctrineTest.php`)
  
  Resolve errors:
  

```bash
$ vendor/bin/phpstan analyze --level=8 tests/Command/DropDatabaseDoctrineTest.php
  Line   tests/Command/DropDatabaseDoctrineTest.php                                                                                                                                                                  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  :42    Parameter #2 $params of method Doctrine\Bundle\DoctrineBundle\Tests\Command\DropDatabaseDoctrineTest::getMockContainer() expects list<mixed>, array{url: non-falsy-string, path: non-falsy-string, driver:  
         'pdo_sqlite'} given.                                                                                                                                                                                        
         🪪  argument.type                                                                                                                                                                                           
         💡 array{url: non-falsy-string, path: non-falsy-string, driver: 'pdo_sqlite'} is not a list.                                                                                                                
  :82    Parameter #2 $params of method Doctrine\Bundle\DoctrineBundle\Tests\Command\DropDatabaseDoctrineTest::getMockContainer() expects list<mixed>, array{path: non-falsy-string, driver: 'pdo_sqlite'} given.    
         🪪  argument.type                                                                                                                                                                                           
         💡 array{path: non-falsy-string, driver: 'pdo_sqlite'} is not a list.  
```
