### PR TITLE
Add functional regression test for EntityValueResolver on primary-key routes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "symfony/flex": true
+            "symfony/flex": true,
+            "symfony/runtime": false
         },
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "symfony/http-kernel": "^6.4 || ^7.0",
         "symfony/messenger": "^6.4 || ^7.0",
         "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/runtime": "^6.4 || ^7.0",
         "symfony/security-bundle": "^6.4 || ^7.0",
         "symfony/stopwatch": "^6.4 || ^7.0",
         "symfony/string": "^6.4 || ^7.0",

--- a/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
+++ b/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver;
 use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\EntityValueResolverFunctionalKernel;
 use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\Post;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -38,7 +37,9 @@ class EntityValueResolverFunctionalTest extends TestCase
             $em        = $container->get('doctrine.orm.default_entity_manager');
             assert($em instanceof EntityManagerInterface);
 
-            (new SchemaTool($em))->createSchema([$em->getClassMetadata(Post::class)]);
+            $em->getConnection()->executeStatement(
+                'CREATE TABLE posts (id INTEGER NOT NULL, title VARCHAR(255) NOT NULL, PRIMARY KEY(id))',
+            );
 
             $post = new Post('Hello world');
             $em->persist($post);

--- a/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
+++ b/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
@@ -6,11 +6,6 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver;
 
 use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\EntityValueResolverFunctionalKernel;
 use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\Post;
-use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
-use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,32 +37,15 @@ class EntityValueResolverFunctionalTest extends TestCase
             $em        = $container->get('doctrine.orm.default_entity_manager');
             assert($em instanceof EntityManagerInterface);
 
-            $table = Table::editor()
-                ->setUnquotedName('posts')
-                ->addColumn(
-                    Column::editor()
-                        ->setUnquotedName('id')
-                        ->setTypeName(Types::INTEGER)
-                        ->setNotNull(true)
-                        ->setAutoincrement(true)
-                        ->create(),
-                )
-                ->addColumn(
-                    Column::editor()
-                        ->setUnquotedName('title')
-                        ->setTypeName(Types::STRING)
-                        ->setNotNull(true)
-                        ->create(),
-                )
-                ->setPrimaryKeyConstraint(
-                    new PrimaryKeyConstraint(null, [UnqualifiedName::unquoted('id')], false),
-                )
-                ->create();
-
-            $connection = $em->getConnection();
-            foreach ($connection->getDatabasePlatform()->getCreateTablesSQL([$table]) as $sql) {
-                $connection->executeStatement($sql);
-            }
+            // SchemaTool::createSchema triggers Schema::createTable, deprecated in
+            // DBAL 4 (https://github.com/doctrine/dbal/pull/7373); the DBAL 4 fluent
+            // replacement (Table::editor() / Column::editor()) is unavailable on
+            // DBAL 3 which this branch must still support, so a raw CREATE TABLE is
+            // emitted directly through the connection. The test kernel is SQLite-
+            // only, so a SQLite literal is safe here.
+            $em->getConnection()->executeStatement(
+                'CREATE TABLE posts (id INTEGER NOT NULL, title VARCHAR(255) NOT NULL, PRIMARY KEY(id))',
+            );
 
             $post = new Post('Hello world');
             $em->persist($post);

--- a/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
+++ b/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
@@ -8,10 +8,7 @@ use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\EntityValueRe
 use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\Post;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
-use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Component\HttpFoundation\Request;
 
 use function assert;
@@ -26,10 +23,8 @@ use function restore_exception_handler;
  * value resolvers) must stay compatible so that the entity argument is still
  * populated from the route placeholder.
  */
