### PR TITLE
Fix typo in `dbal.connections.default_dbname` configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -357,7 +357,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('default_dbname')
                     ->info(
-                        'Override the default database (postgres) to connect to for PostgreSQL connexion.',
+                        'Override the default database (postgres) to connect to for PostgreSQL connection.',
                     )
                 ->end()
                 ->scalarNode('sslmode')


### PR DESCRIPTION
Found in https://github.com/symfony/ux/actions/runs/20876445052/job/59986518072?pr=3286