### PR TITLE
Register the DBAL messenger middlewares from symfony/doctrine-bridge 8.2

### DIFF
--- a/config/messenger.php
+++ b/config/messenger.php
@@ -6,6 +6,10 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineCloseConnectionMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalCloseConnectionMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalOpenTransactionLoggerMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalPingConnectionMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineOpenTransactionLoggerMiddleware;
 use Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineTransactionMiddleware;
@@ -22,7 +26,19 @@ return static function (ContainerConfigurator $container): void {
                 service('doctrine'),
             ])
 
+        ->set('messenger.middleware.doctrine_dbal_transaction', DoctrineDbalTransactionMiddleware::class)
+            ->abstract()
+            ->args([
+                service('doctrine'),
+            ])
+
         ->set('messenger.middleware.doctrine_ping_connection', DoctrinePingConnectionMiddleware::class)
+            ->abstract()
+            ->args([
+                service('doctrine'),
+            ])
+
+        ->set('messenger.middleware.doctrine_dbal_ping_connection', DoctrineDbalPingConnectionMiddleware::class)
             ->abstract()
             ->args([
                 service('doctrine'),
@@ -34,11 +50,24 @@ return static function (ContainerConfigurator $container): void {
                 service('doctrine'),
             ])
 
+        ->set('messenger.middleware.doctrine_dbal_close_connection', DoctrineDbalCloseConnectionMiddleware::class)
+            ->abstract()
+            ->args([
+                service('doctrine'),
+            ])
+
         ->set('messenger.middleware.doctrine_open_transaction_logger', DoctrineOpenTransactionLoggerMiddleware::class)
             ->abstract()
             ->args([
                 service('doctrine'),
                 null,
+                service('logger'),
+            ])
+
+        ->set('messenger.middleware.doctrine_dbal_open_transaction_logger', DoctrineDbalOpenTransactionLoggerMiddleware::class)
+            ->abstract()
+            ->args([
+                service('doctrine'),
                 service('logger'),
             ])
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,12 @@ includes:
 parameters:
    level: 8
    reportUnmatchedIgnoredErrors: true
+   ignoreErrors:
+      # The DBAL messenger middlewares exist since symfony/doctrine-bridge 8.2, which is not released yet
+      -
+         message: '~^Class Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbal\w+Middleware not found\.$~'
+         identifier: class.notFound
+         reportUnmatched: false
    paths:
       - config
       - src

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -48,6 +48,10 @@ use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalCloseConnectionMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalOpenTransactionLoggerMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalPingConnectionMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware;
 use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Listener;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
@@ -1451,6 +1455,22 @@ final class DoctrineExtension extends Extension
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
         $loader->load('messenger.php');
+
+        // The DBAL middlewares exist since symfony/doctrine-bridge 8.2
+        $dbalMiddlewares = [
+            'messenger.middleware.doctrine_dbal_transaction' => DoctrineDbalTransactionMiddleware::class,
+            'messenger.middleware.doctrine_dbal_ping_connection' => DoctrineDbalPingConnectionMiddleware::class,
+            'messenger.middleware.doctrine_dbal_close_connection' => DoctrineDbalCloseConnectionMiddleware::class,
+            'messenger.middleware.doctrine_dbal_open_transaction_logger' => DoctrineDbalOpenTransactionLoggerMiddleware::class,
+        ];
+
+        foreach ($dbalMiddlewares as $middlewareId => $middlewareClass) {
+            if (class_exists($middlewareClass)) {
+                continue;
+            }
+
+            $container->removeDefinition($middlewareId);
+        }
 
         if (! class_exists(PostgreSqlNotifyOnIdleListener::class)) {
             $container->removeDefinition('messenger.transport.doctrine.pg_notify_on_idle_listener');

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -36,6 +36,10 @@ use ReflectionClass;
 use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver as ConsoleEntityValueResolver;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalCloseConnectionMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalOpenTransactionLoggerMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalPingConnectionMiddleware;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware;
 use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Driver;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
@@ -789,6 +793,21 @@ class DoctrineExtensionTest extends TestCase
         $this->assertCount(1, $container->getDefinition('messenger.middleware.doctrine_ping_connection')->getArguments());
         $this->assertCount(1, $container->getDefinition('messenger.middleware.doctrine_close_connection')->getArguments());
         $this->assertCount(1, $container->getDefinition('doctrine.orm.messenger.event_subscriber.doctrine_clear_entity_manager')->getArguments());
+
+        $dbalMiddlewares = [
+            'messenger.middleware.doctrine_dbal_transaction' => [DoctrineDbalTransactionMiddleware::class, 1],
+            'messenger.middleware.doctrine_dbal_ping_connection' => [DoctrineDbalPingConnectionMiddleware::class, 1],
+            'messenger.middleware.doctrine_dbal_close_connection' => [DoctrineDbalCloseConnectionMiddleware::class, 1],
+            'messenger.middleware.doctrine_dbal_open_transaction_logger' => [DoctrineDbalOpenTransactionLoggerMiddleware::class, 2],
+        ];
+
+        foreach ($dbalMiddlewares as $middlewareId => [$middlewareClass, $argumentCount]) {
+            if (class_exists($middlewareClass)) {
+                $this->assertCount($argumentCount, $container->getDefinition($middlewareId)->getArguments());
+            } else {
+                $this->assertFalse($container->hasDefinition($middlewareId));
+            }
+        }
     }
 
     public function testMessengerIntegrationWithDoctrineTransport(): void


### PR DESCRIPTION
symfony/symfony#65302 and symfony/symfony#65329 deprecate `DoctrineCloseConnectionMiddleware` and `DoctrineOpenTransactionLoggerMiddleware` in favor of new middlewares that target DBAL connections instead of entity managers, and symfony/symfony#65346 completes the set: it deprecates `DoctrinePingConnectionMiddleware` and adds `DoctrineDbalTransactionMiddleware` as the DBAL-level alternative to `DoctrineTransactionMiddleware` (which is not deprecated, since its flush has no DBAL equivalent).

This PR registers the four new middlewares so they can be referenced from messenger bus configuration:

- `doctrine_dbal_transaction`
- `doctrine_dbal_ping_connection`
- `doctrine_dbal_close_connection`
- `doctrine_dbal_open_transaction_logger`

All take the `doctrine` registry as first argument (`ManagerRegistry` extends `ConnectionRegistry`), and the logger one takes the `logger` service second, matching the new constructors where connection names come last; user-provided middleware arguments are appended after these by `ResolveChildDefinitionsPass`, so no argument remapping is needed. The definitions are removed when the classes are not available, i.e. with symfony/doctrine-bridge < 8.2, so this is a no-op until then. The PHPStan ignore entry uses `reportUnmatched: false` so it becomes inert once the bridge classes are visible to the analysis.
