### PR TITLE
Remove `$aliasMap` argument from `DoctrineOrmMappingsPass`

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 3.1 to 3.2
+=======================
+
+DoctrineOrmMappingsPass
+-----------------------
+
+The `$aliasMap` argument of the `DoctrineOrmMappingsPass` class and methods
+is removed. Namespace aliases are no longer supported in Doctrine.

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -32,9 +32,8 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
      * @param string|false         $enabledParameter  If specified, the compiler pass only executes
      *                                                if this parameter is defined in the service
      *                                                container.
-     * @param string[]             $aliasMap          Map of alias to namespace.
      */
-    public function __construct(Definition|Reference $driver, array $namespaces, array $managerParameters, string|false $enabledParameter = false, array $aliasMap = [])
+    public function __construct(Definition|Reference $driver, array $namespaces, array $managerParameters, string|false $enabledParameter = false)
     {
         $managerParameters[] = 'doctrine.default_entity_manager';
 
@@ -44,9 +43,6 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
             $managerParameters,
             'doctrine.orm.%s_metadata_driver',
             $enabledParameter,
-            'doctrine.orm.%s_configuration',
-            'addEntityNamespace',
-            $aliasMap,
         );
     }
 
@@ -59,14 +55,13 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false, array $aliasMap = [], bool $enableXsdValidation = false): self
+    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false, bool $enableXsdValidation = false): self
     {
         $locator = new Definition(SymfonyFileLocator::class, [$namespaces, '.orm.xml']);
         $driver  = new Definition(XmlDriver::class, [$locator, XmlDriver::DEFAULT_FILE_EXTENSION, $enableXsdValidation]);
 
-        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
     }
 
     /**
@@ -78,14 +73,13 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createPhpMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false, array $aliasMap = []): self
+    public static function createPhpMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false): self
     {
         $locator = new Definition(SymfonyFileLocator::class, [$namespaces, '.php']);
         $driver  = new Definition(PHPDriver::class, [$locator]);
 
-        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
     }
 
     /**
@@ -98,13 +92,12 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters = [], string|false $enabledParameter = false, array $aliasMap = []): self
+    public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters = [], string|false $enabledParameter = false): self
     {
         $driver = new Definition(AttributeDriver::class, [$directories]);
 
-        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
     }
 
     /**
@@ -117,12 +110,11 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = [], string|false $enabledParameter = false, array $aliasMap = []): self
+    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = [], string|false $enabledParameter = false): self
     {
         $driver = new Definition(StaticPHPDriver::class, [$directories]);
 
-        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineOrmMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
     }
 }

--- a/tests/DependencyInjection/Compiler/DoctrineOrmMappingsPassTest.php
+++ b/tests/DependencyInjection/Compiler/DoctrineOrmMappingsPassTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
+use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+use function interface_exists;
+
+class DoctrineOrmMappingsPassTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (interface_exists(EntityManagerInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires ORM');
+    }
+
+    public function testCreateXmlMappingDriver(): void
+    {
+        $namespaces = ['App\Entity' => '/path/to/mapping'];
+        $pass       = DoctrineOrmMappingsPass::createXmlMappingDriver($namespaces);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.default_entity_manager', 'default');
+
+        $chainDriverDef = new Definition();
+        $container->setDefinition('doctrine.orm.default_metadata_driver', $chainDriverDef);
+
+        $pass->process($container);
+
+        $methodCalls = $chainDriverDef->getMethodCalls();
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $driverDef = $methodCalls[0][1][0];
+        $this->assertInstanceOf(Definition::class, $driverDef);
+
+        $this->assertSame(XmlDriver::class, $driverDef->getClass());
+
+        $args       = $driverDef->getArguments();
+        $locatorDef = $args[0];
+        $this->assertInstanceOf(Definition::class, $locatorDef);
+        $this->assertSame(SymfonyFileLocator::class, $locatorDef->getClass());
+        $this->assertSame($namespaces, $locatorDef->getArgument(0));
+        $this->assertSame('.orm.xml', $locatorDef->getArgument(1));
+
+        $this->assertSame(XmlDriver::DEFAULT_FILE_EXTENSION, $args[1]);
+        $this->assertFalse($args[2]);
+    }
+
+    public function testCreatePhpMappingDriver(): void
+    {
+        $namespaces = ['App\Entity' => '/path/to/mapping'];
+        $pass       = DoctrineOrmMappingsPass::createPhpMappingDriver($namespaces);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.default_entity_manager', 'default');
+
+        $chainDriverDef = new Definition();
+        $container->setDefinition('doctrine.orm.default_metadata_driver', $chainDriverDef);
+
+        $pass->process($container);
+
+        $methodCalls = $chainDriverDef->getMethodCalls();
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $driverDef = $methodCalls[0][1][0];
+        $this->assertInstanceOf(Definition::class, $driverDef);
+
+        $this->assertSame(PHPDriver::class, $driverDef->getClass());
+
+        $args       = $driverDef->getArguments();
+        $locatorDef = $args[0];
+        $this->assertInstanceOf(Definition::class, $locatorDef);
+        $this->assertSame(SymfonyFileLocator::class, $locatorDef->getClass());
+        $this->assertSame($namespaces, $locatorDef->getArgument(0));
+        $this->assertSame('.php', $locatorDef->getArgument(1));
+    }
+
+    public function testCreateAttributeMappingDriver(): void
+    {
+        $namespaces  = ['App\Entity'];
+        $directories = ['/path/to/mapping'];
+        $pass        = DoctrineOrmMappingsPass::createAttributeMappingDriver($namespaces, $directories);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.default_entity_manager', 'default');
+
+        $chainDriverDef = new Definition();
+        $container->setDefinition('doctrine.orm.default_metadata_driver', $chainDriverDef);
+
+        $pass->process($container);
+
+        $methodCalls = $chainDriverDef->getMethodCalls();
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $driverDef = $methodCalls[0][1][0];
+        $this->assertInstanceOf(Definition::class, $driverDef);
+
+        $this->assertSame(AttributeDriver::class, $driverDef->getClass());
+
+        $args = $driverDef->getArguments();
+        $this->assertSame($directories, $args[0]);
+    }
+
+    public function testCreateStaticPhpMappingDriver(): void
+    {
+        $namespaces  = ['App\Entity'];
+        $directories = ['/path/to/mapping'];
+        $pass        = DoctrineOrmMappingsPass::createStaticPhpMappingDriver($namespaces, $directories);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.default_entity_manager', 'default');
+
+        $chainDriverDef = new Definition();
+        $container->setDefinition('doctrine.orm.default_metadata_driver', $chainDriverDef);
+
+        $pass->process($container);
+
+        $methodCalls = $chainDriverDef->getMethodCalls();
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $driverDef = $methodCalls[0][1][0];
+        $this->assertInstanceOf(Definition::class, $driverDef);
+
+        $this->assertSame(StaticPHPDriver::class, $driverDef->getClass());
+
+        $args = $driverDef->getArguments();
+        $this->assertSame($directories, $args[0]);
+    }
+}


### PR DESCRIPTION
The `$aliasMap` argument of the `DoctrineOrmMappingsPass` class and methods is removed. Namespace aliases are no longer supported in Doctrine.

The method `Configuration::addEntityNamespace()` that is called by this option have been removed from `doctrine/orm` 3.0.0

Related to https://github.com/symfony/symfony/pull/62792

Example of usages:
- [FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/607a7fb975bc0c39bc2aa7e4ab8c52aded74d63c/src/FOSUserBundle.php#L47) 
- [ParthenonBundle](https://github.com/getparthenon/parthenon/blob/0fcfaa01b7fd84845d01e34ebcbf0b0370f45921/src/ParthenonBundle.php#L78-L88)
- [BabDevMoneyBundle](https://github.com/BabDev/MoneyBundle/blob/3b9b06cda58d3e1796872094d8568d6c15ad5069/src/BabDevMoneyBundle.php#L35-L37)