### PR TITLE
Update `#[AsDbalType]` attribute to register DBAL types as Symfony services

### DIFF
--- a/docs/en/dbal-type.rst
+++ b/docs/en/dbal-type.rst
@@ -3,7 +3,8 @@ DBAL Types
 
 Custom DBAL types can be registered using the ``AsDbalType`` attribute. This
 attribute allows you to define a name for your custom type directly in the class
-definition. If the name is not provided, the class name will be used as the default.
+definition. If the name is not provided, it defaults to the service id, which is
+the fully-qualified class name of the type when using the attribute.
 
 To register a custom DBAL type, create a class that extends
 ``Doctrine\DBAL\Types\Type`` and add the ``#[AsDbalType]`` attribute to it:
@@ -36,7 +37,49 @@ To register a custom DBAL type, create a class that extends
     }
 
 When using the ``AsDbalType`` attribute, the type will be automatically
-registered with Doctrine.
+registered. As the type is registered as a service, its constructor can declare
+dependencies that are resolved by the container. This requires DBAL >= 4.5 and
+ORM >= 3.7; on older versions the type is registered globally, without
+dependency injection.
+
+The attribute is autoconfigured to the ``doctrine.dbal.type`` tag, so it is
+equivalent to tagging the service in the configuration. The ``type_name``
+parameter defines the type name; when omitted, the service id is used:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    services:
+        App\Doctrine\Type\MoneyType:
+            tags:
+                - name: doctrine.dbal.type
+                  type_name: money
+
+By default the type is registered on every connection. To restrict it to a
+single connection, set the ``connection`` on the attribute (which is repeatable,
+so a type can be registered on several connections) or on the tag:
+
+.. code-block:: php
+
+    #[AsDbalType(name: 'money', connection: 'reporting')]
+    class MoneyType extends Type
+    {
+        // ...
+    }
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    services:
+        App\Doctrine\Type\MoneyType:
+            tags:
+                - name: doctrine.dbal.type
+                  type_name: money
+                  connection: reporting
+
+Restricting a type to a connection requires DBAL >= 4.5 (and ORM >= 3.7 when the
+ORM is used); on older versions the ``connection`` is ignored and the type is
+registered globally.
 
 Manual Registration
 -------------------

--- a/docs/en/dbal-type.rst
+++ b/docs/en/dbal-type.rst
@@ -1,23 +1,26 @@
 DBAL Types
 ==========
 
-Custom DBAL types can be registered using the ``AsDbalType`` attribute. This
-attribute allows you to define a name for your custom type directly in the class
-definition. If the name is not provided, it defaults to the service id, which is
-the fully-qualified class name of the type when using the attribute.
+`Custom DBAL types`_ let you map a database column to a PHP value of your choice.
+The recommended way to register one is the ``#[AsDbalType]`` attribute, which
+declares the type directly on its class.
 
-To register a custom DBAL type, create a class that extends
-``Doctrine\DBAL\Types\Type`` and add the ``#[AsDbalType]`` attribute to it:
+Registering a Type with the Attribute
+-------------------------------------
+
+Create a class that extends ``Doctrine\DBAL\Types\Type`` and add the
+``#[AsDbalType]`` attribute to it:
 
 .. code-block:: php
 
+    // src/Doctrine/Type/MoneyType.php
     namespace App\Doctrine\Type;
 
     use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
     use Doctrine\DBAL\Platforms\AbstractPlatform;
     use Doctrine\DBAL\Types\Type;
 
-    #[AsDbalType(name: 'money')]
+    #[AsDbalType]
     class MoneyType extends Type
     {
         public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
@@ -36,55 +39,130 @@ To register a custom DBAL type, create a class that extends
         }
     }
 
-When using the ``AsDbalType`` attribute, the type will be automatically
-registered. As the type is registered as a service, its constructor can declare
-dependencies that are resolved by the container. This requires DBAL >= 4.5 and
-ORM >= 3.7; on older versions the type is registered globally, without
-dependency injection.
-
-The attribute is autoconfigured to the ``doctrine.dbal.type`` tag, so it is
-equivalent to tagging the service in the configuration. The ``type_name``
-parameter defines the type name; when omitted, the service id is used:
-
-.. code-block:: yaml
-
-    # config/services.yaml
-    services:
-        App\Doctrine\Type\MoneyType:
-            tags:
-                - name: doctrine.dbal.type
-                  type_name: money
-
-By default the type is registered on every connection. To restrict it to a
-single connection, set the ``connection`` on the attribute (which is repeatable,
-so a type can be registered on several connections) or on the tag:
+The type is then available in your mappings. When no name is given, it defaults
+to the fully-qualified class name, so you can reference the type by its class:
 
 .. code-block:: php
 
+    // src/Entity/Product.php
+    namespace App\Entity;
+
+    use App\Doctrine\Type\MoneyType;
+    use Doctrine\ORM\Mapping as ORM;
+
+    #[ORM\Entity]
+    class Product
+    {
+        #[ORM\Column(type: MoneyType::class)]
+        private Money $price;
+    }
+
+To use a shorter, explicit name instead, pass it to the attribute and reference
+that name in the mapping:
+
+.. code-block:: php
+
+    #[AsDbalType(name: 'money')]
+    class MoneyType extends Type
+    {
+        // ...
+    }
+
+.. code-block:: php
+
+    #[ORM\Column(type: 'money')]
+    private Money $price;
+
+.. note::
+
+    The ``#[AsDbalType]`` attribute and the ``doctrine.dbal.type`` tag require
+    DoctrineBundle >= 3.3.
+
+Dependency Injection
+~~~~~~~~~~~~~~~~~~~~~
+
+The type is registered as a service, so its constructor can declare dependencies
+that are resolved by the container:
+
+.. code-block:: php
+
+    #[AsDbalType]
+    class MoneyType extends Type
+    {
+        public function __construct(private readonly ExchangeRateProvider $rates)
+        {
+        }
+
+        // ...
+    }
+
+.. note::
+
+    Dependency injection requires DBAL >= 4.5 and ORM >= 3.7, where the type is
+    resolved lazily from a per-connection registry. On
+    older versions the type is registered in the global registry and instantiated
+    without dependencies.
+
+Restricting a Type to a Connection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default the type is registered on every connection. Use the ``connection``
+parameter to restrict it to a single connection. The attribute is repeatable, so
+a type can be registered on several connections with different names:
+
+.. code-block:: php
+
+    #[AsDbalType(name: 'money', connection: 'default')]
     #[AsDbalType(name: 'money', connection: 'reporting')]
     class MoneyType extends Type
     {
         // ...
     }
 
-.. code-block:: yaml
+.. note::
 
-    # config/services.yaml
-    services:
-        App\Doctrine\Type\MoneyType:
-            tags:
-                - name: doctrine.dbal.type
-                  type_name: money
-                  connection: reporting
+    Restricting a type to a connection requires DBAL >= 4.5 and ORM >= 3.7.
+    On older versions the ``connection`` is ignored and the type is registered
+    globally.
 
-Restricting a type to a connection requires DBAL >= 4.5 (and ORM >= 3.7 when the
-ORM is used); on older versions the ``connection`` is ignored and the type is
-registered globally.
+Registering a Type as a Service
+-------------------------------
 
-Manual Registration
--------------------
+The attribute is autoconfigured to the ``doctrine.dbal.type`` tag, so tagging a
+service is equivalent to using the attribute. This is useful when
+autoconfiguration is disabled, or to register the same class several times with
+different dependencies. The ``type_name`` attribute sets the type name; when
+omitted, the service id is used:
 
-Alternatively, you can register custom types in your configuration:
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            App\Doctrine\Type\MoneyType:
+                tags:
+                    - { name: doctrine.dbal.type, type_name: money, connection: reporting }
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Doctrine\Type\MoneyType;
+
+        return static function (ContainerConfigurator $container): void {
+            $container->services()
+                ->set(MoneyType::class)
+                ->tag('doctrine.dbal.type', ['type_name' => 'money', 'connection' => 'reporting']);
+        };
+
+Registering a Type with the Configuration
+-----------------------------------------
+
+When you do not need dependency injection, a type can be registered by mapping a
+name to its class name under ``doctrine.dbal.types``. This is supported on all
+DBAL versions and does not turn the type into a service:
 
 .. configuration-block::
 
@@ -96,36 +174,21 @@ Alternatively, you can register custom types in your configuration:
                 types:
                     money: App\Doctrine\Type\MoneyType
 
