### PR TITLE
Allow Doctrine ORM 4 on the 4.0.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "twig/twig": "^3.21.1"
     },
     "conflict": {
-        "doctrine/orm": "<3.0 || >=4.0",
+        "doctrine/orm": "<3.0",
         "twig/twig": "<3.0.4"
     },
     "suggest": {


### PR DESCRIPTION
The `4.0.x` branch already requires `doctrine/dbal: ^4.0` and `doctrine/persistence: ^4`, signalling that this branch tracks the ORM 4 release line. However the `conflict` entry still blocks `doctrine/orm >=4.0`, which prevents installing this branch alongside `doctrine/orm: ^4.0@dev`.

This PR lowers the conflict's upper bound so the branch can be installed with ORM 4-dev. The lower bound `<3.0` is preserved.

Tested locally: with this change applied, `composer update` resolves cleanly for a Symfony bundle requiring `doctrine/orm: ^4.0@dev` together with `doctrine/doctrine-bundle: dev-4.0.x`. Composer installs `doctrine/orm 4.0.x-dev`, `doctrine/dbal 4.4.x`, and `doctrine/persistence 4.2.x` (all stable except orm).

Happy to adjust if maintainers prefer `<3.0 || >=5.0` (orm 3 + 4 only) or the line removed entirely.