-#[RequiresMethod(EntityValueResolver::class, '__construct')]
 class EntityValueResolverFunctionalTest extends TestCase
 {
-    #[IgnoreDeprecations]
     public function testEntityArgumentResolvedFromRoutePlaceholder(): void
     {
         if (! interface_exists(EntityManagerInterface::class)) {
@@ -39,26 +34,28 @@ class EntityValueResolverFunctionalTest extends TestCase
         $kernel = new EntityValueResolverFunctionalKernel();
         $kernel->boot();
 
-        $container = $kernel->getContainer();
-        $em        = $container->get('doctrine.orm.default_entity_manager');
-        assert($em instanceof EntityManagerInterface);
+        try {
+            $container = $kernel->getContainer();
+            $em        = $container->get('doctrine.orm.default_entity_manager');
+            assert($em instanceof EntityManagerInterface);
 
-        (new SchemaTool($em))->createSchema([$em->getClassMetadata(Post::class)]);
+            (new SchemaTool($em))->createSchema([$em->getClassMetadata(Post::class)]);
 
-        $post = new Post('Hello world');
-        $em->persist($post);
-        $em->flush();
-        $em->clear();
+            $post = new Post('Hello world');
+            $em->persist($post);
+            $em->flush();
+            $em->clear();
 
-        $response = $kernel->handle(Request::create('/posts/' . $post->id, 'GET'));
+            $response = $kernel->handle(Request::create('/posts/' . $post->id, 'GET'));
 
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame(
-            ['id' => $post->id, 'title' => 'Hello world'],
-            json_decode((string) $response->getContent(), true),
-        );
-
-        $kernel->shutdown();
-        restore_exception_handler();
+            self::assertSame(200, $response->getStatusCode());
+            self::assertSame(
+                ['id' => $post->id, 'title' => 'Hello world'],
+                json_decode((string) $response->getContent(), true),
+            );
+        } finally {
+            $kernel->shutdown();
+            restore_exception_handler();
+        }
     }
 }

--- a/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
+++ b/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver;
+
+use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\EntityValueResolverFunctionalKernel;
+use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\Post;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
+use Symfony\Component\HttpFoundation\Request;
+
+use function assert;
+use function interface_exists;
+use function json_decode;
+use function restore_exception_handler;
+
+/**
+ * Regression coverage for the /posts/{post} + Post $post happy path resolved by
+ * Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver. The tag priority
+ * configured in config/orm.php (and the priorities of FrameworkBundle's own
+ * value resolvers) must stay compatible so that the entity argument is still
+ * populated from the route placeholder.
+ */
+#[RequiresMethod(EntityValueResolver::class, '__construct')]
+class EntityValueResolverFunctionalTest extends TestCase
+{
+    #[IgnoreDeprecations]
+    public function testEntityArgumentResolvedFromRoutePlaceholder(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $kernel = new EntityValueResolverFunctionalKernel();
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+        $em        = $container->get('doctrine.orm.default_entity_manager');
+        assert($em instanceof EntityManagerInterface);
+
+        (new SchemaTool($em))->createSchema([$em->getClassMetadata(Post::class)]);
+
+        $post = new Post('Hello world');
+        $em->persist($post);
+        $em->flush();
+        $em->clear();
+
+        $response = $kernel->handle(Request::create('/posts/' . $post->id, 'GET'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(
+            ['id' => $post->id, 'title' => 'Hello world'],
+            json_decode((string) $response->getContent(), true),
+        );
+
+        $kernel->shutdown();
+        restore_exception_handler();
+    }
+}

--- a/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
+++ b/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
@@ -6,6 +6,11 @@ namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver;
 
 use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\EntityValueResolverFunctionalKernel;
 use Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures\Post;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -37,9 +42,32 @@ class EntityValueResolverFunctionalTest extends TestCase
             $em        = $container->get('doctrine.orm.default_entity_manager');
             assert($em instanceof EntityManagerInterface);
 
-            $em->getConnection()->executeStatement(
-                'CREATE TABLE posts (id INTEGER NOT NULL, title VARCHAR(255) NOT NULL, PRIMARY KEY(id))',
-            );
+            $table = Table::editor()
+                ->setUnquotedName('posts')
+                ->addColumn(
+                    Column::editor()
+                        ->setUnquotedName('id')
+                        ->setTypeName(Types::INTEGER)
+                        ->setNotNull(true)
+                        ->setAutoincrement(true)
+                        ->create(),
+                )
+                ->addColumn(
+                    Column::editor()
+                        ->setUnquotedName('title')
+                        ->setTypeName(Types::STRING)
+                        ->setNotNull(true)
+                        ->create(),
+                )
+                ->setPrimaryKeyConstraint(
+                    new PrimaryKeyConstraint(null, [UnqualifiedName::unquoted('id')], false),
+                )
+                ->create();
+
+            $connection = $em->getConnection();
+            foreach ($connection->getDatabasePlatform()->getCreateTablesSQL([$table]) as $sql) {
+                $connection->executeStatement($sql);
+            }
 
             $post = new Post('Hello world');
             $em->persist($post);

--- a/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
+++ b/tests/ArgumentResolver/EntityValueResolverFunctionalTest.php
@@ -14,7 +14,6 @@ use Symfony\Component\HttpFoundation\Request;
 use function assert;
 use function interface_exists;
 use function json_decode;
-use function restore_exception_handler;
 
 /**
  * Regression coverage for the /posts/{post} + Post $post happy path resolved by
@@ -55,7 +54,6 @@ class EntityValueResolverFunctionalTest extends TestCase
             );
         } finally {
             $kernel->shutdown();
-            restore_exception_handler();
         }
     }
 }

--- a/tests/ArgumentResolver/Fixtures/EntityValueResolverFunctionalKernel.php
+++ b/tests/ArgumentResolver/Fixtures/EntityValueResolverFunctionalKernel.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\ORM\Configuration;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+use function md5;
+use function method_exists;
+use function mt_rand;
+use function sys_get_temp_dir;
+
+use const PHP_VERSION_ID;
+
+class EntityValueResolverFunctionalKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    private string|null $projectDir = null;
+
+    public function __construct()
+    {
+        parent::__construct('test', true);
+    }
+
+    /** @return iterable<BundleInterface> */
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineBundle(),
+        ];
+    }
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->extension('framework', [
+            'secret' => 'F00',
+            'http_method_override' => false,
+            'annotations' => false,
+            'php_errors' => ['log' => true],
+            'handle_all_throwables' => true,
+            'router' => ['utf8' => true],
+            'test' => true,
+        ]);
+
+        $container->extension('doctrine', [
+            'dbal' => [
+                'driver' => 'pdo_sqlite',
+                'memory' => true,
+                'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
+            ],
+            'orm' => [
+                'controller_resolver' => ['auto_mapping' => true],
+                'enable_lazy_ghost_objects' => true,
+                /** @phpstan-ignore function.alreadyNarrowedType */
+                'enable_native_lazy_objects' => PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects'),
+                'mappings' => [
+                    'PostFixtures' => [
+                        'type' => 'attribute',
+                        'dir' => __DIR__,
+                        'prefix' => 'Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures',
+                    ],
+                ],
+            ],
+        ]);
+
+        $services = $container->services();
+        $services->set('logger', NullLogger::class);
+        $services->set(PostController::class)
+            ->autowire()
+            ->autoconfigure()
+            ->public()
+            ->tag('controller.service_arguments');
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->add('post_show', '/posts/{post}')->controller(PostController::class);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->projectDir ??= sys_get_temp_dir() . '/sf_evr_kernel_' . md5((string) mt_rand());
+    }
+}

