### PR TITLE
Remove mention of lazy entity listeners

### DIFF
--- a/docs/en/entity-listeners.rst
+++ b/docs/en/entity-listeners.rst
@@ -122,32 +122,3 @@ back on the ``__invoke()`` method.
 See also
 https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html#entity-listeners
 for more info on entity listeners and the resolver required by Symfony.
-
-Lazy Entity Listeners
----------------------
-
-You can use the ``lazy`` attribute on the tag to make sure the listener services
-are only instantiated when they are actually used.
-    
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        services:
-            App\UserListener:
-                tags:
-                    - { name: doctrine.orm.entity_listener, lazy: true }
-                    
-    .. code-block:: xml
-
-        <?xml version="1.0" ?>
-
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-            <services>
-                <service id="App\UserListener">
-                    <tag name="doctrine.orm.entity_listener" event="preUpdate" entity="App\Entity\User" lazy="true" />            
-                </service>
-            </services>
-        </container>


### PR DESCRIPTION
There are by default since https://github.com/doctrine/DoctrineBundle/pull/951

Paired with https://github.com/symfony/symfony-docs/pull/22335