### PR TITLE
Fix logger service priority alignment with FrameworkBundle

### DIFF
--- a/src/DoctrineBundle.php
+++ b/src/DoctrineBundle.php
@@ -65,7 +65,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new DbalSchemaFilterPass());
         $container->addCompilerPass(new CacheSchemaSubscriberPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
         $container->addCompilerPass(new RemoveProfilerControllerPass());
-        $container->addCompilerPass(new RemoveLoggingMiddlewarePass());
+        $container->addCompilerPass(new RemoveLoggingMiddlewarePass(), PassConfig::TYPE_OPTIMIZE);
         $container->addCompilerPass(new MiddlewaresPass());
         $container->addCompilerPass(new RegisterUidTypePass());
         $container->addCompilerPass(new RegisterDbalTypePass());

--- a/tests/DependencyInjection/Compiler/RemoveLoggingMiddlewarePassTest.php
+++ b/tests/DependencyInjection/Compiler/RemoveLoggingMiddlewarePassTest.php
@@ -10,6 +10,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -31,6 +32,25 @@ final class RemoveLoggingMiddlewarePassTest extends TestCase
         $logger = (new Definition())
             ->setClass(NullLogger::class);
         $container->setDefinition('logger', $logger);
+
+        $container->compile();
+
+        $this->assertTrue($container->hasDefinition('logging_middleware_child'));
+    }
+
+    public function testLoggingMiddlewareNotRemovedWhenSymfonyLoggerPresentViaPass(): void
+    {
+        $container = $this->createContainer();
+
+        // Keep priority consistent with FrameworkBundle. See https://github.com/symfony/symfony/blob/796775495ec4a49f9d711906c4cdf44fea822ced/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php#L169
+        $container->addCompilerPass(new class implements CompilerPassInterface {
+            public function process(ContainerBuilder $container): void
+            {
+                $logger = (new Definition())
+                    ->setClass(NullLogger::class);
+                $container->setDefinition('logger', $logger);
+            }
+        }, priority: -32);
 
         $container->compile();
 

--- a/tests/DependencyInjection/Compiler/RemoveLoggingMiddlewarePassTest.php
+++ b/tests/DependencyInjection/Compiler/RemoveLoggingMiddlewarePassTest.php
@@ -10,7 +10,6 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -38,25 +37,6 @@ final class RemoveLoggingMiddlewarePassTest extends TestCase
         $this->assertTrue($container->hasDefinition('logging_middleware_child'));
     }
 
-    public function testLoggingMiddlewareNotRemovedWhenSymfonyLoggerPresentViaPass(): void
-    {
-        $container = $this->createContainer();
-
-        // Keep priority consistent with FrameworkBundle. See https://github.com/symfony/symfony/blob/796775495ec4a49f9d711906c4cdf44fea822ced/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php#L169
-        $container->addCompilerPass(new class implements CompilerPassInterface {
-            public function process(ContainerBuilder $container): void
-            {
-                $logger = (new Definition())
-                    ->setClass(NullLogger::class);
-                $container->setDefinition('logger', $logger);
-            }
-        }, priority: -32);
-
-        $container->compile();
-
-        $this->assertTrue($container->hasDefinition('logging_middleware_child'));
-    }
-
     private function createContainer(): ContainerBuilder
     {
         $container = new ContainerBuilder();
@@ -64,7 +44,7 @@ final class RemoveLoggingMiddlewarePassTest extends TestCase
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../../../config'));
         $loader->load('middlewares.php');
 
-        $container->addCompilerPass(new RemoveLoggingMiddlewarePass(), PassConfig::TYPE_OPTIMIZE);
+        $container->addCompilerPass(new RemoveLoggingMiddlewarePass());
         $container->addCompilerPass(new class implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void
             {
@@ -76,7 +56,7 @@ final class RemoveLoggingMiddlewarePassTest extends TestCase
                     ->setPublic(true);
                 $container->setDefinition('logging_middleware_child', $loggingMiddlewareChild);
             }
-        }, PassConfig::TYPE_OPTIMIZE);
+        });
 
         return $container;
     }

--- a/tests/DependencyInjection/Compiler/RemoveLoggingMiddlewarePassTest.php
+++ b/tests/DependencyInjection/Compiler/RemoveLoggingMiddlewarePassTest.php
@@ -64,7 +64,7 @@ final class RemoveLoggingMiddlewarePassTest extends TestCase
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../../../config'));
         $loader->load('middlewares.php');
 
-        $container->addCompilerPass(new RemoveLoggingMiddlewarePass());
+        $container->addCompilerPass(new RemoveLoggingMiddlewarePass(), PassConfig::TYPE_OPTIMIZE);
         $container->addCompilerPass(new class implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void
             {
@@ -76,7 +76,7 @@ final class RemoveLoggingMiddlewarePassTest extends TestCase
                     ->setPublic(true);
                 $container->setDefinition('logging_middleware_child', $loggingMiddlewareChild);
             }
-        });
+        }, PassConfig::TYPE_OPTIMIZE);
 
         return $container;
     }


### PR DESCRIPTION
### Description

When `MonologBundle` is not used, Symfony's `FrameworkBundle` registers/configures the `logger` service via its compiler pass with a specific priority. Currently, `DoctrineBundle` does not take this priority into account, which can cause unexpected logger injection behavior.

This PR fixes the compiler pass logic to respect the priority set by `FrameworkBundle`.

### Changes
- Added a test reproducing the missing priority check when using the default FrameworkBundle logger setup.
- Updated compiler pass logic to align priority handling with `FrameworkBundle`.

### Checklist
- [x] Added failing test first to reproduce the issue
- [x] Fixed the issue and made tests pass