### PR TITLE
Add support for inferNullabilityFromPHPType mapping option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^14",
-        "doctrine/orm": "^3.4.4",
+        "doctrine/orm": "3.7.x-dev#5e9e57c49ccb36b7591e348cdffde3816558dd9a as 3.7.0",
         "phpstan/phpstan": "^2.1.13",
         "phpstan/phpstan-phpunit": "2.0.3",
         "phpstan/phpstan-strict-rules": "^2",

--- a/config/schema/doctrine-1.0.xsd
+++ b/config/schema/doctrine-1.0.xsd
@@ -131,6 +131,7 @@
         <xsd:attribute name="alias" type="xsd:string" />
         <xsd:attribute name="prefix" type="xsd:string" />
         <xsd:attribute name="is-bundle" type="xsd:string" />
+        <xsd:attribute name="infer-nullability-from-php-type" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="orm">

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -651,6 +651,7 @@ final class Configuration implements ConfigurationInterface
                                 ->scalarNode('alias')->end()
                                 ->scalarNode('prefix')->end()
                                 ->booleanNode('is_bundle')->end()
+                                ->booleanNode('infer_nullability_from_php_type')->defaultFalse()->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -115,6 +115,9 @@ final class DoctrineExtension extends Extension
      */
     private array $drivers = [];
 
+    /** @var array<string, bool> List of prefix => inferNullabilityFromPHPType */
+    private array $inferNullabilityFromPHPType = [];
+
     /**
      * @param array<string, mixed> $objectManager A configured object manager
      *
@@ -220,6 +223,12 @@ final class DoctrineExtension extends Extension
         }
 
         $this->drivers[$mappingConfig['type']][$mappingConfig['prefix']] = realpath($mappingDirectory) ?: $mappingDirectory;
+
+        if (empty($mappingConfig['infer_nullability_from_php_type'])) {
+            return;
+        }
+
+        $this->inferNullabilityFromPHPType[$mappingConfig['prefix']] = true;
     }
 
     /**
@@ -288,20 +297,41 @@ final class DoctrineExtension extends Extension
         }
 
         foreach ($this->drivers as $driverType => $driverPaths) {
-            $mappingService   = $this->getObjectManagerElementName($objectManager['name'] . '_' . $driverType . '_metadata_driver');
-            $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
-                array_values($driverPaths),
-            ]);
-
-            if ($mappingDriverDef->getClass() === SimplifiedXmlDriver::class) {
-                $mappingDriverDef->setArguments([array_flip($driverPaths)]);
-                $mappingDriverDef->addMethodCall('setGlobalBasename', ['mapping']);
+            // split paths by inferNullabilityFromPHPType to create separate driver instances
+            $groups = [false => [], true => []];
+            foreach ($driverPaths as $prefix => $driverPath) {
+                $infer                   = $this->inferNullabilityFromPHPType[$prefix] ?? false;
+                $groups[$infer][$prefix] = $driverPath;
             }
 
-            $container->setDefinition($mappingService, $mappingDriverDef);
+            foreach ($groups as $inferNullability => $paths) {
+                if ($paths === []) {
+                    continue;
+                }
 
-            foreach ($driverPaths as $prefix => $driverPath) {
-                $chainDriverDef->addMethodCall('addDriver', [new Reference($mappingService), $prefix]);
+                $suffix           = $inferNullability ? '_infer_nullability' : '';
+                $mappingService   = $this->getObjectManagerElementName($objectManager['name'] . '_' . $driverType . $suffix . '_metadata_driver');
+                $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
+                    array_values($paths),
+                ]);
+
+                if ($mappingDriverDef->getClass() === SimplifiedXmlDriver::class) {
+                    $args = [array_flip($paths), SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION, true];
+                    if ($inferNullability) {
+                        $args[] = true;
+                    }
+
+                    $mappingDriverDef->setArguments($args);
+                    $mappingDriverDef->addMethodCall('setGlobalBasename', ['mapping']);
+                } elseif ($inferNullability) {
+                    $mappingDriverDef->setArgument('$inferNullabilityFromPHPType', true);
+                }
+
+                $container->setDefinition($mappingService, $mappingDriverDef);
+
+                foreach ($paths as $prefix => $driverPath) {
+                    $chainDriverDef->addMethodCall('addDriver', [new Reference($mappingService), $prefix]);
+                }
             }
         }
 
@@ -1081,8 +1111,9 @@ final class DoctrineExtension extends Extension
     private function loadOrmEntityManagerMappingInformation(array $entityManager, Definition $ormConfigDef, ContainerBuilder $container): void
     {
         // reset state of drivers and alias map. They are only used by this methods and children.
-        $this->drivers  = [];
-        $this->aliasMap = [];
+        $this->drivers                     = [];
+        $this->aliasMap                    = [];
+        $this->inferNullabilityFromPHPType = [];
 
         $this->loadMappingInformation($entityManager, $container);
         $this->registerMappingDrivers($entityManager, $container);
@@ -1090,17 +1121,24 @@ final class DoctrineExtension extends Extension
         $container->getDefinition($this->getObjectManagerElementName($entityManager['name'] . '_metadata_driver'));
         /** @psalm-suppress NoValue $this->drivers is set by $this->loadMappingInformation() call  */
         foreach (array_keys($this->drivers) as $driverType) {
-            $mappingService   = $this->getObjectManagerElementName($entityManager['name'] . '_' . $driverType . '_metadata_driver');
-            $mappingDriverDef = $container->getDefinition($mappingService);
-            $args             = $mappingDriverDef->getArguments();
             if ($driverType !== 'xml') {
                 continue;
             }
 
-            $args[1] ??= SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION;
-            $args[2]   = $entityManager['validate_xml_mapping'];
+            foreach (['', '_infer_nullability'] as $suffix) {
+                $mappingService = $this->getObjectManagerElementName($entityManager['name'] . '_' . $driverType . $suffix . '_metadata_driver');
+                if (! $container->hasDefinition($mappingService)) {
+                    continue;
+                }
 
-            $mappingDriverDef->setArguments($args);
+                $mappingDriverDef = $container->getDefinition($mappingService);
+                $args             = $mappingDriverDef->getArguments();
+
+                $args[1] ??= SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION;
+                $args[2]   = $entityManager['validate_xml_mapping'];
+
+                $mappingDriverDef->setArguments($args);
+            }
         }
 
         $ormConfigDef->addMethodCall('setEntityNamespaces', [$this->aliasMap]);

