### PR TITLE
Add proper target names to autowiring aliases

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -632,8 +632,7 @@ final class DoctrineExtension extends Extension
             ]);
 
         $container
-            ->registerAliasForArgument($connectionId, Connection::class, sprintf('%s.connection', $name))
-            ->setPublic(false);
+            ->registerAliasForArgument($connectionId, Connection::class, sprintf('%s.connection', $name), $name);
 
         // Set class in case "wrapper_class" option was used to assist IDEs
         if (isset($options['wrapperClass'])) {
@@ -1022,8 +1021,7 @@ final class DoctrineExtension extends Extension
             ->setConfigurator([new Reference($managerConfiguratorName), 'configure']);
 
         $container
-            ->registerAliasForArgument($entityManagerId, EntityManagerInterface::class, sprintf('%s.entity_manager', $entityManager['name']))
-            ->setPublic(false);
+            ->registerAliasForArgument($entityManagerId, EntityManagerInterface::class, sprintf('%s.entity_manager', $entityManager['name']), $entityManager['name']);
 
         $container->setAlias(
             sprintf('doctrine.orm.%s_entity_manager.event_manager', $entityManager['name']),


### PR DESCRIPTION
`#[Target('')]` should not need using fixed suffixes. This does it.

This also fixes a few services names that use FQCN ids, which is discouraged practice for bundles (it pollutes the list of autowireable services)