### PR TITLE
Wire the Console EntityValueResolver as a service

### DIFF
--- a/config/orm.php
+++ b/config/orm.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver as ConsoleEntityValueResolver;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -168,6 +169,13 @@ return static function (ContainerConfigurator $container): void {
                 service('doctrine.orm.entity_value_resolver.expression_language')->ignoreOnInvalid(),
             ])
             ->tag('controller.argument_value_resolver', ['priority' => 110, 'name' => EntityValueResolver::class])
+
+        ->set('doctrine.orm.entity_value_resolver.console', ConsoleEntityValueResolver::class)
+            ->args([
+                service('doctrine'),
+                service('doctrine.orm.entity_value_resolver.expression_language')->ignoreOnInvalid(),
+            ])
+            ->tag('console.argument_value_resolver', ['priority' => 110, 'name' => ConsoleEntityValueResolver::class])
 
         ->set('doctrine.orm.entity_value_resolver.expression_language', ExpressionLanguage::class)
 

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -44,6 +44,7 @@ use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
+use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
@@ -803,21 +804,27 @@ final class DoctrineExtension extends Extension
             $controllerResolverDefaults['evict_cache'] = true;
         }
 
-        $valueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver');
-        $valueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            $controllerResolverDefaults['evict_cache'] ?? null,
-            $controllerResolverDefaults['disabled'] ?? false,
+        $controllerValueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver');
+        $controllerValueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([
+            '$evictCache' => $controllerResolverDefaults['evict_cache'] ?? null,
+            '$disabled' => $controllerResolverDefaults['disabled'] ?? false,
         ]));
 
         // Symfony 7.3 and higher expose type alias support in the EntityValueResolver
-        $valueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
+        $controllerValueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
+
+        // The Console EntityValueResolver is available in Symfony 8.1 and higher
+        if (class_exists(EntityValueResolver::class)) {
+            $consoleValueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver.console');
+            $consoleValueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([
+                '$evictCache' => $controllerResolverDefaults['evict_cache'] ?? null,
+                '$disabled' => $controllerResolverDefaults['disabled'] ?? false,
+            ]));
+
+            $consoleValueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
+        } else {
+            $container->removeDefinition('doctrine.orm.entity_value_resolver.console');
+        }
 
         $entityManagers = [];
         foreach (array_keys($config['entity_managers']) as $name) {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver as ConsoleEntityValueResolver;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
@@ -40,6 +41,10 @@ class ContainerTest extends TestCase
 
         if (class_exists(EntityValueResolver::class)) {
             $this->assertInstanceOf(EntityValueResolver::class, $container->get('doctrine.orm.entity_value_resolver'));
+        }
+
+        if (class_exists(ConsoleEntityValueResolver::class)) {
+            $this->assertInstanceOf(ConsoleEntityValueResolver::class, $container->get('doctrine.orm.entity_value_resolver.console'));
         }
 
         $this->assertInstanceOf(DoctrineDataCollector::class, $container->get('data_collector.doctrine'));

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver as ConsoleEntityValueResolver;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver;
@@ -1333,15 +1334,8 @@ class DoctrineExtensionTest extends TestCase
             0 => new Reference('doctrine'),
             1 => new Reference('doctrine.orm.entity_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE),
             2 => (new Definition(MapEntity::class))->setArguments([
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                false,
+                '$evictCache' => null,
+                '$disabled' => false,
             ]),
             3 => ['Throwable' => 'stdClass'],
         ], $controllerResolver->getArguments());
@@ -1354,9 +1348,57 @@ class DoctrineExtensionTest extends TestCase
         ];
         $extension->load([$config], $container);
 
-        $container->setDefinition('controller_resolver_defaults', $container->getDefinition('doctrine.orm.entity_value_resolver')->getArgument(2))->setPublic(true);
-        $container->compile();
-        $this->assertEquals(new MapEntity(null, null, null, null, null, null, null, true, true), $container->get('controller_resolver_defaults'));
+        $this->assertEquals((new Definition(MapEntity::class))->setArguments([
+            '$evictCache' => true,
+            '$disabled' => true,
+        ]), $container->getDefinition('doctrine.orm.entity_value_resolver')->getArgument(2));
+    }
+
+    #[RequiresMethod(ConsoleEntityValueResolver::class, '__construct')]
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testConsoleCommandResolver(bool $simpleEntityManagerConfig): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+        $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
+
+        if ($simpleEntityManagerConfig) {
+            $config['orm'] = [];
+        }
+
+        $config['orm']['resolve_target_entities'] = ['Throwable' => 'stdClass'];
+
+        $extension->load([$config], $container);
+
+        $consoleResolver = $container->getDefinition('doctrine.orm.entity_value_resolver.console');
+
+        $this->assertEquals([
+            0 => new Reference('doctrine'),
+            1 => new Reference('doctrine.orm.entity_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE),
+            2 => (new Definition(MapEntity::class))->setArguments([
+                '$evictCache' => null,
+                '$disabled' => false,
+            ]),
+            3 => ['Throwable' => 'stdClass'],
+        ], $consoleResolver->getArguments());
+
+        $container = $this->getContainer();
+
+        $config['orm']['controller_resolver'] = [
+            'enabled' => false,
+            'evict_cache' => true,
+        ];
+        $extension->load([$config], $container);
+
+        $this->assertEquals((new Definition(MapEntity::class))->setArguments([
+            '$evictCache' => true,
+            '$disabled' => true,
+        ]), $container->getDefinition('doctrine.orm.entity_value_resolver.console')->getArgument(2));
     }
 
     /** @param list<string> $bundles */


### PR DESCRIPTION
This PR enables the EntityValueResolver for Console commands that has been introduced in https://github.com/symfony/symfony/pull/62917. 

~~Needs https://github.com/symfony/symfony/pull/62917 to be merged first~~ ✅

Please let me know if I missed anything.