### PR TITLE
Add `#[AsDbalType]` attribute

### DIFF
--- a/docs/en/dbal-type.rst
+++ b/docs/en/dbal-type.rst
@@ -1,0 +1,88 @@
+DBAL Types
+==========
+
+Custom DBAL types can be registered using the ``AsDbalType`` attribute. This
+attribute allows you to define a name for your custom type directly in the class
+definition. If the name is not provided, the class name will be used as the default.
+
+To register a custom DBAL type, create a class that extends
+``Doctrine\DBAL\Types\Type`` and add the ``#[AsDbalType]`` attribute to it:
+
+.. code-block:: php
+
+    namespace App\Doctrine\Type;
+
+    use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
+    use Doctrine\DBAL\Platforms\AbstractPlatform;
+    use Doctrine\DBAL\Types\Type;
+
+    #[AsDbalType(name: 'money')]
+    class MoneyType extends Type
+    {
+        public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+        {
+            return $platform->getDecimalTypeDeclarationSQL($column);
+        }
+
+        public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+        {
+            return $value;
+        }
+
+        public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
+        {
+            return $value;
+        }
+    }
+
+When using the ``AsDbalType`` attribute, the type will be automatically
+registered with Doctrine.
+
+Manual Registration
+-------------------
+
+Alternatively, you can register custom types in your configuration:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/doctrine.yaml
+        doctrine:
+            dbal:
+                types:
+                    money: App\Doctrine\Type\MoneyType
+
+    .. code-block:: xml
+
+        <!-- config/packages/doctrine.xml -->
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/doctrine
+                http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+            <doctrine:config>
+                <doctrine:dbal>
+                    <doctrine:type name="money">App\Doctrine\Type\MoneyType</doctrine:type>
+                </doctrine:dbal>
+            </doctrine:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/doctrine.php
+        use App\Doctrine\Type\MoneyType;
+        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+        return static function (ContainerConfigurator $containerConfigurator): void {
+            $containerConfigurator->extension('doctrine', [
+                'dbal' => [
+                    'types' => [
+                        'money' => MoneyType::class,
+                    ],
+                ],
+            ]);
+        };

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -8,6 +8,7 @@ configuration options, console commands and even a web debug toolbar collector.
 
     installation
     doctrine-console
+    dbal-type
     entity-listeners
     event-listeners
     custom-id-generators

--- a/src/Attribute/AsDbalType.php
+++ b/src/Attribute/AsDbalType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class AsDbalType
+{
+    public function __construct(public string|null $name = null)
+    {
+    }
+}

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
+use Doctrine\DBAL\Types\Type;
+use ReflectionClass;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+use function is_subclass_of;
+use function method_exists;
+use function sprintf;
+
+/** @internal */
+final class RegisterDbalTypePass implements CompilerPassInterface
+{
+    private const string TAG = 'doctrine.dbal.type';
+
+    /**
+     * @param ReflectionClass<T> $reflector
+     *
+     * @template T of ReflectionClass
+     */
+    public static function autoconfigureFromAttribute(ChildDefinition $definition, AsDbalType $type, ReflectionClass $reflector): void
+    {
+        $attributes = [
+            'type_name' => $type->name ?? $reflector->name,
+        ];
+
+        // Determine if the version of symfony/dependency-injection is >= 7.3
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (method_exists($definition, 'addResourceTag')) {
+            $definition->addResourceTag(self::TAG, $attributes);
+        } else {
+            // Needed to keep compatibility with symfony/dependency-injection < 7.3
+            $definition->addTag(self::TAG, $attributes)
+                ->addTag('container.excluded', ['source' => sprintf('by tag "%s"', self::TAG)]);
+        }
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $types = $container->getParameter('doctrine.dbal.connection_factory.types');
+
+        foreach ($this->findTaggedResourceIds($container) as $id => $tags) {
+            foreach ($tags as $tag) {
+                $class = $container->getDefinition($id)->getClass();
+                if (! $class) {
+                    throw new InvalidArgumentException(sprintf('The definition of "%s" must define its class.', $id));
+                }
+
+                if (! is_subclass_of($class, Type::class)) {
+                    throw new InvalidArgumentException(sprintf('The "%s" class must extends "%s".', $class, Type::class));
+                }
+
+                $types[$tag['type_name'] ?? $id] = ['class' => $class];
+            }
+        }
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', $types);
+    }
+
+    /** @return array<string, array<array{type_name?: string}>> */
+    private function findTaggedResourceIds(ContainerBuilder $container): array
+    {
+        // Determine if the version of symfony/dependency-injection is >= 7.3
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (method_exists($container, 'findTaggedResourceIds')) {
+            return $container->findTaggedResourceIds(self::TAG);
+        }
+
+        // Needed to keep compatibility with symfony/dependency-injection < 7.3
+        $tags = [];
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (! $definition->hasTag(self::TAG)) {
+                continue;
+            }
+
+            if (! $definition->hasTag('container.excluded')) {
+                throw new InvalidArgumentException(sprintf('The resource "%s" tagged "%s" is missing the "container.excluded" tag.', $id, self::TAG));
+            }
+
+            $class = $container->getParameterBag()->resolveValue($definition->getClass());
+            if (! $class || $definition->isAbstract()) {
+                throw new InvalidArgumentException(sprintf('The resource "%s" tagged "%s" must have a class and not be abstract.', $id, self::TAG));
+            }
+
+            if ($definition->getClass() !== $class) {
+                $definition->setClass($class);
+            }
+
+            $tags[$id] = $definition->getTag(self::TAG);
+        }
+
+        return $tags;
+    }
+}

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection;
 
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsMiddleware;
@@ -11,6 +12,7 @@ use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use Doctrine\Bundle\DoctrineBundle\Dbal\RegexSchemaAssetFilter;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterDbalTypePass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
@@ -549,6 +551,9 @@ final class DoctrineExtension extends Extension
 
             $this->loadDbalConnection($name, $connection, $container);
         }
