### PR TITLE
feat: rise phpstan level 8 and resolve errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,10 @@
     "require-dev": {
         "doctrine/coding-standard": "^14",
         "doctrine/orm": "^3.4.4",
-        "phpstan/phpstan": "2.1.1",
+        "phpstan/phpstan": "2.1.13",
         "phpstan/phpstan-phpunit": "2.0.3",
         "phpstan/phpstan-strict-rules": "^2",
-        "phpstan/phpstan-symfony": "^2.0",
+        "phpstan/phpstan-symfony": "2.0.9",
         "phpunit/phpunit": "^12.3.10",
         "psr/log": "^3.0",
         "symfony/doctrine-messenger": "^6.4 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,10 @@
     "require-dev": {
         "doctrine/coding-standard": "^14",
         "doctrine/orm": "^3.4.4",
-        "phpstan/phpstan": "2.1.13",
+        "phpstan/phpstan": "^2.1.13",
         "phpstan/phpstan-phpunit": "2.0.3",
         "phpstan/phpstan-strict-rules": "^2",
-        "phpstan/phpstan-symfony": "2.0.9",
+        "phpstan/phpstan-symfony": "^2.0.9",
         "phpunit/phpunit": "^12.3.10",
         "psr/log": "^3.0",
         "symfony/doctrine-messenger": "^6.4 || ^7.0 || ^8.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
 parameters:
-   level: 7
+   level: 8
    reportUnmatchedIgnoredErrors: true
    paths:
       - config

--- a/src/Controller/ProfilerController.php
+++ b/src/Controller/ProfilerController.php
@@ -40,7 +40,11 @@ class ProfilerController
     {
         $this->profiler->disable();
 
-        $profile   = $this->profiler->loadProfile($token);
+        $profile = $this->profiler->loadProfile($token);
+        if ($profile === null) {
+            return new Response('Profile not found.', 404);
+        }
+
         $collector = $profile->getCollector('db');
 
         assert($collector instanceof DoctrineDataCollector);

--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -55,7 +55,7 @@ use function usort;
  *    types: ?array<array-key, Type|int|string|null>,
  *    count: int,
  *    index: int,
- *    executionPercent?: float
+ *    executionPercent: float
  * }
  * @phpstan-type GroupedQueriesType = array<string, array<int, GroupedQueryItemType>>
  * @phpstan-property DataType $data
@@ -308,14 +308,13 @@ class DoctrineDataCollector extends BaseCollector
 
                 return $a['executionMS'] < $b['executionMS'] ? 1 : -1;
             });
-            $this->groupedQueries[$connection] = $connectionGroupedQueries;
-        }
 
-        foreach ($this->groupedQueries as $connection => $queries) {
-            foreach ($queries as $i => $query) {
-                $this->groupedQueries[$connection][$i]['executionPercent'] =
+            foreach ($connectionGroupedQueries as $i => $query) {
+                $connectionGroupedQueries[$i]['executionPercent'] =
                     $this->executionTimePercentage($query['executionMS'], $totalExecutionMS);
             }
+
+            $this->groupedQueries[$connection] = $connectionGroupedQueries;
         }
 
         return $this->groupedQueries;

--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -55,7 +55,7 @@ use function usort;
  *    types: ?array<array-key, Type|int|string|null>,
  *    count: int,
  *    index: int,
- *    executionPercent: float
+ *    executionPercent?: float
  * }
  * @phpstan-type GroupedQueriesType = array<string, array<int, GroupedQueryItemType>>
  * @phpstan-property DataType $data
@@ -66,10 +66,7 @@ class DoctrineDataCollector extends BaseCollector
 
     private int|null $managedEntityCount = null;
 
-    /**
-     * @var mixed[][]|null
-     * @phpstan-var ?GroupedQueriesType
-     */
+    /** @var GroupedQueriesType|null */
     private array|null $groupedQueries = null;
 
     public function __construct(
@@ -308,16 +305,17 @@ class DoctrineDataCollector extends BaseCollector
 
                 return $a['executionMS'] < $b['executionMS'] ? 1 : -1;
             });
