### PR TITLE
Fix PHPUnit warning on incomplete version constraint

### DIFF
--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -577,7 +577,7 @@ class DoctrineExtensionTest extends TestCase
 
     /** @param array<string, mixed> $settings */
     #[IgnoreDeprecations]
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[RequiresMethod(Configuration::class, 'enableNativeLazyObjects')]
     #[DataProvider('proxySettingsProvider')]
     public function testProxySettingsAreConditionallyDeprecated(array $settings): void


### PR DESCRIPTION
Fix es a PHPUnit warning that currently breaks our CI.

```
Incomplete version requirement "8.4" used by Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\DoctrineExtensionTest::testProxySettingsAreConditionallyDeprecated()
```