-    .. code-block:: xml
-
-        <!-- config/packages/doctrine.xml -->
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                http://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/doctrine
-                http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
-
-            <doctrine:config>
-                <doctrine:dbal>
-                    <doctrine:type name="money">App\Doctrine\Type\MoneyType</doctrine:type>
-                </doctrine:dbal>
-            </doctrine:config>
-        </container>
-
     .. code-block:: php
 
         // config/packages/doctrine.php
-        use App\Doctrine\Type\MoneyType;
-        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator): void {
-            $containerConfigurator->extension('doctrine', [
+        use App\Doctrine\Type\MoneyType;
+
+        return App::config([
+            'doctrine' => [
                 'dbal' => [
                     'types' => [
                         'money' => MoneyType::class,
                     ],
                 ],
-            ]);
-        };
+            ],
+        ]);
+
+.. _`Custom DBAL types`: https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/types.html#custom-mapping-types

--- a/src/Attribute/AsDbalType.php
+++ b/src/Attribute/AsDbalType.php
@@ -9,8 +9,8 @@ use Attribute;
 /**
  * Registers the tagged class as a Doctrine DBAL type on the connection.
  *
- * With DBAL >= 4.5 and ORM >= 3.7 when the ORM are used, the type is registered
- * per connection and enables constructor dependency injection.
+ * With DBAL >= 4.5 and ORM >= 3.7, the type is registered per connection and
+ * enables constructor dependency injection.
  *
  * With DBAL < 4.5, the type is registered globally instead.
  */

--- a/src/Attribute/AsDbalType.php
+++ b/src/Attribute/AsDbalType.php
@@ -7,24 +7,21 @@ namespace Doctrine\Bundle\DoctrineBundle\Attribute;
 use Attribute;
 
 /**
- * Registers a DBAL type as a service, with full dependency injection support
- * when DBAL's TypeRegistry injection is available (DBAL >= 4.5).
+ * Registers the tagged class as a Doctrine DBAL type on the connection.
  *
- * When TypeRegistry injection is supported, the type is registered in the
- * per-connection TypeRegistry, enabling constructor dependency injection.
- * When not supported, the type falls back to the global type registry
- * via doctrine.dbal.connection_factory.types (no DI support).
+ * With DBAL >= 4.5 and ORM >= 3.7 when the ORM are used, the type is registered
+ * per connection and enables constructor dependency injection.
+ *
+ * With DBAL < 4.5, the type is registered globally instead.
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final readonly class AsDbalType
 {
     /**
      * @param string|null $name       The DBAL type name used in column mappings (e.g. in #[Column(type: ...)]).
-     *                                Defaults to the fully-qualified class name of the type when omitted,
-     *                                so that #[Column(type: MyType::class)] works without declaring a name.
+     *                                Defaults to the fully-qualified class name of the type when omitted.
      * @param string|null $connection Restrict the type to a specific named connection.
      *                                When null (default), the type is registered for all connections.
-     *                                Ignored when TypeRegistry injection is not supported by the installed DBAL version.
      */
     public function __construct(
         public string|null $name = null,

--- a/src/Attribute/AsDbalType.php
+++ b/src/Attribute/AsDbalType.php
@@ -6,10 +6,29 @@ namespace Doctrine\Bundle\DoctrineBundle\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_CLASS)]
+/**
+ * Registers a DBAL type as a service, with full dependency injection support
+ * when DBAL's TypeRegistry injection is available (DBAL >= 4.5).
+ *
+ * When TypeRegistry injection is supported, the type is registered in the
+ * per-connection TypeRegistry, enabling constructor dependency injection.
+ * When not supported, the type falls back to the global type registry
+ * via doctrine.dbal.connection_factory.types (no DI support).
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final readonly class AsDbalType
 {
-    public function __construct(public string|null $name = null)
-    {
+    /**
+     * @param string|null $name       The DBAL type name used in column mappings (e.g. in #[Column(type: ...)]).
+     *                                Defaults to the fully-qualified class name of the type when omitted,
+     *                                so that #[Column(type: MyType::class)] works without declaring a name.
+     * @param string|null $connection Restrict the type to a specific named connection.
+     *                                When null (default), the type is registered for all connections.
+     *                                Ignored when TypeRegistry injection is not supported by the installed DBAL version.
+     */
+    public function __construct(
+        public string|null $name = null,
+        public string|null $connection = null,
+    ) {
     }
 }

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -40,7 +40,7 @@ final class RegisterDbalTypePass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container): void
     {
-        if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+        if (method_exists(DbalConfiguration::class, 'setTypeProvider')) {
             $this->registerInTypeRegistry($container);
         } else {
             $this->registerInConfig($container);
@@ -115,10 +115,10 @@ final class RegisterDbalTypePass implements CompilerPassInterface
 
             $container
                 ->getDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name))
-                ->addMethodCall('setTypeRegistry', [$registryRef]);
+                ->addMethodCall('setTypeProvider', [$registryRef]);
 
             foreach ($connectionToOrmConfigs[$name] ?? [] as $ormConfigId) {
-                $container->getDefinition($ormConfigId)->addMethodCall('setTypeRegistry', [$registryRef]);
+                $container->getDefinition($ormConfigId)->addMethodCall('setTypeProvider', [$registryRef]);
             }
         }
     }

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -80,7 +80,7 @@ final class RegisterDbalTypePass implements CompilerPassInterface
                         continue;
                     }
 
-                    $services[$tag['type_name'] ?? $tag['type'] ?? $id] = new Reference($id);
+                    $services[$tag['type_name'] ?? $id] = new Reference($id);
                 }
             }
 
@@ -129,7 +129,7 @@ final class RegisterDbalTypePass implements CompilerPassInterface
             $definition->addTag('container.excluded', ['source' => sprintf('by tag "%s"', self::TAG)]);
 
             foreach ($tags as $tag) {
-                $types[$tag['type_name'] ?? $tag['type'] ?? $id] = ['class' => $class];
+                $types[$tag['type_name'] ?? $id] = ['class' => $class];
             }
         }
 

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -133,16 +133,33 @@ final class RegisterDbalTypePass implements CompilerPassInterface
         $types = $container->getParameter('doctrine.dbal.connection_factory.types');
 
         foreach ($container->findTaggedServiceIds(self::TAG) as $id => $tags) {
+            $definition = $container->getDefinition($id);
+
+            $class = $definition->getClass();
+            if (! $class) {
+                throw new InvalidArgumentException(sprintf('The definition of "%s" must define its class.', $id));
+            }
+
+            if (! is_subclass_of($class, Type::class)) {
+                throw new InvalidArgumentException(sprintf('The "%s" class must extends "%s".', $class, Type::class));
+            }
+
+            // On this DBAL version, types are instantiated by the connection factory with
+            // "new $class()", so dependency injection is not available. Reject types whose
+            // constructor has mandatory arguments, as they could never be instantiated.
+            $constructor = (new ReflectionClass($class))->getConstructor();
+            if ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0) {
+                throw new InvalidArgumentException(sprintf(
+                    'The "%s" DBAL type cannot have required constructor arguments because dependency injection of types requires DBAL >= 4.5. Upgrade DBAL or remove the mandatory arguments.',
+                    $class,
+                ));
+            }
+
+            // The type is instantiated by DBAL, not used as a service, so exclude its
+            // definition from the container.
+            $definition->addTag('container.excluded', ['source' => sprintf('by tag "%s"', self::TAG)]);
+
             foreach ($tags as $tag) {
-                $class = $container->getDefinition($id)->getClass();
-                if (! $class) {
-                    throw new InvalidArgumentException(sprintf('The definition of "%s" must define its class.', $id));
-                }
-
-                if (! is_subclass_of($class, Type::class)) {
-                    throw new InvalidArgumentException(sprintf('The "%s" class must extends "%s".', $class, Type::class));
-                }
-
                 $types[$tag['type_name'] ?? $tag['type'] ?? $id] = ['class' => $class];
             }
         }

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -5,13 +5,20 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
 
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
+use Doctrine\DBAL\Configuration as DbalConfiguration;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use ReflectionClass;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
 
+use function array_flip;
+use function array_keys;
 use function is_subclass_of;
 use function method_exists;
 use function sprintf;
