### PR TITLE
Add ValueResolverInterface check for EntityValueResolver

### DIFF
--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -815,9 +815,7 @@ final class DoctrineExtension extends Extension
         $controllerValueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
 
         // The Console EntityValueResolver is available in Symfony 8.1 and higher
-        if (class_exists(EntityValueResolver::class)
-           && class_exists(ValueResolverInterface::class)
-        ) {
+        if (class_exists(ValueResolverInterface::class) && class_exists(EntityValueResolver::class)) {
             $consoleValueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver.console');
             $consoleValueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([
                 '$evictCache' => $controllerResolverDefaults['evict_cache'] ?? null,

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -55,6 +55,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\ValueResolverInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -814,7 +815,9 @@ final class DoctrineExtension extends Extension
         $controllerValueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
 
         // The Console EntityValueResolver is available in Symfony 8.1 and higher
-        if (class_exists(EntityValueResolver::class)) {
+        if (class_exists(EntityValueResolver::class)
+           && class_exists(ValueResolverInterface::class)
+        ) {
             $consoleValueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver.console');
             $consoleValueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([
                 '$evictCache' => $controllerResolverDefaults['evict_cache'] ?? null,

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -814,7 +814,7 @@ final class DoctrineExtension extends Extension
         // Symfony 7.3 and higher expose type alias support in the EntityValueResolver
         $controllerValueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
 
-        // The Console EntityValueResolver is available in Symfony 8.1 and higher
+        // The Console ValueResolverInterface and EntityValueResolver is available in Symfony 8.1 and higher
         if (class_exists(ValueResolverInterface::class) && class_exists(EntityValueResolver::class)) {
             $consoleValueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver.console');
             $consoleValueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -815,7 +815,7 @@ final class DoctrineExtension extends Extension
         $controllerValueResolverDefinition->setArgument(3, $config['resolve_target_entities']);
 
         // The Console ValueResolverInterface and EntityValueResolver is available in Symfony 8.1 and higher
-        if (class_exists(ValueResolverInterface::class) && class_exists(EntityValueResolver::class)) {
+        if (interface_exists(ValueResolverInterface::class) && class_exists(EntityValueResolver::class)) {
             $consoleValueResolverDefinition = $container->getDefinition('doctrine.orm.entity_value_resolver.console');
             $consoleValueResolverDefinition->setArgument(2, (new Definition(MapEntity::class))->setArguments([
                 '$evictCache' => $controllerResolverDefaults['evict_cache'] ?? null,


### PR DESCRIPTION
If somebody has just a requirement to doctrine-bundle but its application is still on Symfony 7.4 or 8.0 it can still happening that it install 8.1 bridge and ends in an error like:

```
PHP Fatal error:  Uncaught Error: Interface "Symfony\Component\Console\ArgumentResolver\ValueResolver\ValueResolverInterface" not found in /home/runner/work/sulu/sulu/vendor/symfony/doctrine-bridge/ArgumentResolver/Console/EntityValueResolver.php:35
Stack trace:
#0 /home/runner/work/sulu/sulu/vendor/composer/ClassLoader.php(576): include()
#1 /home/runner/work/sulu/sulu/vendor/composer/ClassLoader.php(427): {closure:Composer\Autoload\ClassLoader::initializeIncludeClosure():575}()
#2 [internal function]: Composer\Autoload\ClassLoader->loadClass()
#3 /home/runner/work/sulu/sulu/vendor/doctrine/doctrine-bundle/src/DependencyInjection/DoctrineExtension.php(817): class_exists()
#4 /home/runner/work/sulu/sulu/vendor/doctrine/doctrine-bundle/src/DependencyInjection/DoctrineExtension.php(455): Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension->ormLoad()
#5 /home/runner/work/sulu/sulu/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(81): Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension->load()
#6 /home/runner/work/sulu/sulu/vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php(40): Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process()
#7 /home/runner/work/sulu/sulu/vendor/symfony/dependency-injection/Compiler/Compiler.php(73): Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass->process()
#8 /home/runner/work/sulu/sulu/vendor/symfony/dependency-injection/ContainerBuilder.php(825): Symfony\Component\DependencyInjection\Compiler\Compiler->compile()
#9 /home/runner/work/sulu/sulu/vendor/symfony/http-kernel/Kernel.php(516): Symfony\Component\DependencyInjection\ContainerBuilder->compile()
#10 /home/runner/work/sulu/sulu/vendor/symfony/http-kernel/Kernel.php(762): Symfony\Component\HttpKernel\Kernel->initializeContainer()
#11 /home/runner/work/sulu/sulu/vendor/symfony/http-kernel/Kernel.php(122): Symfony\Component\HttpKernel\Kernel->preBoot()
#12 /home/runner/work/sulu/sulu/vendor/symfony/framework-bundle/Console/Application.php(196): Symfony\Component\HttpKernel\Kernel->boot()
#13 /home/runner/work/sulu/sulu/vendor/symfony/framework-bundle/Console/Application.php(70): Symfony\Bundle\FrameworkBundle\Console\Application->registerCommands()
#14 /home/runner/work/sulu/sulu/vendor/symfony/console/Application.php(195): Symfony\Bundle\FrameworkBundle\Console\Application->doRun()
#15 /home/runner/work/sulu/sulu/packages/article/tests/Application/bin/console.php(49): Symfony\Component\Console\Application->run()
#16 /home/runner/work/sulu/sulu/packages/article/tests/Application/bin/adminconsole(5): include('...')
#17 {main}
```

To avoid this it need check for both the class and its interface, which comes from different packages which may not be installed in the version expected.

Related to: https://github.com/doctrine/DoctrineBundle/pull/2193