### PR TITLE
Add missing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^8.4",
+        "ext-mbstring": "*",
         "doctrine/dbal": "^4.0",
         "doctrine/deprecations": "^1.0",
         "doctrine/persistence": "^4",


### PR DESCRIPTION
In #2241, I added a call to `mb_check_encoding()`, making `mbstring` required.