### PR TITLE
Twig 4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "symfony/var-exporter": "^6.4.1 || ^7.0.1",
         "symfony/web-profiler-bundle": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",
-        "twig/twig": "^2.14.7 || ^3.0.4"
+        "twig/twig": "^2.14.7 || ^3.0.4 || ^4"
     },
     "conflict": {
         "doctrine/annotations": ">=3.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,6 +28,10 @@
         <exclude-pattern>tests/*</exclude-pattern>
         <exclude-pattern>src/Repository/RepositoryFactoryCompatibility.php</exclude-pattern>
         <exclude-pattern>src/Repository/ServiceEntityRepository.php</exclude-pattern>
+        <exclude-pattern>src/Twig/AbstractExtensionCompatibility.php</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <exclude-pattern>src/Twig/AbstractExtensionCompatibility.php</exclude-pattern>
     </rule>
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
         <exclude-pattern>tests/*</exclude-pattern>

--- a/src/Twig/AbstractExtensionCompatibility.php
+++ b/src/Twig/AbstractExtensionCompatibility.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Twig;
+
+use ReflectionMethod;
+use Twig\Extension\AbstractExtension;
+
+if ((new ReflectionMethod(AbstractExtension::class, 'getFilters'))->hasReturnType()) {
+    /** @internal */
+    trait AbstractExtensionCompatibility
+    {
+        public function getFilters(): array
+        {
+            return $this->doGetFilters();
+        }
+    }
+} else {
+    /** @internal */
+    trait AbstractExtensionCompatibility
+    {
+        public function getFilters()
+        {
+            return $this->doGetFilters();
+        }
+    }
+}

--- a/src/Twig/DoctrineExtension.php
+++ b/src/Twig/DoctrineExtension.php
@@ -40,6 +40,8 @@ use function substr;
  */
 class DoctrineExtension extends AbstractExtension
 {
+    use AbstractExtensionCompatibility;
+
     private SqlFormatter $sqlFormatter;
 
     /**
@@ -47,7 +49,7 @@ class DoctrineExtension extends AbstractExtension
      *
      * @return TwigFilter[]
      */
-    public function getFilters()
+    private function doGetFilters(): array
     {
         $out     = [
             new TwigFilter('doctrine_prettify_sql', [$this, 'prettifySql'], ['is_safe' => ['html']]),


### PR DESCRIPTION
Symfony started to stabilize Twig 4 which enables us to test against it. Our 3.x series is already compatible, but on 2.x we're missing one native return type on `DoctrineExtension::getFilters()`. Since we don't block the istallation of Twig 4, people will get a runtime error as soon as they try to use Twig 4 with DoctrineBundle 2.

Adding this return type would be a breaking change, which is why I'm adding it conditionally here: The method only has a return type if the parent has it. When merging up to 3.x, we can revert all of this.

Fixes #1879