@@ -21,33 +28,104 @@ final class RegisterDbalTypePass implements CompilerPassInterface
 {
     private const string TAG = 'doctrine.dbal.type';
 
-    /**
-     * @param ReflectionClass<T> $reflector
-     *
-     * @template T of ReflectionClass
-     */
+    /** @param ReflectionClass<object> $reflector */
     public static function autoconfigureFromAttribute(ChildDefinition $definition, AsDbalType $type, ReflectionClass $reflector): void
     {
-        $attributes = [
+        $definition->addTag(self::TAG, [
             'type_name' => $type->name ?? $reflector->name,
-        ];
-
-        // Determine if the version of symfony/dependency-injection is >= 7.3
-        /** @phpstan-ignore function.alreadyNarrowedType */
-        if (method_exists($definition, 'addResourceTag')) {
-            $definition->addResourceTag(self::TAG, $attributes);
-        } else {
-            // Needed to keep compatibility with symfony/dependency-injection < 7.3
-            $definition->addTag(self::TAG, $attributes)
-                ->addTag('container.excluded', ['source' => sprintf('by tag "%s"', self::TAG)]);
-        }
+            'connection' => $type->connection,
+        ]);
     }
 
     public function process(ContainerBuilder $container): void
     {
+        if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+            $this->registerInTypeRegistry($container);
+        } else {
+            $this->registerInConfig($container);
+        }
+    }
+
+    /**
+     * New approach: inject a per-connection TypeRegistry with lazy service resolution (DBAL >= 4.5).
+     */
+    private function registerInTypeRegistry(ContainerBuilder $container): void
+    {
+        if (! $container->hasParameter('doctrine.connections')) {
+            return;
+        }
+
+        // Config-based types (apply to all connections)
+        /** @var array<string, array{class: string}> $configTypes */
+        $configTypes = $container->getParameter('doctrine.dbal.connection_factory.types');
+
+        $taggedServiceIds = $container->findTaggedServiceIds(self::TAG);
+
+        if ($configTypes === [] && $taggedServiceIds === []) {
+            return;
+        }
+
+        // Map connection name → ORM configuration service IDs (when ORM is installed)
+        $connectionToOrmConfigs = [];
+        if ($container->hasParameter('doctrine.entity_managers')) {
+            $connectionServiceToName = array_flip($container->getParameter('doctrine.connections'));
+            foreach (array_keys($container->getParameter('doctrine.entity_managers')) as $emName) {
+                $emDef    = $container->getDefinition(sprintf('doctrine.orm.%s_entity_manager', $emName));
+                $connName = $connectionServiceToName[(string) $emDef->getArgument(0)] ?? null;
+                if ($connName === null) {
+                    continue;
+                }
+
+                $connectionToOrmConfigs[$connName][] = (string) $emDef->getArgument(1);
+            }
+        }
+
+        foreach (array_keys($container->getParameter('doctrine.connections')) as $name) {
+            $services = [];
+
+            // Config-based types become inline definitions in the ServiceLocator
+            foreach ($configTypes as $typeName => $typeConfig) {
+                $services[$typeName] = new Definition($typeConfig['class']);
+            }
+
+            // Service-tagged types: global (no connection restriction) or matching this connection
+            foreach ($taggedServiceIds as $id => $tags) {
+                foreach ($tags as $tag) {
+                    if ($name !== ($tag['connection'] ?? $name)) {
+                        continue;
+                    }
+
+                    $services[$tag['type_name'] ?? $tag['type'] ?? $id] = new Reference($id);
+                }
+            }
+
+            $registryId  = sprintf('doctrine.dbal.%s_connection.type_registry', $name);
+            $registryRef = new Reference($registryId);
+
+            // Inject a ServiceLocator so types are resolved lazily on first use
+            $locatorRef = ServiceLocatorTagPass::register($container, $services);
+            $container->setDefinition($registryId, new Definition(TypeRegistry::class, [$locatorRef]));
+
+            $container
+                ->getDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name))
+                ->addMethodCall('setTypeRegistry', [$registryRef]);
+
+            foreach ($connectionToOrmConfigs[$name] ?? [] as $ormConfigId) {
+                $container->getDefinition($ormConfigId)->addMethodCall('setTypeRegistry', [$registryRef]);
+            }
+        }
+    }
+
+    /**
+     * Fallback approach: register types in the global type registry via doctrine.dbal.connection_factory.types.
+     * Used when DBAL does not support TypeRegistry injection (DBAL < 4.5).
+     * Does not support DI or per-connection type restriction.
+     */
+    private function registerInConfig(ContainerBuilder $container): void
+    {
         $types = $container->getParameter('doctrine.dbal.connection_factory.types');
 
-        foreach ($this->findTaggedResourceIds($container) as $id => $tags) {
+        foreach ($container->findTaggedServiceIds(self::TAG) as $id => $tags) {
             foreach ($tags as $tag) {
                 $class = $container->getDefinition($id)->getClass();
                 if (! $class) {
@@ -58,45 +136,10 @@ final class RegisterDbalTypePass implements CompilerPassInterface
                     throw new InvalidArgumentException(sprintf('The "%s" class must extends "%s".', $class, Type::class));
                 }
 
-                $types[$tag['type_name'] ?? $id] = ['class' => $class];
+                $types[$tag['type_name'] ?? $tag['type'] ?? $id] = ['class' => $class];
             }
         }
 
         $container->setParameter('doctrine.dbal.connection_factory.types', $types);
-    }
-
-    /** @return array<string, array<array{type_name?: string}>> */
-    private function findTaggedResourceIds(ContainerBuilder $container): array
-    {
-        // Determine if the version of symfony/dependency-injection is >= 7.3
-        /** @phpstan-ignore function.alreadyNarrowedType */
-        if (method_exists($container, 'findTaggedResourceIds')) {
-            return $container->findTaggedResourceIds(self::TAG);
-        }
-
-        // Needed to keep compatibility with symfony/dependency-injection < 7.3
-        $tags = [];
-        foreach ($container->getDefinitions() as $id => $definition) {
-            if (! $definition->hasTag(self::TAG)) {
-                continue;
-            }
-
-            if (! $definition->hasTag('container.excluded')) {
-                throw new InvalidArgumentException(sprintf('The resource "%s" tagged "%s" is missing the "container.excluded" tag.', $id, self::TAG));
-            }
-
-            $class = $container->getParameterBag()->resolveValue($definition->getClass());
-            if (! $class || $definition->isAbstract()) {
-                throw new InvalidArgumentException(sprintf('The resource "%s" tagged "%s" must have a class and not be abstract.', $id, self::TAG));
-            }
-
-            if ($definition->getClass() !== $class) {
-                $definition->setClass($class);
-            }
-
-            $tags[$id] = $definition->getTag(self::TAG);
-        }
-
-        return $tags;
     }
 }

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 use function array_combine;
-use function array_flip;
 use function array_keys;
 use function is_subclass_of;
 use function method_exists;
@@ -29,7 +28,7 @@ final class RegisterDbalTypePass implements CompilerPassInterface
 {
     private const string TAG = 'doctrine.dbal.type';
 
-    /** @param ReflectionClass<object> $reflector */
+    /** @param ReflectionClass<*> $reflector */
     public static function autoconfigureFromAttribute(ChildDefinition $definition, AsDbalType $type, ReflectionClass $reflector): void
     {
         $definition->addTag(self::TAG, [
@@ -64,21 +63,6 @@ final class RegisterDbalTypePass implements CompilerPassInterface
 
         if ($configTypes === [] && $taggedServiceIds === []) {
             return;
-        }
-
-        // Map connection name → ORM configuration service IDs (when ORM is installed)
-        $connectionToOrmConfigs = [];
-        if ($container->hasParameter('doctrine.entity_managers')) {
-            $connectionServiceToName = array_flip($container->getParameter('doctrine.connections'));
-            foreach (array_keys($container->getParameter('doctrine.entity_managers')) as $emName) {
-                $emDef    = $container->getDefinition(sprintf('doctrine.orm.%s_entity_manager', $emName));
-                $connName = $connectionServiceToName[(string) $emDef->getArgument(0)] ?? null;
-                if ($connName === null) {
-                    continue;
-                }
-
-                $connectionToOrmConfigs[$connName][] = (string) $emDef->getArgument(1);
-            }
         }
 
         foreach (array_keys($container->getParameter('doctrine.connections')) as $name) {
@@ -116,10 +100,6 @@ final class RegisterDbalTypePass implements CompilerPassInterface
             $container
                 ->getDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name))
                 ->addMethodCall('setTypeProvider', [$registryRef]);
-
-            foreach ($connectionToOrmConfigs[$name] ?? [] as $ormConfigId) {
-                $container->getDefinition($ormConfigId)->addMethodCall('setTypeProvider', [$registryRef]);
-            }
         }
     }
 

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -144,17 +144,6 @@ final class RegisterDbalTypePass implements CompilerPassInterface
                 throw new InvalidArgumentException(sprintf('The "%s" class must extends "%s".', $class, Type::class));
             }
 
