### PR TITLE
Twig 4 compatibility (BC break)

### DIFF
--- a/UPGRADE-2.19.md
+++ b/UPGRADE-2.19.md
@@ -4,6 +4,13 @@ UPGRADE FROM 2.18 to 2.19
 Configuration
 -------------
 
+### BC Break: Native return type on Twig extension
+
+A native return type `array` has been added to
+`Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension`. That class is not
+meant to be extended, but if a downstream project did that, the return type
+needs to be added there as well.
+
 ### Proxy-related configuration settings are conditionally deprecated
 
 When using PHP 8.4 or higher in combination with Doctrine ORM 3.4 or

--- a/composer.json
+++ b/composer.json
@@ -68,14 +68,14 @@
         "symfony/var-exporter": "^6.4.1 || ^7.0.1",
         "symfony/web-profiler-bundle": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",
-        "twig/twig": "^2.14.7 || ^3.0.4"
+        "twig/twig": "^2.14.7 || ^3.0.4 || ^4"
     },
     "conflict": {
         "doctrine/annotations": ">=3.0",
         "doctrine/cache": "< 1.11",
         "doctrine/orm": "<2.17 || >=4.0",
         "symfony/var-exporter": "< 6.4.1 || 7.0.0",
-        "twig/twig": "<2.13 || >=3.0 <3.0.4"
+        "twig/twig": "<2.13 || >=3.0 <3.0.4 || >=5"
     },
     "suggest": {
         "ext-pdo": "*",

--- a/src/Twig/DoctrineExtension.php
+++ b/src/Twig/DoctrineExtension.php
@@ -47,7 +47,7 @@ class DoctrineExtension extends AbstractExtension
      *
      * @return TwigFilter[]
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         $out     = [
             new TwigFilter('doctrine_prettify_sql', [$this, 'prettifySql'], ['is_safe' => ['html']]),


### PR DESCRIPTION
Symfony started to stabilize Twig 4 which enables us to test against it. Our 3.x series is already compatible, but on 2.x we're missing one native return type on DoctrineExtension::getFilters(). Since we don't block the istallation of Twig 4, people will get a runtime error as soon as they try to use Twig 4 with DoctrineBundle 2.

Adding this return type is technically a breaking change, but as discussed on #1879, it might be an acceptable one.

Replaces #2262 
Fixes #1879