### PR TITLE
Ignore /var/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ phpunit.xml
 /.phpunit.result.cache
 /phpcs.xml
 /.phpcs-cache
+
+# created by phpstan-symfony
+/var/


### PR DESCRIPTION
phpstan-symfony is in use since 56d1865e . It relies on a Symfony container being created in that directory, so let us ignore it.