-            // On this DBAL version, types are instantiated by the connection factory with
-            // "new $class()", so dependency injection is not available. Reject types whose
-            // constructor has mandatory arguments, as they could never be instantiated.
-            $constructor = (new ReflectionClass($class))->getConstructor();
-            if ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0) {
-                throw new InvalidArgumentException(sprintf(
-                    'The "%s" DBAL type cannot have required constructor arguments because dependency injection of types requires DBAL >= 4.5. Upgrade DBAL or remove the mandatory arguments.',
-                    $class,
-                ));
-            }
-
             // The type is instantiated by DBAL, not used as a service, so exclude its
             // definition from the container.
             $definition->addTag('container.excluded', ['source' => sprintf('by tag "%s"', self::TAG)]);

--- a/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
+++ b/src/DependencyInjection/Compiler/RegisterDbalTypePass.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
+use function array_combine;
 use function array_flip;
 use function array_keys;
 use function is_subclass_of;
@@ -102,9 +103,15 @@ final class RegisterDbalTypePass implements CompilerPassInterface
             $registryId  = sprintf('doctrine.dbal.%s_connection.type_registry', $name);
             $registryRef = new Reference($registryId);
 
-            // Inject a ServiceLocator so types are resolved lazily on first use
+            // Inject a ServiceLocator so types are resolved lazily on first use. The locator is
+            // keyed by type name, so the name-to-service-ID map the registry requires is an
+            // identity map.
             $locatorRef = ServiceLocatorTagPass::register($container, $services);
-            $container->setDefinition($registryId, new Definition(TypeRegistry::class, [$locatorRef]));
+            $typeNames  = array_keys($services);
+            $container->setDefinition($registryId, new Definition(TypeRegistry::class, [
+                $locatorRef,
+                array_combine($typeNames, $typeNames),
+            ]));
 
             $container
                 ->getDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name))

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DataCollector;
 
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Doctrine\DBAL\Configuration as DBALConfiguration;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -21,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 use function interface_exists;
+use function method_exists;
 
 /**
  * @phpstan-type GroupedQueryItemType = array{
@@ -56,6 +60,14 @@ class DoctrineDataCollectorTest extends TestCase
 
         $manager->method('getMetadataFactory')->willReturn($factory);
         $manager->method('getConfiguration')->willReturn($config);
+        if (method_exists(DBALConfiguration::class, 'getTypeRegistry')) {
+            $dbalConfig = $this->createStub(DBALConfiguration::class);
+            $dbalConfig->method('getTypeRegistry')->willReturn(new TypeRegistry());
+            $connection = $this->createStub(Connection::class);
+            $connection->method('getConfiguration')->willReturn($dbalConfig);
+            $manager->method('getConnection')->willReturn($connection);
+        }
+
         $manager->method('getUnitOfWork')->willReturn($unitOfWork);
         $unitOfWork->method('getIdentityMap')->willReturn([
             self::FIRST_ENTITY => [new stdClass()],

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -8,7 +8,7 @@ use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\DBAL\Configuration as DBALConfiguration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\TypeRegistry;
+use Doctrine\DBAL\Types\TypeProvider;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -60,9 +60,10 @@ class DoctrineDataCollectorTest extends TestCase
 
         $manager->method('getMetadataFactory')->willReturn($factory);
         $manager->method('getConfiguration')->willReturn($config);
-        if (method_exists(DBALConfiguration::class, 'getTypeRegistry')) {
+        if (method_exists(DBALConfiguration::class, 'getTypeProvider')) {
             $dbalConfig = $this->createStub(DBALConfiguration::class);
-            $dbalConfig->method('getTypeRegistry')->willReturn(new TypeRegistry());
+            // TypeProvider is an interface, so it can simply be stubbed.
+            $dbalConfig->method('getTypeProvider')->willReturn($this->createStub(TypeProvider::class));
             $connection = $this->createStub(Connection::class);
             $connection->method('getConfiguration')->willReturn($dbalConfig);
             $manager->method('getConnection')->willReturn($connection);

--- a/tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/DataCollector/DoctrineDataCollectorTest.php
@@ -63,6 +63,7 @@ class DoctrineDataCollectorTest extends TestCase
         if (method_exists(DBALConfiguration::class, 'getTypeProvider')) {
             $dbalConfig = $this->createStub(DBALConfiguration::class);
             // TypeProvider is an interface, so it can simply be stubbed.
+            /** @phpstan-ignore class.notFound (TypeProvider only exists on DBAL >= 4.5) */
             $dbalConfig->method('getTypeProvider')->willReturn($this->createStub(TypeProvider::class));
             $connection = $this->createStub(Connection::class);
             $connection->method('getConfiguration')->willReturn($dbalConfig);

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -238,31 +238,6 @@ class RegisterDbalTypePassTest extends TestCase
         self::assertSame(TypeRegistry::class, $registryArg->getClass());
     }
 
