### PR TITLE
[RFC] Warn about user entities stored into session without implementing `__serialize`

### DIFF
--- a/config/security_debug.php
+++ b/config/security_debug.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Doctrine\Bundle\DoctrineBundle\Security\Debug\UserSerializationChecker;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+
+        ->set('doctrine.security.debug.user_serialization_checker', UserSerializationChecker::class)
+            ->args([
+                service('security.firewall.map'),
+                service('security.untracked_token_storage'),
+                service('doctrine'),
+                service('logger'),
+            ])
+            ->tag('kernel.event_subscriber')
+            ->tag('monolog.logger', ['channel' => 'security']);
+};

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -50,6 +50,7 @@ use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Listener;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -445,6 +446,8 @@ final class DoctrineExtension extends Extension
         if (empty($config['orm'])) {
             return;
         }
+
+        $this->loadSecurityServices($container);
 
         if (empty($config['dbal'])) {
             throw new LogicException('Configuring the ORM layer requires to configure the DBAL layer as well.');
@@ -1446,6 +1449,20 @@ final class DoctrineExtension extends Extension
 
         $container->removeDefinition('messenger.transport.doctrine.factory');
         $container->removeDefinition('doctrine.orm.messenger.doctrine_schema_listener');
+    }
+
+    private function loadSecurityServices(ContainerBuilder $container): void
+    {
+        if (! class_exists(Security::class)) {
+            return;
+        }
+
+        if (! $container->getParameter('kernel.debug')) {
+            return;
+        }
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
+        $loader->load('security_debug.php');
     }
 
     private function createArrayAdapterCachePool(ContainerBuilder $container, string $objectManagerName, string $cacheName): string

--- a/src/Security/Debug/UserSerializationChecker.php
+++ b/src/Security/Debug/UserSerializationChecker.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Security\Debug;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Serializable;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Http\FirewallMapInterface;
+
+use function method_exists;
+
+class UserSerializationChecker implements EventSubscriberInterface
+{
+    public function __construct(
+        private FirewallMapInterface $firewallMap,
+        private TokenStorageInterface $tokenStorage,
+        private ManagerRegistry $managerRegistry,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (! $event->isMainRequest() || ! $this->firewallMap instanceof FirewallMap) {
+            return;
+        }
+
+        $firewallConfig = $this->firewallMap->getFirewallConfig($event->getRequest());
+        if ($firewallConfig === null || $firewallConfig->isStateless()) {
+            return;
+        }
+
+        $user = $this->tokenStorage->getToken()?->getUser();
+        if (
+            $user === null
+            || method_exists($user, '__serialize')
+            || $user instanceof Serializable
+            || $this->managerRegistry->getManagerForClass($user::class)?->getMetadataFactory()->isTransient($user::class) !== false
+        ) {
+            return;
+        }
+
+        $this->logger->warning(
+            <<<'WARNING'
+                The "{firewallName}" firewall triggered the serialization of a "{userClass}" instance into the session.
+                It is recommended you implement its {serialize} and {unserialize} methods
+                to only handle data which should disconnect users if they change, like their user identifier and roles.
+                WARNING,
+            [
+                'serialize' => '__serialize()',
+                'unserialize' => '__unserialize()',
+                'firewallName' => $firewallConfig->getName(),
+                'userClass' => $user::class,
+            ],
+        );
+    }
+
+    /** @return array<string, string> */
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::RESPONSE => 'onKernelResponse'];
+    }
+}


### PR DESCRIPTION
Attempt to address https://github.com/symfony/symfony/issues/11155: Symfony makes it easy to use entities as security users, and those entities will always benefit from a `__serialize` and `__unserialize` methods when authenticated against a stateful firewall: it will limit the data stored into the session and avoid errors due to uninitialized proxies.

The issue is, you generally learn about this after opening an issue due to such error (like https://github.com/symfony/symfony/issues/64017) as there is no heads-up before that.

This PR tries to compensate by logging a warning before a stateful firewall triggers the serialization of a user entity which doesn’t implement `Serializable` or `__serialize` in debug mode.

Warning logs are highlighted in Symfony Web Debug Toolbar which should attract developers attention and helping them understand what’s wrong:

<img width="950" height="112" alt="" src="https://github.com/user-attachments/assets/e5cc3961-243e-435a-93d9-c912e871c787" />