### PR TITLE
Avoid reporting error from unrelated call

### DIFF
--- a/src/Twig/DoctrineExtension.php
+++ b/src/Twig/DoctrineExtension.php
@@ -25,14 +25,12 @@ use function implode;
 use function is_array;
 use function is_bool;
 use function is_string;
+use function mb_check_encoding;
 use function preg_last_error;
-use function preg_match;
 use function preg_replace_callback;
 use function sprintf;
 use function strtoupper;
 use function substr;
-
-use const PREG_NO_ERROR;
 
 /**
  * This class contains the needed functions in order to do the query highlighting
@@ -68,8 +66,7 @@ class DoctrineExtension extends AbstractExtension
         $result = $parameter;
 
         switch (true) {
-            // Check if result is non-unicode string using PCRE_UTF8 modifier
-            case is_string($result) && ! preg_match('//u', $result):
+            case is_string($result) && ! mb_check_encoding($result, 'UTF-8'):
                 $result = '0x' . strtoupper(bin2hex($result));
                 break;
 
@@ -139,13 +136,11 @@ class DoctrineExtension extends AbstractExtension
             $query,
         );
 
-        $pregError = preg_last_error();
-        if ($pregError !== PREG_NO_ERROR) {
-            throw new RuntimeException(sprintf('Failed to replace query parameters: PCRE error %d', $pregError));
-        }
-
         if ($result === null) {
-            throw new RuntimeException('Failed to replace query parameters: unexpected null result');
+            throw new RuntimeException(sprintf(
+                'Failed to replace query parameters: PCRE error %d',
+                preg_last_error(),
+            ));
         }
 
         return $result;

--- a/tests/Twig/DoctrineExtensionTest.php
+++ b/tests/Twig/DoctrineExtensionTest.php
@@ -118,6 +118,16 @@ class DoctrineExtensionTest extends TestCase
     {
         $this->assertEquals(1.1, DoctrineExtension::escapeFunction(1.1));
     }
+
+    public function testReplaceBinaryParameterAfterEscaping(): void
+    {
+        $extension  = new DoctrineExtension();
+        $query      = 'column = ?';
+        $parameters = [pack('H*', '9d40b8c1417f42d099af4782ec4b20b6')];
+
+        $result = $extension->replaceQueryParameters($query, $parameters);
+        $this->assertEquals('column = 0x9D40B8C1417F42D099AF4782EC4B20B6', $result);
+    }
 }
 
 class DummyClass


### PR DESCRIPTION
preg_match('//u', …)  is not the most idiomatic way of checking the encoding of a string. The most idiomatic way would be to use… `mb_check_encoding()`.

Even then, checking `preg_last_error()` should only happen if the previous preg call reported a failure, so as to avoid leading to the same issue with another call somewhere else.

Hopefully, in the future, we get a version of these functions that throw exceptions.

Fixes #2239