-    public function testTypeRegistryIsSetOnOrmConfiguration(): void
-    {
-        self::requiresTypeRegistry();
-
-        $container = $this->createContainer(
-            static function (ContainerBuilder $container): void {
-                $container->register('my_type', RegisterDbalTypePassMoneyType::class)
-                    ->addTag('doctrine.dbal.type', ['type' => 'money']);
-
-                $container->setAlias('orm_conf_conn1', 'doctrine.orm.em_conn1_configuration')->setPublic(true);
-                $container->setAlias('orm_conf_conn2', 'doctrine.orm.em_conn2_configuration')->setPublic(true);
-            },
-            withOrm: true,
-        );
-
-        foreach (['orm_conf_conn1', 'orm_conf_conn2'] as $alias) {
-            $setTypeProviderCalls = array_filter(
-                $container->getDefinition($alias)->getMethodCalls(),
-                static fn (array $call): bool => $call[0] === 'setTypeProvider',
-            );
-
-            self::assertCount(1, $setTypeProviderCalls, sprintf('setTypeProvider not called on %s', $alias));
-        }
-    }
-
     public function testCustomTypeIsAvailableForOrmEntityMapping(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -4,69 +4,407 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
 
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterDbalTypePass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Doctrine\DBAL\Configuration as DbalConfiguration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Reference;
 
+use function array_filter;
+use function array_values;
+use function method_exists;
 use function sprintf;
+use function sys_get_temp_dir;
 
 class RegisterDbalTypePassTest extends TestCase
 {
-    public function testTaggedTypeAreAdded(): void
+    private static function requiresTypeRegistry(): void
     {
-        $container = new ContainerBuilder();
-        $container->addCompilerPass(new RegisterDbalTypePass());
-
-        $container->setParameter('doctrine.dbal.connection_factory.types', []);
-
-        $container->register(BarType::class)
-            ->addTag('doctrine.dbal.type', ['type_name' => 'bar'])
-            ->addTag('container.excluded');
-
-        $container->compile();
-
-        self::assertSame(['bar' => ['class' => BarType::class]], $container->getParameter('doctrine.dbal.connection_factory.types'));
+        if (! method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+            self::markTestSkipped('This test requires DBAL >= 4.5 with TypeRegistry injection support.');
+        }
     }
 
-    public function testServiceIdMustBeUsedAsTypeNameIfNotDefined(): void
+    private static function requiresNoTypeRegistry(): void
     {
+        if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+            self::markTestSkipped('This test covers the fallback path for DBAL < 4.5 without TypeRegistry support.');
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for the TypeRegistry path (DBAL >= 4.5)
+    // -----------------------------------------------------------------------
+
+    public function testNoTaggedTypesSkipsTypeRegistrySetup(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')
+                ->setPublic(true);
+        });
+
+        foreach ($container->getDefinition('conf_conn1')->getMethodCalls() as [$method]) {
+            self::assertNotSame('setTypeRegistry', $method);
+        }
+    }
+
+    public function testGlobalTypeIsRegisteredOnAllConnections(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register('my_type', RegisterDbalTypePassMoneyType::class)
+                ->addTag('doctrine.dbal.type', ['type' => 'money']);
+
+            $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
+            $container->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')->setPublic(true);
+            $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+            $container->setAlias('registry_conn2', 'doctrine.dbal.conn2_connection.type_registry')->setPublic(true);
+        });
+
+        $this->assertTypeRegistered($container, 'conn1', 'money', RegisterDbalTypePassMoneyType::class);
+        $this->assertTypeRegistered($container, 'conn2', 'money', RegisterDbalTypePassMoneyType::class);
+    }
+
+    public function testTypeRestrictedToOneConnection(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register('my_type', RegisterDbalTypePassMoneyType::class)
+                ->addTag('doctrine.dbal.type', ['type' => 'money', 'connection' => 'conn1']);
+
+            $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
+            $container->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')->setPublic(true);
+            $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+            $container->setAlias('registry_conn2', 'doctrine.dbal.conn2_connection.type_registry')->setPublic(true);
+        });
+
+        $this->assertTypeRegistered($container, 'conn1', 'money', RegisterDbalTypePassMoneyType::class);
+        $this->assertTypeNotRegistered($container, 'conn2', 'money');
+    }
+
+    public function testAutoconfiguredTypeRestrictedToConnectionViaAttribute(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register('my_type', RegisterDbalTypePassMoneyTypeForConn1::class)
+                ->setAutoconfigured(true);
+
+            $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
+            $container->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')->setPublic(true);
+            $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+            $container->setAlias('registry_conn2', 'doctrine.dbal.conn2_connection.type_registry')->setPublic(true);
+        });
+
+        $this->assertTypeRegistered($container, 'conn1', 'money', RegisterDbalTypePassMoneyTypeForConn1::class);
+        $this->assertTypeNotRegistered($container, 'conn2', 'money');
+    }
+
+    public function testTypeRegisteredOnMultipleConnectionsViaRepeatedAttribute(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register('my_type', RegisterDbalTypePassMultiConnectionType::class)
+                ->setAutoconfigured(true);
+
+            $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
+            $container->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')->setPublic(true);
+            $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+            $container->setAlias('registry_conn2', 'doctrine.dbal.conn2_connection.type_registry')->setPublic(true);
+        });
+
+        $this->assertTypeRegistered($container, 'conn1', 'multi', RegisterDbalTypePassMultiConnectionType::class);
+        $this->assertTypeNotRegistered($container, 'conn1', 'multi_alias');
+        $this->assertTypeNotRegistered($container, 'conn2', 'multi');
+        $this->assertTypeRegistered($container, 'conn2', 'multi_alias', RegisterDbalTypePassMultiConnectionType::class);
+    }
+
+    public function testTypeWithNoNameDefaultsToServiceId(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register(RegisterDbalTypePassAnonymousType::class, RegisterDbalTypePassAnonymousType::class)
+                ->setAutoconfigured(true);
+
+            $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+            $container->setAlias('registry_conn2', 'doctrine.dbal.conn2_connection.type_registry')->setPublic(true);
+        });
+
+        $this->assertTypeRegistered($container, 'conn1', RegisterDbalTypePassAnonymousType::class, RegisterDbalTypePassAnonymousType::class);
+        $this->assertTypeRegistered($container, 'conn2', RegisterDbalTypePassAnonymousType::class, RegisterDbalTypePassAnonymousType::class);
+    }
+
+    public function testTaggedTypeWithNoTypeAttributeDefaultsToServiceId(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register('my_type', RegisterDbalTypePassMoneyType::class)
+                ->addTag('doctrine.dbal.type');
+
+            $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+        });
+
+        $this->assertTypeRegistered($container, 'conn1', 'my_type', RegisterDbalTypePassMoneyType::class);
+    }
+
+    public function testConfigTypesAreIncludedInRegistry(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(
+            static function (ContainerBuilder $container): void {
+                $container->register('my_type', RegisterDbalTypePassMoneyType::class)
+                    ->addTag('doctrine.dbal.type', ['type' => 'money']);
+
+                $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+            },
+            configTypes: ['uuid' => ['class' => RegisterDbalTypePassUuidType::class]],
+        );
+
+        $this->assertTypeRegistered($container, 'conn1', 'money', RegisterDbalTypePassMoneyType::class);
+        $this->assertTypeRegistered($container, 'conn1', 'uuid', RegisterDbalTypePassUuidType::class);
+    }
+
+    public function testTypeRegistryIsSetOnConfiguration(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register('my_type', RegisterDbalTypePassMoneyType::class)
+                ->addTag('doctrine.dbal.type', ['type' => 'money']);
+
+            $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
+        });
+
+        $setTypeRegistryCalls = array_filter(
+            $container->getDefinition('conf_conn1')->getMethodCalls(),
+            static fn (array $call): bool => $call[0] === 'setTypeRegistry',
+        );
+
+        self::assertCount(1, $setTypeRegistryCalls);
+        $registryArg = array_values($setTypeRegistryCalls)[0][1][0];
+
+        if ($registryArg instanceof Reference) {
+            $registryArg = $container->getDefinition((string) $registryArg);
+        }
+
+        self::assertInstanceOf(Definition::class, $registryArg);
+        self::assertSame(TypeRegistry::class, $registryArg->getClass());
+    }
+
+    public function testTypeRegistryIsSetOnOrmConfiguration(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(
+            static function (ContainerBuilder $container): void {
+                $container->register('my_type', RegisterDbalTypePassMoneyType::class)
+                    ->addTag('doctrine.dbal.type', ['type' => 'money']);
+
+                $container->setAlias('orm_conf_conn1', 'doctrine.orm.em_conn1_configuration')->setPublic(true);
+                $container->setAlias('orm_conf_conn2', 'doctrine.orm.em_conn2_configuration')->setPublic(true);
+            },
+            withOrm: true,
+        );
+
+        foreach (['orm_conf_conn1', 'orm_conf_conn2'] as $alias) {
+            $setTypeRegistryCalls = array_filter(
+                $container->getDefinition($alias)->getMethodCalls(),
+                static fn (array $call): bool => $call[0] === 'setTypeRegistry',
+            );
+
+            self::assertCount(1, $setTypeRegistryCalls, sprintf('setTypeRegistry not called on %s', $alias));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for the fallback path (DBAL < 4.5, no TypeRegistry injection)
+    // -----------------------------------------------------------------------
+
+    public function testTaggedTypeAreAddedToConfig(): void
+    {
+        self::requiresNoTypeRegistry();
+
         $container = new ContainerBuilder();
         $container->addCompilerPass(new RegisterDbalTypePass());
 
         $container->setParameter('doctrine.dbal.connection_factory.types', []);
 
-        $container->register('doctrine.dbal.type.bar')
-            ->setClass(BarType::class)
-            ->addTag('doctrine.dbal.type')
-            ->addTag('container.excluded');
+        $container->register(RegisterDbalTypePassBarType::class)
+            ->addTag('doctrine.dbal.type', ['type_name' => 'bar']);
 
         $container->compile();
 
-        self::assertSame(['doctrine.dbal.type.bar' => ['class' => BarType::class]], $container->getParameter('doctrine.dbal.connection_factory.types'));
+        self::assertSame(['bar' => ['class' => RegisterDbalTypePassBarType::class]], $container->getParameter('doctrine.dbal.connection_factory.types'));
     }
 
     public function testTypeMustBeASubclassOfTheDbalBaseType(): void
     {
+        self::requiresNoTypeRegistry();
+
         $container = new ContainerBuilder();
         $container->addCompilerPass(new RegisterDbalTypePass());
 
         $container->setParameter('doctrine.dbal.connection_factory.types', []);
 
-        $container->register(NotASubClassOfDbalBaseType::class)
-            ->addTag('doctrine.dbal.type', ['type_name' => 'invalid_type'])
-            ->addTag('container.excluded');
+        $container->register(RegisterDbalTypePassNotAType::class)
+            ->addTag('doctrine.dbal.type', ['type_name' => 'invalid_type']);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('The "%s" class must extends "%s".', NotASubClassOfDbalBaseType::class, Type::class));
+        $this->expectExceptionMessage(sprintf('The "%s" class must extends "%s".', RegisterDbalTypePassNotAType::class, Type::class));
 
         $container->compile();
     }
+
+    /** @param array<string, array{class: string}> $configTypes */
+    private function createContainer(
+        callable $func,
+        array $configTypes = [],
+        bool $withOrm = false,
+    ): ContainerBuilder {
+        $params = ['kernel.debug' => false];
+        if ($withOrm) {
+            $params['kernel.bundles']          = [];
+            $params['kernel.bundles_metadata'] = [];
+            $params['kernel.project_dir']      = sys_get_temp_dir();
+            $params['kernel.environment']      = 'test';
+            $params['kernel.build_dir']        = sys_get_temp_dir();
+        }
+
+        $container = new ContainerBuilder(new ParameterBag($params));
+
+        $container->registerExtension(new DoctrineExtension());
+
+        $doctrineConfig = [
+            'dbal' => [
+                'connections' => [
+                    'conn1' => ['url' => 'mysql://user:pass@server1.tld:3306/db1'],
+                    'conn2' => ['url' => 'mysql://user:pass@server2.tld:3306/db2'],
+                ],
+                'types' => $configTypes,
+            ],
+        ];
+
+        if ($withOrm) {
+            $doctrineConfig['orm'] = [
+                'entity_managers' => [
+                    'em_conn1' => ['connection' => 'conn1'],
+                    'em_conn2' => ['connection' => 'conn2'],
+                ],
+            ];
+        }
+
+        $container->loadFromExtension('doctrine', $doctrineConfig);
+
+        $container->addCompilerPass(new RegisterDbalTypePass());
+
+        $func($container);
+
+        $container->compile();
+
+        return $container;
+    }
+
+    private function assertTypeRegistered(
+        ContainerBuilder $container,
+        string $connName,
+        string $typeName,
+        string $typeClass,
+    ): void {
+        $registry = $this->getRegistry($container, $connName);
+
+        self::assertTrue($registry->has($typeName), sprintf(
+            'Type "%s" not found in TypeRegistry for connection "%s".',
+            $typeName,
+            $connName,
+        ));
+
+        self::assertInstanceOf($typeClass, $registry->get($typeName));
+    }
+
+    private function assertTypeNotRegistered(ContainerBuilder $container, string $connName, string $typeName): void
+    {
+        $registryId = sprintf('doctrine.dbal.%s_connection.type_registry', $connName);
+
+        if (! $container->hasDefinition($registryId)) {
+            return;
+        }
+
+        $registry = $this->getRegistry($container, $connName);
+
+        self::assertFalse($registry->has($typeName), sprintf(
+            'Type "%s" should not be registered in TypeRegistry for connection "%s".',
+            $typeName,
+            $connName,
+        ));
+    }
+
+    private function getRegistry(ContainerBuilder $container, string $connName): TypeRegistry
+    {
+        return $container->get(sprintf('registry_%s', $connName));
+    }
 }
 
