### PR TITLE
Detect bundles containing only MappedSuperclass annotations

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -422,6 +422,7 @@ class DoctrineExtension extends Extension
             if (
                 preg_match('/^#\[.*' . $quotedMappingObjectName . '\b/m', $content)
                 || preg_match('/^#\[.*Embeddable\b/m', $content)
+                || preg_match('/^#\[.*MappedSuperclass\b/m', $content)
             ) {
                 break;
             }
@@ -429,6 +430,7 @@ class DoctrineExtension extends Extension
             if (
                 self::textContainsAnnotation($quotedMappingObjectName, $content)
                 || self::textContainsAnnotation('Embeddable', $content)
+                || self::textContainsAnnotation('MappedSuperclass', $content)
             ) {
                 $type = 'annotation';
                 break;

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1511,6 +1511,7 @@ class DoctrineExtensionTest extends TestCase
     #[TestWith(['AttributesBundle', 'attribute'], 'Bundle with attributes')]
     #[TestWith(['RepositoryServiceBundle', 'attribute'], 'Bundle with both')]
     #[TestWith(['AnnotationsBundle', 'annotation'], 'Bundle with annotations')]
+    #[TestWith(['MappedSuperclassBundle', 'annotation'], 'Bundle with annotations containing only MappedSuperclass')]
     #[TestWith(['AttributesWithPackageBundle', 'attribute'], 'Bundle with attributes and @package')]
     public function testDetectMappingType(string $bundle, string $expectedType, string $vendor = '')
     {

--- a/tests/DependencyInjection/Fixtures/Bundles/MappedSuperclassBundle/Entity/TestAnnotationEntity.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/MappedSuperclassBundle/Entity/TestAnnotationEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Bundles\MappedSuperclassBundle\Entity;
+
+/** @ORM\MappedSuperclass() */
+class TestAnnotationEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     */
+    public int|null $id = null;
+}

--- a/tests/DependencyInjection/Fixtures/Bundles/MappedSuperclassBundle/MappedSuperclassBundle.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/MappedSuperclassBundle/MappedSuperclassBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Bundles\MappedSuperclassBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MappedSuperclassBundle extends Bundle
+{
+}


### PR DESCRIPTION
Add the MappedSuperclass (annotations and attributes) to the DoctrineExtension::detectMappingType.

Should fix #2166