-
-            foreach ($connectionGroupedQueries as $i => $query) {
-                $connectionGroupedQueries[$i]['executionPercent'] =
-                    $this->executionTimePercentage($query['executionMS'], $totalExecutionMS);
-            }
-
             $this->groupedQueries[$connection] = $connectionGroupedQueries;
         }
 
-        return $this->groupedQueries;
+        foreach ($this->groupedQueries as $connection => $queries) {
+            foreach ($queries as $i => $query) {
+                $this->groupedQueries[$connection][$i]['executionPercent'] = // @phpstan-ignore-line
+                    $this->executionTimePercentage($query['executionMS'], $totalExecutionMS);
+            }
+        }
+
+        return $this->groupedQueries; // @phpstan-ignore-line
     }
 
     private function executionTimePercentage(float $executionTimeMS, float $totalExecutionTimeMS): float

--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -77,6 +77,10 @@ class DoctrineDataCollector extends BaseCollector
         private readonly bool $shouldValidateSchema = true,
         DebugDataHolder|null $debugDataHolder = null,
     ) {
+        if ($debugDataHolder === null) {
+            $debugDataHolder = new DebugDataHolder();
+        }
+
         parent::__construct($registry, $debugDataHolder);
     }
 

--- a/src/DataCollector/DoctrineDataCollector.php
+++ b/src/DataCollector/DoctrineDataCollector.php
@@ -308,14 +308,13 @@ class DoctrineDataCollector extends BaseCollector
             $this->groupedQueries[$connection] = $connectionGroupedQueries;
         }
 
-        foreach ($this->groupedQueries as $connection => $queries) {
-            foreach ($queries as $i => $query) {
-                $this->groupedQueries[$connection][$i]['executionPercent'] = // @phpstan-ignore-line
-                    $this->executionTimePercentage($query['executionMS'], $totalExecutionMS);
+        foreach ($this->groupedQueries as &$queries) {
+            foreach ($queries as &$query) {
+                $query['executionPercent'] = $this->executionTimePercentage($query['executionMS'], $totalExecutionMS);
             }
         }
 
-        return $this->groupedQueries; // @phpstan-ignore-line
+        return $this->groupedQueries;
     }
 
     private function executionTimePercentage(float $executionTimeMS, float $totalExecutionTimeMS): float

--- a/src/DependencyInjection/Compiler/MiddlewaresPass.php
+++ b/src/DependencyInjection/Compiler/MiddlewaresPass.php
@@ -64,7 +64,8 @@ final class MiddlewaresPass implements CompilerPassInterface
                 );
                 $middlewareRefs[$id] = [new Reference($childId), ++$i];
 