--- a/tests/ArgumentResolver/Fixtures/EntityValueResolverFunctionalKernel.php
+++ b/tests/ArgumentResolver/Fixtures/EntityValueResolverFunctionalKernel.php
@@ -60,7 +60,7 @@ class EntityValueResolverFunctionalKernel extends Kernel
                 'schema_manager_factory' => 'doctrine.dbal.default_schema_manager_factory',
             ],
             'orm' => [
-                'controller_resolver' => ['auto_mapping' => true],
+                'controller_resolver' => ['auto_mapping' => false],
                 'enable_lazy_ghost_objects' => true,
                 /** @phpstan-ignore function.alreadyNarrowedType */
                 'enable_native_lazy_objects' => PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'enableNativeLazyObjects'),

--- a/tests/ArgumentResolver/Fixtures/Post.php
+++ b/tests/ArgumentResolver/Fixtures/Post.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'posts')]
+class Post
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: Types::INTEGER)]
+    public int|null $id = null;
+
+    public function __construct(
+        #[ORM\Column(type: Types::STRING)]
+        public string $title,
+    ) {
+    }
+}

--- a/tests/ArgumentResolver/Fixtures/PostController.php
+++ b/tests/ArgumentResolver/Fixtures/PostController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\ArgumentResolver\Fixtures;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class PostController
+{
+    public function __invoke(Post $post): JsonResponse
+    {
+        return new JsonResponse(['id' => $post->id, 'title' => $post->title]);
+    }
+}


### PR DESCRIPTION
Focused follow-up to #2229: drop the priority-change approach (rejected as a perf optimisation rather than a bug fix), keep only the regression test stof requested.

> Btw, a valuable contribution to DoctrineBundle would be to add a functional test for this `/posts/{post}` + `Post $post` use case, so that the testsuite catches regressions
> — stof on #2229 (https://github.com/doctrine/DoctrineBundle/pull/2229#issuecomment-3548470770)

Past attempts at lowering `EntityValueResolver`'s tag priority (#1574, #1578) broke this exact scenario and had to be reverted within 24 hours. The `symfony/doctrine-bridge` unit tests do not catch it — it requires a real kernel, a real router and a real `EntityManager`.

## What the test does

- Boots a `MicroKernelTrait` kernel with `FrameworkBundle` + `DoctrineBundle` and an in-memory sqlite DBAL.
- Maps a `Post` entity, declares a `/posts/{post}` route bound to a controller with `__invoke(Post $post)`.
- Persists a `Post`, hits the route, asserts `200` + the JSON body matches the resolved entity.

## Regression check

Verified locally: dropping the `controller.argument_value_resolver` tag priority to `40` in `config/orm.php` (the change that was previously rejected on #2229) flips the response from `200` to `500` — the test fails closed.

## Scope

Test-only: 4 new files under `tests/ArgumentResolver/`, no runtime change. Targeted at `2.18.x` so the coverage propagates upward via the merge-up branches.

Once this lands, #2229 can be closed (already de-facto rejected).