-class BarType extends Type
+class RegisterDbalTypePassMoneyType extends Type
+{
+    public function getSQLDeclaration(mixed $column, AbstractPlatform $platform): string
+    {
+        return 'NUMERIC(10,2)';
+    }
+}
+
+class RegisterDbalTypePassUuidType extends Type
+{
+    public function getSQLDeclaration(mixed $column, AbstractPlatform $platform): string
+    {
+        return 'CHAR(36)';
+    }
+}
+
+#[AsDbalType(name: 'money', connection: 'conn1')]
+class RegisterDbalTypePassMoneyTypeForConn1 extends Type
+{
+    public function getSQLDeclaration(mixed $column, AbstractPlatform $platform): string
+    {
+        return 'NUMERIC(10,2)';
+    }
+}
+
+#[AsDbalType(name: 'multi', connection: 'conn1')]
+#[AsDbalType(name: 'multi_alias', connection: 'conn2')]
+class RegisterDbalTypePassMultiConnectionType extends Type
+{
+    public function getSQLDeclaration(mixed $column, AbstractPlatform $platform): string
+    {
+        return 'VARCHAR(255)';
+    }
+}
+
+#[AsDbalType]
+class RegisterDbalTypePassAnonymousType extends Type
+{
+    public function getSQLDeclaration(mixed $column, AbstractPlatform $platform): string
+    {
+        return 'VARCHAR(255)';
+    }
+}
+
+class RegisterDbalTypePassBarType extends Type
 {
     /** @param array<string, mixed> $column */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
@@ -75,6 +413,6 @@ class BarType extends Type
     }
 }
 
-class NotASubClassOfDbalBaseType
+class RegisterDbalTypePassNotAType
 {
 }

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -281,6 +281,7 @@ class RegisterDbalTypePassTest extends TestCase
             self::assertSame('money', $metadata->fieldMappings['amount']['type']);
 
             if (method_exists(DbalConfiguration::class, 'setTypeProvider')) {
+                /** @phpstan-ignore method.notFound (getTypeProvider() only exists on DBAL >= 4.5) */
                 $typeRegistry = $em->getConnection()->getConfiguration()->getTypeProvider();
                 self::assertInstanceOf(MoneyTypeFixture::class, $typeRegistry->get('money'));
             } else {
@@ -330,27 +331,6 @@ class RegisterDbalTypePassTest extends TestCase
             [['source' => 'by tag "doctrine.dbal.type"']],
             $definition->getTag('container.excluded'),
         );
-    }
-
-    public function testTaggedTypeWithRequiredConstructorArgumentIsRejected(): void
-    {
-        self::requiresNoTypeRegistry();
-
-        $container = new ContainerBuilder();
-        $container->addCompilerPass(new RegisterDbalTypePass());
-
-        $container->setParameter('doctrine.dbal.connection_factory.types', []);
-
-        $container->register(RegisterDbalTypePassTypeWithRequiredArg::class)
-            ->addTag('doctrine.dbal.type', ['type_name' => 'with_required_arg']);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf(
-            'The "%s" DBAL type cannot have required constructor arguments',
-            RegisterDbalTypePassTypeWithRequiredArg::class,
-        ));
-
-        $container->compile();
     }
 
     public function testTypeMustBeASubclassOfTheDbalBaseType(): void
@@ -420,6 +400,7 @@ class RegisterDbalTypePassTest extends TestCase
         return $container;
     }
 
+    /** @param class-string $typeClass */
     private function assertTypeRegistered(
         ContainerBuilder $container,
         string $connName,
@@ -456,7 +437,10 @@ class RegisterDbalTypePassTest extends TestCase
 
     private function getRegistry(ContainerBuilder $container, string $connName): TypeRegistry
     {
-        return $container->get(sprintf('registry_%s', $connName));
+        $registry = $container->get(sprintf('registry_%s', $connName));
+        self::assertInstanceOf(TypeRegistry::class, $registry);
+
+        return $registry;
     }
 }
 
@@ -513,16 +497,21 @@ class RegisterDbalTypePassBarType extends Type
     }
 }
 