--- a/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractDoctrineExtensionTestCase.php
@@ -456,6 +456,28 @@ abstract class AbstractDoctrineExtensionTestCase extends TestCase
         ]);
     }
 
+    public function testInferNullabilityFromPHPType(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->loadContainer('orm_infer_nullability', ['XmlBundle', 'AttributesBundle']);
+
+        $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
+
+        $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', [
+            new Reference('doctrine.orm.default_attribute_infer_nullability_metadata_driver'),
+            'Fixtures\Bundles\AttributesBundle\Entity',
+        ]);
+
+        $attrDef = $container->getDefinition('doctrine.orm.default_attribute_infer_nullability_metadata_driver');
+        $this->assertEquals(true, $attrDef->getArgument('$inferNullabilityFromPHPType'));
+
+        $xmlDef = $container->getDefinition('doctrine.orm.default_xml_metadata_driver');
+        $this->assertCount(3, $xmlDef->getArguments());
+    }
+
     /** Remove the attribute and keep the test in 3.0.x */
     #[IgnoreDeprecations]
     public function testMultipleEntityManagersMappingBundleDefinitions(): void

--- a/tests/DependencyInjection/Fixtures/config/xml/orm_infer_nullability.xml
+++ b/tests/DependencyInjection/Fixtures/config/xml/orm_infer_nullability.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
+        <orm>
+            <mapping name="AttributesBundle" type="attribute" infer-nullability-from-php-type="true" />
+            <mapping name="XmlBundle" dir="Resources/config/doctrine" alias="xml" />
+        </orm>
+    </config>
+</srv:container>

--- a/tests/DependencyInjection/Fixtures/config/yml/orm_infer_nullability.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/orm_infer_nullability.yml
@@ -1,0 +1,15 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        mappings:
+            AttributesBundle:
+                type: attribute
+                infer_nullability_from_php_type: true
+            XmlBundle:
+                dir: Resources/config/doctrine
+                alias: xml


### PR DESCRIPTION
Adds `infer_nullability_from_php_type` per-mapping option, passing `inferNullabilityFromPHPType` to the driver constructor from doctrine/orm#11814.

Mappings with this enabled get a separate driver instance since the flag is a constructor parameter.

If naming feels too long feel free to rename it, it was originally shorter but [it was suggested to me to use this one](https://github.com/doctrine/orm/pull/11814#issuecomment-2752395734) so I thought I'd use the same naming here.

Depends on doctrine/orm#11814.