### PR TITLE
[Bug] Lower EntityValueResolver priority below Request/Session value resolvers

### DIFF
--- a/config/orm.php
+++ b/config/orm.php
@@ -265,7 +265,7 @@ return static function (ContainerConfigurator $container): void {
                 service('doctrine'),
                 service('doctrine.orm.entity_value_resolver.expression_language')->ignoreOnInvalid(),
             ])
-            ->tag('controller.argument_value_resolver', ['priority' => 110, 'name' => EntityValueResolver::class])
+            ->tag('controller.argument_value_resolver', ['priority' => 40, 'name' => EntityValueResolver::class])
 
         ->set('doctrine.orm.entity_value_resolver.expression_language', ExpressionLanguage::class)
 

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -1507,6 +1507,30 @@ class DoctrineExtensionTest extends TestCase
         $this->assertEquals(new MapEntity(null, null, null, [], null, null, null, true, true), $container->get('controller_resolver_defaults'));
     }
 
+    #[RequiresMethod(EntityValueResolver::class, '__construct')]
+    public function testEntityValueResolverPriorityIsBelowRequestAndSessionResolvers(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->getContainer();
+        $extension = new DoctrineExtension();
+        $config    = BundleConfigurationBuilder::createBuilderWithBaseValues()->build();
+
+        $extension->load([DeprecationFreeConfig::get(), $config], $container);
+
+        $tags = $container->getDefinition('doctrine.orm.entity_value_resolver')->getTag('controller.argument_value_resolver');
+
+        $this->assertCount(1, $tags);
+        $this->assertArrayHasKey('priority', $tags[0]);
+        $this->assertLessThan(
+            50,
+            $tags[0]['priority'],
+            'EntityValueResolver must be tagged below FrameworkBundle Request/Session value resolvers (priority 50) so it does not bootstrap an entity manager on controllers that only declare Request or Session arguments. See symfony/symfony#54337.',
+        );
+    }
+
     #[TestWith(['AnnotationsBundle', 'attribute', 'Vendor'], 'Bundle without anything')]
     #[TestWith(['AttributesBundle', 'attribute'], 'Bundle with attributes')]
     #[TestWith(['RepositoryServiceBundle', 'attribute'], 'Bundle with both')]


### PR DESCRIPTION
Follow-up to symfony/symfony#54337 and symfony/symfony#64189, where Nicolas Grekas suggested patching DoctrineBundle instead of FrameworkBundle.

`doctrine.orm.entity_value_resolver` is tagged with priority `110`, which places it above every FrameworkBundle resolver — including `RequestValueResolver` and `SessionValueResolver` at priority `50`. For every controller argument typed `Request` or `Session`, `EntityValueResolver::resolve()` runs first and calls `ManagerRegistry::getManagerForClass()`, bootstrapping the EM just to discover the argument is not an entity. The reporter measures a 40-50 ms hit per request on a fresh `symfony/skeleton` + `symfony/webapp-pack`.

Lowering the tag priority to `40` (below FrameworkBundle's `Request` and `Session` resolvers at 50, and below `BackedEnum`/`Uid`/`DateTime`/`RequestAttribute` at 100) lets those resolvers claim their narrow-typed arguments first; `EntityValueResolver` only runs for arguments none of them resolved, so the EM is not bootstrapped for `Request \$request` / `SessionInterface \$session` controllers.

Behavior for entity-typed arguments (`User \$user` etc.) is unchanged — none of the earlier resolvers claim user-land entity types, so the chain falls through to `EntityValueResolver` exactly as before.

Target: `2.18.x` (lowest maintained branch where the bug exists; the fix propagates upward via the merge-up branches).

Test asserts the tag priority is strictly less than `50`. Verified locally: reverting the priority change makes the test fail with "Failed asserting that 110 is less than 50."