-class RegisterDbalTypePassTypeWithRequiredArg extends Type
-{
-    public function __construct(public string $dependency)
+// Doctrine\DBAL\Types\Type::__construct() is final before DBAL 4.5, so a type declaring
+// its own constructor can only be defined when the TypeProvider API is available. The
+// tests using this fixture are skipped on older DBAL versions.
+if (method_exists(DbalConfiguration::class, 'setTypeProvider')) {
+    class RegisterDbalTypePassTypeWithRequiredArg extends Type
     {
-    }
+        public function __construct(public string $dependency)
+        {
+        }
 
-    /** @param array<string, mixed> $column */
-    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
-    {
-        return 'VARCHAR(255)';
+        /** @param array<string, mixed> $column */
+        public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+        {
+            return 'VARCHAR(255)';
+        }
     }
 }
 

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -77,7 +77,7 @@ class RegisterDbalTypePassTest extends TestCase
 
         $container = $this->createContainer(static function (ContainerBuilder $container): void {
             $container->register('my_type', RegisterDbalTypePassMoneyType::class)
-                ->addTag('doctrine.dbal.type', ['type' => 'money']);
+                ->addTag('doctrine.dbal.type', ['type_name' => 'money']);
 
             $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
             $container->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')->setPublic(true);
@@ -113,7 +113,7 @@ class RegisterDbalTypePassTest extends TestCase
 
         $container = $this->createContainer(static function (ContainerBuilder $container): void {
             $container->register('my_type', RegisterDbalTypePassMoneyType::class)
-                ->addTag('doctrine.dbal.type', ['type' => 'money', 'connection' => 'conn1']);
+                ->addTag('doctrine.dbal.type', ['type_name' => 'money', 'connection' => 'conn1']);
 
             $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
             $container->setAlias('conf_conn2', 'doctrine.dbal.conn2_connection.configuration')->setPublic(true);
@@ -200,7 +200,7 @@ class RegisterDbalTypePassTest extends TestCase
         $container = $this->createContainer(
             static function (ContainerBuilder $container): void {
                 $container->register('my_type', RegisterDbalTypePassMoneyType::class)
-                    ->addTag('doctrine.dbal.type', ['type' => 'money']);
+                    ->addTag('doctrine.dbal.type', ['type_name' => 'money']);
 
                 $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
             },
@@ -217,7 +217,7 @@ class RegisterDbalTypePassTest extends TestCase
 
         $container = $this->createContainer(static function (ContainerBuilder $container): void {
             $container->register('my_type', RegisterDbalTypePassMoneyType::class)
-                ->addTag('doctrine.dbal.type', ['type' => 'money']);
+                ->addTag('doctrine.dbal.type', ['type_name' => 'money']);
 
             $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
         });

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -41,7 +41,7 @@ class RegisterDbalTypePassTest extends TestCase
 {
     private static function requiresTypeRegistry(): void
     {
-        if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+        if (method_exists(DbalConfiguration::class, 'setTypeProvider')) {
             return;
         }
 
@@ -50,7 +50,7 @@ class RegisterDbalTypePassTest extends TestCase
 
     private static function requiresNoTypeRegistry(): void
     {
-        if (! method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+        if (! method_exists(DbalConfiguration::class, 'setTypeProvider')) {
             return;
         }
 
@@ -67,7 +67,7 @@ class RegisterDbalTypePassTest extends TestCase
         });
 
         foreach ($container->getDefinition('conf_conn1')->getMethodCalls() as [$method]) {
-            self::assertNotSame('setTypeRegistry', $method);
+            self::assertNotSame('setTypeProvider', $method);
         }
     }
 
@@ -222,13 +222,13 @@ class RegisterDbalTypePassTest extends TestCase
             $container->setAlias('conf_conn1', 'doctrine.dbal.conn1_connection.configuration')->setPublic(true);
         });
 
-        $setTypeRegistryCalls = array_filter(
+        $setTypeProviderCalls = array_filter(
             $container->getDefinition('conf_conn1')->getMethodCalls(),
-            static fn (array $call): bool => $call[0] === 'setTypeRegistry',
+            static fn (array $call): bool => $call[0] === 'setTypeProvider',
         );
 
-        self::assertCount(1, $setTypeRegistryCalls);
-        $registryArg = array_values($setTypeRegistryCalls)[0][1][0];
+        self::assertCount(1, $setTypeProviderCalls);
+        $registryArg = array_values($setTypeProviderCalls)[0][1][0];
 
         if ($registryArg instanceof Reference) {
             $registryArg = $container->getDefinition((string) $registryArg);
@@ -254,12 +254,12 @@ class RegisterDbalTypePassTest extends TestCase
         );
 
         foreach (['orm_conf_conn1', 'orm_conf_conn2'] as $alias) {
-            $setTypeRegistryCalls = array_filter(
+            $setTypeProviderCalls = array_filter(
                 $container->getDefinition($alias)->getMethodCalls(),
-                static fn (array $call): bool => $call[0] === 'setTypeRegistry',
+                static fn (array $call): bool => $call[0] === 'setTypeProvider',
             );
 
-            self::assertCount(1, $setTypeRegistryCalls, sprintf('setTypeRegistry not called on %s', $alias));
+            self::assertCount(1, $setTypeProviderCalls, sprintf('setTypeProvider not called on %s', $alias));
         }
     }
 
@@ -280,8 +280,8 @@ class RegisterDbalTypePassTest extends TestCase
             $metadata = $em->getClassMetadata(MoneyEntity::class);
             self::assertSame('money', $metadata->fieldMappings['amount']['type']);
 
-            if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
-                $typeRegistry = $em->getConnection()->getConfiguration()->getTypeRegistry();
+            if (method_exists(DbalConfiguration::class, 'setTypeProvider')) {
+                $typeRegistry = $em->getConnection()->getConfiguration()->getTypeProvider();
                 self::assertInstanceOf(MoneyTypeFixture::class, $typeRegistry->get('money'));
             } else {
                 self::assertTrue(Type::hasType('money'));

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -89,6 +89,24 @@ class RegisterDbalTypePassTest extends TestCase
         $this->assertTypeRegistered($container, 'conn2', 'money', RegisterDbalTypePassMoneyType::class);
     }
 
+    public function testTypeServiceReceivesInjectedDependencies(): void
+    {
+        self::requiresTypeRegistry();
+
+        $container = $this->createContainer(static function (ContainerBuilder $container): void {
+            $container->register('my_type', RegisterDbalTypePassTypeWithRequiredArg::class)
+                ->addArgument('injected value')
+                ->addTag('doctrine.dbal.type', ['type_name' => 'with_dependency']);
+
+            $container->setAlias('registry_conn1', 'doctrine.dbal.conn1_connection.type_registry')->setPublic(true);
+        });
+
+        $type = $this->getRegistry($container, 'conn1')->get('with_dependency');
+
+        self::assertInstanceOf(RegisterDbalTypePassTypeWithRequiredArg::class, $type);
+        self::assertSame('injected value', $type->dependency);
+    }
+
     public function testTypeRestrictedToOneConnection(): void
     {
         self::requiresTypeRegistry();
@@ -294,6 +312,47 @@ class RegisterDbalTypePassTest extends TestCase
         self::assertSame(['bar' => ['class' => RegisterDbalTypePassBarType::class]], $container->getParameter('doctrine.dbal.connection_factory.types'));
     }
 
+    public function testTaggedTypeDefinitionIsExcludedFromContainer(): void
+    {
+        self::requiresNoTypeRegistry();
+
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new RegisterDbalTypePass());
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $definition = $container->register(RegisterDbalTypePassBarType::class, RegisterDbalTypePassBarType::class)
+            ->addTag('doctrine.dbal.type', ['type_name' => 'bar']);
+
+        (new RegisterDbalTypePass())->process($container);
+
+        self::assertSame(
+            [['source' => 'by tag "doctrine.dbal.type"']],
+            $definition->getTag('container.excluded'),
+        );
+    }
+
+    public function testTaggedTypeWithRequiredConstructorArgumentIsRejected(): void
+    {
+        self::requiresNoTypeRegistry();
+
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new RegisterDbalTypePass());
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $container->register(RegisterDbalTypePassTypeWithRequiredArg::class)
+            ->addTag('doctrine.dbal.type', ['type_name' => 'with_required_arg']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "%s" DBAL type cannot have required constructor arguments',
+            RegisterDbalTypePassTypeWithRequiredArg::class,
+        ));
+
+        $container->compile();
+    }
+
     public function testTypeMustBeASubclassOfTheDbalBaseType(): void
     {
         self::requiresNoTypeRegistry();
@@ -451,6 +510,19 @@ class RegisterDbalTypePassBarType extends Type
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'bar';
+    }
+}
+
+class RegisterDbalTypePassTypeWithRequiredArg extends Type
+{
+    public function __construct(public string $dependency)
+    {
+    }
+
+    /** @param array<string, mixed> $column */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return 'VARCHAR(255)';
     }
 }
 

--- a/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterDbalTypePassTest.php
@@ -7,20 +7,33 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterDbalTypePass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\MoneyEntity;
+use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\MoneyType as MoneyTypeFixture;
+use Doctrine\Bundle\DoctrineBundle\Tests\TestCaseAllPublicCompilerPass;
 use Doctrine\DBAL\Configuration as DbalConfiguration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\TypeRegistry;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Kernel;
 
 use function array_filter;
 use function array_values;
+use function interface_exists;
+use function md5;
 use function method_exists;
+use function set_exception_handler;
 use function sprintf;
 use function sys_get_temp_dir;
 
@@ -28,21 +41,21 @@ class RegisterDbalTypePassTest extends TestCase
 {
     private static function requiresTypeRegistry(): void
     {
-        if (! method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
-            self::markTestSkipped('This test requires DBAL >= 4.5 with TypeRegistry injection support.');
+        if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+            return;
         }
+
+        self::markTestSkipped('This test requires DBAL >= 4.5 with TypeRegistry injection support.');
     }
 
     private static function requiresNoTypeRegistry(): void
     {
-        if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
-            self::markTestSkipped('This test covers the fallback path for DBAL < 4.5 without TypeRegistry support.');
+        if (! method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+            return;
         }
-    }
 
-    // -----------------------------------------------------------------------
-    // Tests for the TypeRegistry path (DBAL >= 4.5)
-    // -----------------------------------------------------------------------
+        self::markTestSkipped('This test covers the fallback path for DBAL < 4.5 without TypeRegistry support.');
+    }
 
     public function testNoTaggedTypesSkipsTypeRegistrySetup(): void
     {
@@ -232,9 +245,37 @@ class RegisterDbalTypePassTest extends TestCase
         }
     }
 