+
+        /** @phpstan-ignore argument.type (Needed for the $reflector parameter) */
+        $container->registerAttributeForAutoconfiguration(AsDbalType::class, RegisterDbalTypePass::autoconfigureFromAttribute(...));
 
         $container->registerForAutoconfiguration(MiddlewareInterface::class)->addTag('doctrine.middleware');
 

--- a/src/DoctrineBundle.php
+++ b/src/DoctrineBundle.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilter
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\MiddlewaresPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterDbalTypePass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RemoveLoggingMiddlewarePass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RemoveProfilerControllerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
@@ -68,6 +69,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new RemoveLoggingMiddlewarePass());
         $container->addCompilerPass(new MiddlewaresPass());
         $container->addCompilerPass(new RegisterUidTypePass());
+        $container->addCompilerPass(new RegisterDbalTypePass());
 
         if (! class_exists(RegisterDatePointTypePass::class)) {
             return;

--- a/tests/BundleTest.php
+++ b/tests/BundleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\DoctrineBundle\Tests;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterDbalTypePass;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
@@ -22,9 +23,10 @@ class BundleTest extends TestCase
         $config = $container->getCompilerPassConfig();
         $passes = $config->getBeforeOptimizationPasses();
 
-        $foundEventListener = false;
-        $foundValidation    = false;
-        $foundSchemaFilter  = false;
+        $foundEventListener    = false;
+        $foundValidation       = false;
+        $foundSchemaFilter     = false;
+        $foundRegisterDbalType = false;
 
         foreach ($passes as $pass) {
             if ($pass instanceof RegisterEventListenersAndSubscribersPass) {
@@ -33,11 +35,14 @@ class BundleTest extends TestCase
                 $foundValidation = true;
             } elseif ($pass instanceof DbalSchemaFilterPass) {
                 $foundSchemaFilter = true;
+            } elseif ($pass instanceof RegisterDbalTypePass) {
+                $foundRegisterDbalType = true;
             }
         }
 
         $this->assertTrue($foundEventListener, 'RegisterEventListenersAndSubscribersPass was not found');
         $this->assertTrue($foundValidation, 'DoctrineValidationPass was not found');
         $this->assertTrue($foundSchemaFilter, 'DbalSchemaFilterPass was not found');
+        $this->assertTrue($foundRegisterDbalType, 'RegisterDbalTypePass was not found');
     }
 }

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterDbalTypePass;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+use function sprintf;
+
+class RegisterDbalTypePassTest extends TestCase
+{
+    public function testTaggedTypeAreAdded(): void
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new RegisterDbalTypePass());
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $container->register(BarType::class)
+            ->addTag('doctrine.dbal.type', ['type_name' => 'bar'])
+            ->addTag('container.excluded');
+
+        $container->compile();
+
+        self::assertSame(['bar' => ['class' => BarType::class]], $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testServiceIdMustBeUsedAsTypeNameIfNotDefined(): void
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new RegisterDbalTypePass());
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $container->register('doctrine.dbal.type.bar')
+            ->setClass(BarType::class)
+            ->addTag('doctrine.dbal.type')
+            ->addTag('container.excluded');
+
+        $container->compile();
+
+        self::assertSame(['doctrine.dbal.type.bar' => ['class' => BarType::class]], $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testTypeMustBeASubclassOfTheDbalBaseType(): void
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new RegisterDbalTypePass());
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $container->register(NotASubClassOfDbalBaseType::class)
+            ->addTag('doctrine.dbal.type', ['type_name' => 'invalid_type'])
+            ->addTag('container.excluded');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The "%s" class must extends "%s".', NotASubClassOfDbalBaseType::class, Type::class));
+
+        $container->compile();
+    }
+}
+
+class BarType extends Type
+{
+    /** @param array<string, mixed> $column */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return 'bar';
+    }
+}
+
+class NotASubClassOfDbalBaseType
+{
+}

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection;
 
 use Closure;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\DbalType;
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\DbalTypeNoName;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\Php8EntityListener;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\Php8EventListener;
 use Doctrine\DBAL\Connection;