-                if (! is_subclass_of($abstractDef->getClass(), ConnectionNameAwareInterface::class)) {
+                $class = $abstractDef->getClass();
+                if ($class === null || ! is_subclass_of($class, ConnectionNameAwareInterface::class)) {
                     continue;
                 }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -67,7 +67,6 @@ final class Configuration implements ConfigurationInterface
         // Key that should not be rewritten to the connection config
         $excludedKeys = ['default_connection' => true, 'driver_schemes' => true, 'driver_scheme' => true, 'types' => true, 'type' => true];
 
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $node
             ->children()
             ->arrayNode('dbal')
@@ -167,7 +166,6 @@ final class Configuration implements ConfigurationInterface
 
         $this->configureDbalDriverNode($connectionNode);
 
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $connectionNode
             ->fixXmlConfig('option')
             ->fixXmlConfig('mapping_type')
@@ -214,7 +212,6 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('result_cache')->end()
             ->end();
 
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $replicaNode = $connectionNode
             ->children()
                 ->arrayNode('replicas')
@@ -232,7 +229,6 @@ final class Configuration implements ConfigurationInterface
      */
     private function configureDbalDriverNode(ArrayNodeDefinition $node): void
     {
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $node
             ->validate()
             ->always(static function (array $values) {
@@ -370,7 +366,6 @@ final class Configuration implements ConfigurationInterface
             'controller_resolver' => true,
         ];
 
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $node
             ->children()
                 ->arrayNode('orm')
@@ -518,7 +513,6 @@ final class Configuration implements ConfigurationInterface
             return ['entities' => $entities];
         };
 
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $node
             ->beforeNormalization()
                 // Yaml normalization
@@ -564,7 +558,6 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('entity_managers');
         $node        = $treeBuilder->getRootNode();
 
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $node
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
@@ -739,7 +732,6 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder($name);
         $node        = $treeBuilder->getRootNode();
 
-        /** @phpstan-ignore class.notFound (Phpstan Symfony extension does not know yet how to deal with these) */
         $node
             ->beforeNormalization()
                 ->ifString()

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -171,9 +171,11 @@ final class DoctrineExtension extends Extension
                     throw new InvalidArgumentException(sprintf('Bundle "%s" does not exist or it is not enabled.', $mappingName));
                 }
 
-                $mappingConfig = $this->getMappingDriverBundleConfigDefaults($mappingConfig, $bundle, $container, $bundleMetadata['path']);
-                if (! $mappingConfig) {
-                    continue;
+                if ($bundleMetadata !== null) {
+                    $mappingConfig = $this->getMappingDriverBundleConfigDefaults($mappingConfig, $bundle, $container, $bundleMetadata['path']);
+                    if (! $mappingConfig) {
+                        continue;
+                    }
                 }
             } elseif (! $mappingConfig['type']) {
                 $mappingConfig['type'] = 'attribute';

--- a/src/DoctrineBundle.php
+++ b/src/DoctrineBundle.php
@@ -78,6 +78,10 @@ class DoctrineBundle extends Bundle
 
     public function shutdown(): void
     {
+        if ($this->container === null) {
+            return;
+        }
+
         // Clear all entity managers to clear references to entities for GC
         if ($this->container->hasParameter('doctrine.entity_managers')) {
             foreach ($this->container->getParameter('doctrine.entity_managers') as $id) {

--- a/src/Twig/DoctrineExtension.php
+++ b/src/Twig/DoctrineExtension.php
@@ -116,7 +116,7 @@ class DoctrineExtension extends AbstractExtension
 
         $i = 0;
 
-        return preg_replace_callback(
+        return (string) preg_replace_callback(
             '/(?<!\?)\?(?!\?)|(?<!:)(:[a-z0-9_]+)/i',
             static function (array $matches) use ($parameters, &$i): string {
                 $key = substr($matches[0], 1);

--- a/src/Twig/DoctrineExtension.php
+++ b/src/Twig/DoctrineExtension.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\DoctrineBundle\Twig;
 use Doctrine\SqlFormatter\HtmlHighlighter;
 use Doctrine\SqlFormatter\NullHighlighter;
 use Doctrine\SqlFormatter\SqlFormatter;
+use RuntimeException;
 use Stringable;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Twig\Extension\AbstractExtension;
@@ -24,10 +25,14 @@ use function implode;
 use function is_array;
 use function is_bool;
 use function is_string;
+use function preg_last_error;
 use function preg_match;
 use function preg_replace_callback;
+use function sprintf;
 use function strtoupper;
 use function substr;
+
+use const PREG_NO_ERROR;
 
 /**
  * This class contains the needed functions in order to do the query highlighting
@@ -116,7 +121,7 @@ class DoctrineExtension extends AbstractExtension
 
         $i = 0;
 
-        return (string) preg_replace_callback(
+        $result = preg_replace_callback(
             '/(?<!\?)\?(?!\?)|(?<!:)(:[a-z0-9_]+)/i',
             static function (array $matches) use ($parameters, &$i): string {
                 $key = substr($matches[0], 1);
@@ -133,6 +138,17 @@ class DoctrineExtension extends AbstractExtension
             },
             $query,
         );
+
+        $pregError = preg_last_error();
+        if ($pregError !== PREG_NO_ERROR) {
+            throw new RuntimeException(sprintf('Failed to replace query parameters: PCRE error %d', $pregError));
+        }
+
+        if ($result === null) {
+            throw new RuntimeException('Failed to replace query parameters: unexpected null result');
+        }
+
+        return $result;
     }
 
     public function prettifySql(string $sql): string

--- a/tests/Command/DropDatabaseDoctrineTest.php
+++ b/tests/Command/DropDatabaseDoctrineTest.php
@@ -134,7 +134,7 @@ class DropDatabaseDoctrineTest extends TestCase
     }
 
     /**
-     * @param list<mixed> $params Connection parameters
+     * @param array{url?: string, path?: string, driver: string} $params Connection parameters
      * @psalm-param Params $params
      *
      * @return Stub&Container

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DataCollector;
 
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -20,6 +21,21 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 use function interface_exists;
+
+/**
+ * @phpstan-type GroupedQueryItemType = array{
+ *    executionMS: float,
+ *    explainable: bool,
+ *    sql: string,
+ *    params: ?array<array-key, mixed>,
+ *    runnable: bool,
+ *    types: ?array<array-key, Type|int|string|null>,
+ *    count: int,
+ *    index: int,
+ *    executionPercent?: float
+ * }
+ * @phpstan-type GroupedQueriesType = array<string, array<int, GroupedQueryItemType>>
+ */
 
 class DoctrineDataCollectorTest extends TestCase
 {
@@ -137,6 +153,47 @@ class DoctrineDataCollectorTest extends TestCase
         $this->assertCount(2, $groupedQueries['default']);
         $this->assertSame('SELECT * FROM bar', $groupedQueries['default'][1]['sql']);
         $this->assertSame(1, $groupedQueries['default'][1]['count']);
+    }
+
+    public function testGetGroupedQueriesExecutionPercent(): void
+    {
+        $debugDataHolder = $this->createStub(DebugDataHolder::class);
+
+        $queries = [
+            'default' => [
+                [
+                    'sql' => 'SELECT * FROM foo',
+                    'params' => [],
+                    'types' => null,
+                    'executionMS' => 100.0,
+                ],
+                [
+                    'sql' => 'SELECT * FROM bar',
+                    'params' => [],
+                    'types' => null,
+                    'executionMS' => 200.0,
+                ],
+            ],
+        ];
+
+        $debugDataHolder->method('getData')
+            ->willReturnCallback(static function () use (&$queries) {
+                return $queries;
+            });
+
+        $collector = $this->createCollector([], true, $debugDataHolder);
+        $collector->collect(new Request(), new Response());
+
+        $groupedQueries = $collector->getGroupedQueries();
+
+        $this->assertCount(2, $groupedQueries['default']);
+
+        $firstItem = $groupedQueries['default'][0];
+        $this->assertEqualsWithDelta(66.667, $firstItem['executionPercent'], 0.001); // @phpstan-ignore-line
+        $this->assertSame('SELECT * FROM bar', $firstItem['sql']);
+        $secondItem = $groupedQueries['default'][1];
+        $this->assertEqualsWithDelta(33.333, $secondItem['executionPercent'], 0.001); // @phpstan-ignore-line
+        $this->assertSame('SELECT * FROM foo', $secondItem['sql']);
     }
 
     /**

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -189,10 +189,10 @@ class DoctrineDataCollectorTest extends TestCase
         $this->assertCount(2, $groupedQueries['default']);
 
         $firstItem = $groupedQueries['default'][0];
-        $this->assertEqualsWithDelta(66.667, $firstItem['executionPercent'], 0.001); // @phpstan-ignore-line
+        $this->assertEqualsWithDelta(66.667, $firstItem['executionPercent'] ?? null, 0.001);
         $this->assertSame('SELECT * FROM bar', $firstItem['sql']);
         $secondItem = $groupedQueries['default'][1];
-        $this->assertEqualsWithDelta(33.333, $secondItem['executionPercent'], 0.001); // @phpstan-ignore-line
+        $this->assertEqualsWithDelta(33.333, $secondItem['executionPercent'] ?? null, 0.001);
         $this->assertSame('SELECT * FROM foo', $secondItem['sql']);
     }
 

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -146,9 +146,11 @@ class DoctrineDataCollectorTest extends TestCase
      */
     private function createEntityMetadata(string $entityFQCN): ClassMetadata
     {
-        $metadata            = new ClassMetadata($entityFQCN);
-        $metadata->name      = $entityFQCN;
-        $metadata->reflClass = new ReflectionClass('stdClass');
+        $metadata       = new ClassMetadata($entityFQCN);
+        $metadata->name = $entityFQCN;
+        /** @var ReflectionClass<object> $stdClassReflection */
+        $stdClassReflection  = new ReflectionClass('stdClass');
+        $metadata->reflClass = $stdClassReflection;
 
         return $metadata;
     }

--- a/tests/DependencyInjection/XMLSchemaTest.php
+++ b/tests/DependencyInjection/XMLSchemaTest.php
@@ -41,28 +41,34 @@ class XMLSchemaTest extends TestCase
 
         $dbalElements = $dom->getElementsByTagNameNS($xmlns, 'dbal');
         if ($dbalElements->length) {
-            $dbalDom    = new DOMDocument('1.0', 'UTF-8');
-            $dbalNode   = $dbalDom->importNode($dbalElements->item(0));
-            $configNode = $dbalDom->createElementNS($xmlns, 'config');
-            $configNode->appendChild($dbalNode);
-            $dbalDom->appendChild($configNode);
+            $dbalDom     = new DOMDocument('1.0', 'UTF-8');
+            $dbalElement = $dbalElements->item(0);
+            if ($dbalElement !== null) {
+                $dbalNode   = $dbalDom->importNode($dbalElement);
+                $configNode = $dbalDom->createElementNS($xmlns, 'config');
+                $configNode->appendChild($dbalNode);
+                $dbalDom->appendChild($configNode);
 
-            $ret = $dbalDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
-            $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
-            $found = true;
+                $ret = $dbalDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
+                $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
+                $found = true;
+            }
         }
 
         $ormElements = $dom->getElementsByTagNameNS($xmlns, 'orm');
         if ($ormElements->length) {
             $ormDom     = new DOMDocument('1.0', 'UTF-8');
-            $ormNode    = $ormDom->importNode($ormElements->item(0));
-            $configNode = $ormDom->createElementNS($xmlns, 'config');
-            $configNode->appendChild($ormNode);
-            $ormDom->appendChild($configNode);
+            $ormElement = $ormElements->item(0);
+            if ($ormElement !== null) {
+                $ormNode    = $ormDom->importNode($ormElement);
+                $configNode = $ormDom->createElementNS($xmlns, 'config');
+                $configNode->appendChild($ormNode);
+                $ormDom->appendChild($configNode);
 
-            $ret = $ormDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
-            $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
-            $found = true;
+                $ret = $ormDom->schemaValidate(__DIR__ . '/../../config/schema/doctrine-1.0.xsd');
+                $this->assertTrue($ret, 'DoctrineBundle Dependency Injection XMLSchema did not validate this XML instance.');
+                $found = true;
+            }
         }
 
         $this->assertTrue($found, 'Neither <doctrine:orm> nor <doctrine:dbal> elements found in given XML. Are namespaces configured correctly?');


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the codebase, focusing on stricter static analysis, improved null handling, and better type safety. The main changes include raising the PHPStan analysis level, adding type and null checks to prevent runtime errors, and improving documentation for generics-related issues.

**Static analysis and type safety improvements:**

* Increased PHPStan static analysis level from 7 to 8 in `phpstan.neon.dist` for stricter code quality checks.
* Added `@phpstan-ignore missingType.generics` annotations throughout `src/DependencyInjection/Configuration.php` to suppress generics-related warnings and clarify intent. 
* Improved PHPDoc for the `$params` argument in `provideIncompatibleDriverOptions` to specify expected structure, aiding static analysis tools.

**Null handling and bug fixes:**

* Added null checks when accessing bundle metadata in `DoctrineExtension.php` and when importing DOM nodes in `XMLSchemaTest.php` to prevent potential errors.
* Added a null check for the profile object in `ProfilerController.php` to return a 404 response if not found, avoiding errors on missing profiles.
* Ensured the container is not null before shutdown logic in `DoctrineBundle.php`.
* Improved constructor in `DoctrineDataCollector.php` to always provide a valid `DebugDataHolder`, preventing null-related issues.

**Other improvements:**

* Added a null check for middleware class in `MiddlewaresPass.php` to avoid calling `is_subclass_of` on null.
* Cast the result of `preg_replace_callback` to string in `DoctrineExtension.php` for stricter type safety.