-    // -----------------------------------------------------------------------
-    // Tests for the fallback path (DBAL < 4.5, no TypeRegistry injection)
-    // -----------------------------------------------------------------------
+    public function testCustomTypeIsAvailableForOrmEntityMapping(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $exceptionHandler = set_exception_handler(null);
+
+        $kernel = new RegisterDbalTypePassTestKernel();
+        $kernel->boot();
+
+        try {
+            $em = $kernel->getContainer()->get('doctrine.orm.default_entity_manager');
+
+            $metadata = $em->getClassMetadata(MoneyEntity::class);
+            self::assertSame('money', $metadata->fieldMappings['amount']['type']);
+
+            if (method_exists(DbalConfiguration::class, 'setTypeRegistry')) {
+                $typeRegistry = $em->getConnection()->getConfiguration()->getTypeRegistry();
+                self::assertInstanceOf(MoneyTypeFixture::class, $typeRegistry->get('money'));
+            } else {
+                self::assertTrue(Type::hasType('money'));
+                self::assertInstanceOf(MoneyTypeFixture::class, Type::getType('money'));
+            }
+        } finally {
+            $kernel->shutdown();
+            // The kernel registers Symfony's debug exception handler on boot but does
+            // not restore it on shutdown, so restore it here to avoid a risky test.
+            set_exception_handler($exceptionHandler);
+        }
+    }
 
     public function testTaggedTypeAreAddedToConfig(): void
     {
@@ -415,4 +456,52 @@ class RegisterDbalTypePassBarType extends Type
 
 class RegisterDbalTypePassNotAType
 {
+}
+
+class RegisterDbalTypePassTestKernel extends Kernel
+{
+    public function __construct()
+    {
+        parent::__construct('test', true);
+    }
+
+    /** @return iterable<Bundle> */
+    public function registerBundles(): iterable
+    {
+        return [new FrameworkBundle(), new DoctrineBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(static function (ContainerBuilder $container): void {
+            $container->loadFromExtension('framework', [
+                'secret' => 'F00',
+                'http_method_override' => false,
+                'php_errors' => ['log' => true],
+                'handle_all_throwables' => true,
+            ]);
+            $container->loadFromExtension('doctrine', [
+                'dbal' => ['driver' => 'pdo_sqlite'],
+                'orm' => [
+                    'mappings' => [
+                        'Fixtures' => [
+                            'type' => 'attribute',
+                            'dir' => __DIR__ . '/../Fixtures',
+                            'prefix' => 'Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures',
+                            'is_bundle' => false,
+                        ],
+                    ],
+                ],
+            ]);
+            $container->register(MoneyTypeFixture::class)
+                ->setAutoconfigured(true);
+            $container->register('logger', NullLogger::class);
+            $container->getCompilerPassConfig()->addPass(new TestCaseAllPublicCompilerPass());
+        });
+    }
+
+    public function getProjectDir(): string
+    {
+        return sys_get_temp_dir() . '/sf_kernel_' . md5(static::class);
+    }
 }

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -953,8 +953,8 @@ class DoctrineExtensionTest extends TestCase
     }
 
     /** @param class-string $typeClassname */
-    #[DataProvider('provideDatabaseTypeAttribute')]
-    public function testAsDatabaseTypeAttribute(string $typeClassname, string $expectedTypeName): void
+    #[DataProvider('provideDbalTypeAttribute')]
+    public function testAsDbalTypeAttribute(string $typeClassname, string $expectedTypeName): void
     {
         $container = $this->getContainer();
         $extension = new DoctrineExtension();
@@ -978,13 +978,13 @@ class DoctrineExtensionTest extends TestCase
 
         $attributes[AsDbalType::class]($definition, $attribute, $reflector);
 
-        $expected = ['type_name' => $expectedTypeName];
+        $expected = ['type_name' => $expectedTypeName, 'connection' => null];
         $this->assertSame([$expected], $definition->getTag('doctrine.dbal.type'));
-        $this->assertSame([['source' => 'by tag "doctrine.dbal.type"']], $definition->getTag('container.excluded'));
+        $this->assertSame([], $definition->getTag('container.excluded'), 'The type is a service, not excluded');
     }
 
     /** @return array<array{0: class-string, 1: string}> */
-    public static function provideDatabaseTypeAttribute(): array
+    public static function provideDbalTypeAttribute(): array
     {
         return [
             'with type name' => [DbalType::class, 'dbal_type'],

--- a/tests/DependencyInjection/Fixtures/MoneyEntity.php
+++ b/tests/DependencyInjection/Fixtures/MoneyEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class MoneyEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $id = 1;
+
+    #[ORM\Column(type: 'money')]
+    private string $amount = '0.00';
+}

--- a/tests/DependencyInjection/Fixtures/MoneyEntity.php
+++ b/tests/DependencyInjection/Fixtures/MoneyEntity.php
@@ -12,8 +12,8 @@ class MoneyEntity
 {
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
-    private int $id = 1;
+    public int $id = 1;
 
     #[ORM\Column(type: 'money')]
-    private string $amount = '0.00';
+    public string $amount = '0.00';
 }

--- a/tests/DependencyInjection/Fixtures/MoneyType.php
+++ b/tests/DependencyInjection/Fixtures/MoneyType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+#[AsDbalType(name: 'money')]
+class MoneyType extends Type
+{
+    /** @param array<string, mixed> $column */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return 'NUMERIC(10,2)';
+    }
+}


### PR DESCRIPTION
Update the `#[AsDbalType]` PHP attribute and a `RegisterDbalTypePass` compiler pass to register Doctrine DBAL types as Symfony services with a per-connection `TypeRegistry`, without touching the global static type registry.

The PR https://github.com/doctrine/DoctrineBundle/pull/2197 that added this attribute only supports injection of class names into the configuration. This PR requires DBAL and ORM changes to inject services.

## How it works

- A new `#[AsDbalType(name: 'money')]` attribute tags the service with `doctrine.dbal.type`
- `RegisterDbalTypePass` builds a `TypeRegistry` per connection, populated with:
  - Config-based types (`doctrine.dbal.types`) as inline definitions
  - Service-tagged types as service references, resolved lazily through a `ServiceLocator`
- The `TypeRegistry` is wired to both the DBAL `Configuration` and the ORM `Configuration` of each associated entity manager
- Types can be restricted to specific connections by repeating the attribute: `#[AsDbalType(name: 'money', connection: 'reporting')]`

Because types are registered as services and resolved lazily, they support full dependency injection: a type class can declare constructor arguments and receive autowired or explicitly configured dependencies.

## Example

```php
use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
use Doctrine\DBAL\Platforms\AbstractPlatform;
use Doctrine\DBAL\Types\Type;

#[AsDbalType(name: self::class /* by default */)]
final class MoneyType extends Type
{
    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
    {
        return $platform->getDecimalTypeDeclarationSQL($column);
    }
}
```

```php
#[ORM\Column(type: MoneyType::class)]
private Money $price;
```

## Backward compatibility (DBAL < 4.5)

Per-connection `TypeRegistry` injection requires DBAL >= 4.5. On older versions, the compiler pass falls back to registering the types in the global type registry through `doctrine.dbal.connection_factory.types`. This fallback has two limitations, both enforced at compile time:

- Dependency injection is not available: DBAL instantiates types with `new $class()`, so a type whose constructor has mandatory arguments is rejected with a clear error message.
- Per-connection restriction is not supported; types apply to all connections.

In this fallback, the type service definition is marked `container.excluded` since the type is instantiated by DBAL rather than consumed as a service.

## Dependencies

This PR depends on changes in DBAL and ORM to support per-connection `TypeRegistry`:

- DBAL doctrine/dbal#7342
- ORM doctrine/orm#12421

## Demo

A working example using `#[AsDbalType]` to store emails as base64 in the database is available at: https://github.com/GromNaN/symfony-demo/pull/5