@@ -945,6 +948,46 @@ class DoctrineExtensionTest extends TestCase
                 'cacheName' => 'metadata_cache_driver',
                 'cacheConfig' => ['type' => 'service', 'id' => 'service_target_metadata'],
             ],
+        ];
+    }
+
+    /** @param class-string $typeClassname */
+    #[DataProvider('provideDatabaseTypeAttribute')]
+    public function testAsDatabaseTypeAttribute(string $typeClassname, string $expectedTypeName): void
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+
+        $config = BundleConfigurationBuilder::createBuilder()
+            ->addBaseConnection()
+            ->build();
+
+        $extension->load([$config], $container);
+
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        $attributes = method_exists($container, 'getAttributeAutoconfigurators')
+            ? array_map(static fn (array $arr) => $arr[0], $container->getAttributeAutoconfigurators())
+            /** @phpstan-ignore method.notFound */
+            : $container->getAutoconfiguredAttributes();
+        $this->assertInstanceOf(Closure::class, $attributes[AsDbalType::class]);
+
+        $reflector  = new ReflectionClass($typeClassname);
+        $definition = new ChildDefinition('');
+        $attribute  = $reflector->getAttributes(AsDbalType::class)[0]->newInstance();
+
+        $attributes[AsDbalType::class]($definition, $attribute, $reflector);
+
+        $expected = ['type_name' => $expectedTypeName];
+        $this->assertSame([$expected], $definition->getTag('doctrine.dbal.type'));
+        $this->assertSame([['source' => 'by tag "doctrine.dbal.type"']], $definition->getTag('container.excluded'));
+    }
+
+    /** @return array<array{0: class-string, 1: string}> */
+    public static function provideDatabaseTypeAttribute(): array
+    {
+        return [
+            'with type name' => [DbalType::class, 'dbal_type'],
+            'without type name' => [DbalTypeNoName::class, DbalTypeNoName::class],
         ];
     }
 

--- a/tests/DependencyInjection/Fixtures/DbalType.php
+++ b/tests/DependencyInjection/Fixtures/DbalType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+#[AsDbalType(name: 'dbal_type')]
+class DbalType extends Type
+{
+    /** @param array<string, mixed> $column */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return 'dbal_type';
+    }
+}

--- a/tests/DependencyInjection/Fixtures/DbalTypeNoName.php
+++ b/tests/DependencyInjection/Fixtures/DbalTypeNoName.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+#[AsDbalType]
+class DbalTypeNoName extends Type
+{
+    /** @param array<string, mixed> $column */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return 'dbal_type_no_name';
+    }
+}


### PR DESCRIPTION
**Description**

This PR add a new `#[AsDbalType]` attribute to automatically register the related class as a DBAL type.


**Problem Solved**

Currently, to register a custom DBAL type, it must be manually declared in the Doctrine configuration file:

``` yaml
# config/packages/doctrine.yaml

doctrine:
    dbal:
        types:
            my_custom_type: App\Type\MyCustomType

```

This approach is verbose and requires the developer to manage configuration in addition to the type class itself.

**Feature Added**

The addition of the  `#[AsDbalType]`  attribute allows the application to automatically detect and register any class that uses this attribute.

-----

**Concrete Usage Example**

Here is how you can register a custom type directly via the attribute, without touching the YAML configuration:

**1. Creating the Custom Type**

``` php
<?php

namespace App\Type;

use Doctrine\DBAL\Types\Type;
use Doctrine\DBAL\Platforms\AbstractPlatform;
use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineType;

#[AsDbalType(name: 'my_custom_type')]
final class MyCustomType extends Type
{
    // ... implementation of methods
}

```

**2. Usage in an Entity**

You can then use this type directly in your entities:

``` php
<?php

namespace App\Entity;

use Doctrine\ORM\Mapping as ORM;

class Product
{
    #[ORM\Column(type: 'my_custom_type', length: 255)]
    private ?string $name = null;
    
    // ...
}

```

**Advantages**

  * **Zero Configuration:** No need to modify `doctrine.yaml` for every new custom type.
  * **Discoverability:** The DBAL type and its name are declared in the same location as its implementation.

