### PR TITLE
Remove empty registerCommands override

### DIFF
--- a/src/DoctrineBundle.php
+++ b/src/DoctrineBundle.php
@@ -20,7 +20,6 @@ use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListen
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterUidTypePass;
 use Symfony\Bridge\Doctrine\DependencyInjection\Security\UserProvider\EntityFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -109,10 +108,6 @@ class DoctrineBundle extends Bundle
             assert($connection instanceof Connection);
             $connection->close();
         }
-    }
-
-    public function registerCommands(Application $application): void
-    {
     }
 
     public function getPath(): string


### PR DESCRIPTION
## Summary

Removes the empty `DoctrineBundle::registerCommands()` override.

## Why

Symfony FrameworkBundle 8.1 deprecates overriding `Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()`. DoctrineBundle 3.2.2 still overrides the method, but the implementation is empty, so removing it avoids the deprecation without changing command registration behavior.

Fixes #2231.

## Validation

- `php -l src/DoctrineBundle.php`
- `vendor/bin/phpcs src/DoctrineBundle.php`
- `vendor/bin/phpunit`
- `php tests/console-application.php list --no-ansi`
- `vendor/bin/phpstan analyse -v`
