### PR TITLE
Downgrade event-dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "phpunit/phpunit": "^10.5.53 || ^12.3.10",
         "psr/log": "^1.1.4 || ^2.0 || ^3.0",
         "symfony/doctrine-messenger": "^6.4 || ^7.0",
+        "symfony/event-dispatcher": "^6.4 || ^7.0",
         "symfony/expression-language": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0",
         "symfony/messenger": "^6.4 || ^7.0",

--- a/tests/Middleware/IdleConnectionMiddlewareTest.php
+++ b/tests/Middleware/IdleConnectionMiddlewareTest.php
@@ -15,7 +15,7 @@ use function time;
 
 class IdleConnectionMiddlewareTest extends TestCase
 {
-    #[RequiresMethod(\Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver::class, '__construct')]
+    #[RequiresMethod(IdleConnectionDriver::class, '__construct')]
     public function testWrap()
     {
         /** @var ArrayObject<string, int> $connectionExpiries */


### PR DESCRIPTION
The test suite fails because we are using symfony/event-dispatcher 8
with all other symfony components constrained to at most v7. If I recall
correctly, DoctrineBundle v2 will never support Symfony v8, so let's
downgrade this particular component.