### PR TITLE
Fix position of `$enableXsdValidation` in `DoctrineOrmMappingsPass::createXmlMappingDriver`

### DIFF
--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -70,7 +70,8 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
             Deprecation::trigger(
                 'doctrine/doctrine-bundle',
                 'https://github.com/doctrine/DoctrineBundle/pull/2190',
-                'Providing a $aliasMap argument to createXmlMappingDriver() is deprecated and has no effect.',
+                'Providing a $aliasMap argument to %s is deprecated and has no effect.',
+                __METHOD__,
             );
             $enableXsdValidation = false;
 

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -13,10 +13,14 @@ use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use TypeError;
 
 use function func_get_arg;
 use function func_num_args;
+use function gettype;
 use function is_array;
+use function is_bool;
+use function sprintf;
 
 /**
  * Class for Symfony bundles to configure mappings for model classes not in the
@@ -76,7 +80,12 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
             $enableXsdValidation = false;
 
             if (func_num_args() === 5) {
-                $enableXsdValidation = func_get_arg(4);
+                $enableXsdValidationArg = func_get_arg(4);
+                if (! is_bool($enableXsdValidationArg)) {
+                    throw new TypeError(sprintf('$enableXsdValidation is expected to be boolean, %s provided', gettype($enableXsdValidationArg)));
+                }
+
+                $enableXsdValidation = $enableXsdValidationArg;
             }
         }
 

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -62,7 +62,7 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
      *                                          optional.
      * @param bool         $enableXsdValidation
      *
-     * @phpstan-ignore     missingType.iterableValue
+     * @phpstan-ignore missingType.iterableValue
      */
     public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false, bool|array $enableXsdValidation = false): self
     {

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -70,7 +70,7 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
             Deprecation::trigger(
                 'doctrine/doctrine-bundle',
                 'https://github.com/doctrine/DoctrineBundle/pull/2190',
-                'Providing a $aliasMap to createXmlMappingDriver is deprecated and has no effect.',
+                'Providing a $aliasMap argument to createXmlMappingDriver() is deprecated and has no effect.',
             );
             $enableXsdValidation = false;
 

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
@@ -12,6 +13,10 @@ use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+
+use function func_get_arg;
+use function func_num_args;
+use function is_array;
 
 /**
  * Class for Symfony bundles to configure mappings for model classes not in the
@@ -46,18 +51,33 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
         );
     }
 
+    // @phpstan-ignore missingType.iterableValue
     /**
-     * @param string[]     $namespaces        Hashmap of directory path to namespace.
-     * @param string[]     $managerParameters List of parameters that could which object manager name
-     *                                        your bundle uses. This compiler pass will automatically
-     *                                        append the parameter name for the default entity manager
-     *                                        to this list.
-     * @param string|false $enabledParameter  Service container parameter that must be present to
-     *                                        enable the mapping. Set to false to not do any check,
-     *                                        optional.
+     * @param string[]     $namespaces          Hashmap of directory path to namespace.
+     * @param string[]     $managerParameters   List of parameters that could which object manager name
+     *                                          your bundle uses. This compiler pass will automatically
+     *                                          append the parameter name for the default entity manager
+     *                                          to this list.
+     * @param string|false $enabledParameter    Service container parameter that must be present to
+     *                                          enable the mapping. Set to false to not do any check,
+     *                                          optional.
+     * @param bool         $enableXsdValidation
      */
-    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false, bool $enableXsdValidation = false): self
+    public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false, bool|array $enableXsdValidation = false): self
     {
+        if (is_array($enableXsdValidation)) {
+            Deprecation::trigger(
+                'doctrine/doctrine-bundle',
+                'https://github.com/doctrine/DoctrineBundle/pull/2190',
+                'Providing a $aliasMap to createXmlMappingDriver is deprecated and has no effect.',
+            );
+            $enableXsdValidation = false;
+
+            if (func_num_args() === 5) {
+                $enableXsdValidation = func_get_arg(4);
+            }
+        }
+
         $locator = new Definition(SymfonyFileLocator::class, [$namespaces, '.orm.xml']);
         $driver  = new Definition(XmlDriver::class, [$locator, XmlDriver::DEFAULT_FILE_EXTENSION, $enableXsdValidation]);
 

--- a/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineOrmMappingsPass.php
@@ -51,7 +51,6 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
         );
     }
 
-    // @phpstan-ignore missingType.iterableValue
     /**
      * @param string[]     $namespaces          Hashmap of directory path to namespace.
      * @param string[]     $managerParameters   List of parameters that could which object manager name
@@ -62,6 +61,8 @@ final class DoctrineOrmMappingsPass extends RegisterMappingsPass
      *                                          enable the mapping. Set to false to not do any check,
      *                                          optional.
      * @param bool         $enableXsdValidation
+     *
+     * @phpstan-ignore     missingType.iterableValue
      */
     public static function createXmlMappingDriver(array $namespaces, array $managerParameters = [], string|false $enabledParameter = false, bool|array $enableXsdValidation = false): self
     {


### PR DESCRIPTION
Fix by allowing $enableXsdValidation to contain an array. If it does trigger a deprecation and grab the correct $enableXsdValidation parameter via func_get_arg

Fixes #2189 