### PR TITLE
Add `auto_discover_entities` option to register entities discovered by the container scan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-mbstring": "*",
         "doctrine/dbal": "^4.0",
         "doctrine/deprecations": "^1.0",
-        "doctrine/persistence": "^4",
+        "doctrine/persistence": "^4.2",
         "doctrine/sql-formatter": "^1.0.1",
         "symfony/cache": "^6.4 || ^7.0 || ^8.0",
         "symfony/config": "^6.4 || ^7.0 || ^8.0",

--- a/config/schema/doctrine-1.0.xsd
+++ b/config/schema/doctrine-1.0.xsd
@@ -215,6 +215,7 @@
     </xsd:group>
 
     <xsd:attributeGroup name="entity-manager-config">
+        <xsd:attribute name="auto-discover-entities" type="xsd:boolean" />
         <xsd:attribute name="auto-mapping" type="xsd:string" />
         <xsd:attribute name="connection" type="xsd:string" />
         <xsd:attribute name="default-repository-class" type="xsd:string" />

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -246,6 +246,11 @@ Configuration Reference
                         class_metadata_factory_name:  Doctrine\ORM\Mapping\ClassMetadataFactory
                         default_repository_class:     Doctrine\ORM\EntityRepository
                         auto_mapping:                 false
+                        # Registers all classes tagged with "doctrine.orm.entity" by the container scan,
+                        # removing the need for explicit "mappings". When not set, enabled if neither
+                        # "mappings" nor "auto_mapping" is configured and Symfony 8.2 and doctrine/orm 3.6
+                        # are available.
+                        auto_discover_entities:       ~
                         # 0pt-in to the new mapping driver mode as of Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728.
                         validate_xml_mapping: false
                         naming_strategy:              doctrine.orm.naming_strategy.default
@@ -704,6 +709,34 @@ The following example shows an overview of the caching configurations:
             pools:
                 doctrine.result_cache_pool:
                     adapter: cache.app
+
+Entity Auto-Discovery
+~~~~~~~~~~~~~~~~~~~~~
+
+Setting ``auto_discover_entities: true`` on an entity manager (requires Symfony
+8.2) registers every entity class discovered by the service container scan:
+classes carrying the ``#[Entity]`` or ``#[MappedSuperclass]`` attribute are
+tagged with ``doctrine.orm.entity`` while ``src/`` is scanned, removing the
+need for an explicit ``mappings`` block. Explicit mappings keep priority — the
+discovered classes only feed the metadata driver chain's default driver.
+
+Discovery relies on ``ContainerBuilder::findTaggedResourceIds()`` (Symfony
+8.2) and on the ORM's ``AttributeDriver`` accepting a ``ClassLocator`` (doctrine/orm
+3.6). When the option is not set, discovery is enabled automatically for entity
+managers that configure neither ``mappings`` nor ``auto_mapping``, provided both
+requirements are met. Set it to ``false`` to opt out, or to ``true`` to require
+it: a ``LogicException`` naming the missing requirement is then thrown.
+
+.. warning::
+
+    Only classes seen by the container scan are discovered. If your
+    ``services.yaml`` still excludes the entity directory (the legacy
+    ``exclude: '../src/{Entity,...}'`` line from older skeletons), those
+    classes are registered from their file path without attribute
+    autoconfiguration and will **not** be discovered. Remove the entity
+    directory from the ``exclude`` list: since Symfony 7.3, entities are
+    automatically excluded from the service container without being hidden
+    from discovery.
 
 Mapping Configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/DependencyInjection/Compiler/EntityAutoDiscoveryPass.php
+++ b/src/DependencyInjection/Compiler/EntityAutoDiscoveryPass.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+use function array_keys;
+use function assert;
+use function method_exists;
+
+final class EntityAutoDiscoveryPass implements CompilerPassInterface
+{
+    public const string TAG = 'doctrine.orm.auto_discover_class_locator';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $locatorIds = array_keys($container->findTaggedServiceIds(self::TAG));
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if ($locatorIds === [] || ! method_exists($container, 'findTaggedResourceIds')) {
+            return;
+        }
+
+        $classes = [];
+        foreach ($container->findTaggedResourceIds('doctrine.orm.entity', false) as $id => $tags) {
+            $class = $container->getDefinition($id)->getClass();
+            assert($class !== null);
+
+            $classes[$class] = true;
+        }
+
+        foreach ($locatorIds as $locatorId) {
+            $container->getDefinition($locatorId)->replaceArgument(0, array_keys($classes));
+        }
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -573,6 +573,7 @@ final class Configuration implements ConfigurationInterface
                     ->scalarNode('class_metadata_factory_name')->defaultValue(ClassMetadataFactory::class)->end()
                     ->scalarNode('default_repository_class')->defaultValue(EntityRepository::class)->end()
                     ->scalarNode('auto_mapping')->defaultFalse()->end()
+                    ->booleanNode('auto_discover_entities')->defaultNull()->info('Registers all entity classes discovered by the container scan, removing the need for explicit "mappings". When not set, enabled if neither "mappings" nor "auto_mapping" is configured and Symfony 8.2 and doctrine/orm 3.6 are available.')->end()
                     ->scalarNode('naming_strategy')->defaultValue('doctrine.orm.naming_strategy.default')->end()
                     ->scalarNode('quote_strategy')->defaultValue('doctrine.orm.quote_strategy.default')->end()
                     ->scalarNode('typed_field_mapper')->defaultValue('doctrine.orm.typed_field_mapper.default')->end()

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -11,6 +11,7 @@ use Doctrine\Bundle\DoctrineBundle\Attribute\AsMiddleware;
 use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use Doctrine\Bundle\DoctrineBundle\Dbal\RegexSchemaAssetFilter;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityAutoDiscoveryPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterDbalTypePass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
@@ -38,12 +39,15 @@ use Doctrine\ORM\Proxy\Autoloader;
 use Doctrine\ORM\Tools\AttachEntityListenersListener;
 use Doctrine\ORM\Tools\Console\Command\Debug\DebugEventManagerDoctrineCommand;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Mapping\Driver\ClassNames;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
 use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
+use ReflectionParameter;
+use ReflectionUnionType;
 use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
@@ -85,6 +89,7 @@ use function in_array;
 use function interface_exists;
 use function is_dir;
 use function is_string;
+use function method_exists;
 use function realpath;
 use function reset;
 use function sprintf;
@@ -1109,6 +1114,13 @@ final class DoctrineExtension extends Extension
         $this->loadMappingInformation($entityManager, $container);
         $this->registerMappingDrivers($entityManager, $container);
 
+        $autoDiscoverEntities = $entityManager['auto_discover_entities']
+            ?? ($entityManager['mappings'] === [] && ! $entityManager['auto_mapping'] && self::missingEntityAutoDiscoveryRequirement() === null);
+
+        if ($autoDiscoverEntities) {
+            $this->registerEntityAutoDiscoveryDriver($entityManager, $container);
+        }
+
         $container->getDefinition($this->getObjectManagerElementName($entityManager['name'] . '_metadata_driver'));
         /** @psalm-suppress NoValue $this->drivers is set by $this->loadMappingInformation() call  */
         foreach (array_keys($this->drivers) as $driverType) {
@@ -1126,6 +1138,40 @@ final class DoctrineExtension extends Extension
         }
 
         $ormConfigDef->addMethodCall('setEntityNamespaces', [$this->aliasMap]);
+    }
+
+    /** @param array<string, mixed> $entityManager A configured ORM entity manager */
+    private function registerEntityAutoDiscoveryDriver(array $entityManager, ContainerBuilder $container): void
+    {
+        $missingRequirement = self::missingEntityAutoDiscoveryRequirement();
+        if ($missingRequirement !== null) {
+            throw new LogicException(sprintf('The "auto_discover_entities" option requires %s.', $missingRequirement));
+        }
+
+        $locatorId  = $this->getObjectManagerElementName($entityManager['name'] . '_auto_discover_class_locator');
+        $locatorDef = new Definition(ClassNames::class, [[]]);
+        $locatorDef->addTag(EntityAutoDiscoveryPass::TAG);
+        $container->setDefinition($locatorId, $locatorDef);
+
+        $driverId = $this->getObjectManagerElementName($entityManager['name'] . '_auto_discover_metadata_driver');
+        $container->setDefinition($driverId, new Definition(AttributeDriver::class, [new Reference($locatorId)]));
+
+        $container->getDefinition($this->getObjectManagerElementName($entityManager['name'] . '_metadata_driver'))
+            ->addMethodCall('setDefaultDriver', [new Reference($driverId)]);
+    }
+
+    private static function missingEntityAutoDiscoveryRequirement(): string|null
+    {
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (! method_exists(ContainerBuilder::class, 'findTaggedResourceIds')) {
+            return 'symfony/dependency-injection 8.2 (ContainerBuilder::findTaggedResourceIds())';
+        }
+
+        if (! (new ReflectionParameter([AttributeDriver::class, '__construct'], 'paths'))->getType() instanceof ReflectionUnionType) {
+            return 'doctrine/orm 3.6 (AttributeDriver accepting a ClassLocator)';
+        }
+
+        return null;
     }
 
     /**

--- a/src/DoctrineBundle.php
+++ b/src/DoctrineBundle.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\DoctrineBundle;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheSchemaSubscriberPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DbalSchemaFilterPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityAutoDiscoveryPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityListenerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\IdGeneratorPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\MiddlewaresPass;
@@ -49,6 +50,7 @@ class DoctrineBundle extends Bundle
         }, PassConfig::TYPE_BEFORE_OPTIMIZATION);
 
         $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass('doctrine.connections', 'doctrine.dbal.%s_connection.event_manager', 'doctrine'), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+        $container->addCompilerPass(new EntityAutoDiscoveryPass(), PassConfig::TYPE_BEFORE_REMOVING);
 
         if ($container->hasExtension('security')) {
             $security = $container->getExtension('security');

--- a/tests/DependencyInjection/Compiler/EntityAutoDiscoveryPassTest.php
+++ b/tests/DependencyInjection/Compiler/EntityAutoDiscoveryPassTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityAutoDiscoveryPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+use function method_exists;
+
+class EntityAutoDiscoveryPassTest extends TestCase
+{
+    public function testPopulatesAutoDiscoverLocatorsWithTaggedEntityClasses(): void
+    {
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (! method_exists(ContainerBuilder::class, 'findTaggedResourceIds')) {
+            self::markTestSkipped('symfony/dependency-injection 8.2 is required.');
+        }
+
+        $container = new ContainerBuilder();
+
+        $locator = new Definition('ClassNames', [[]]);
+        $locator->addTag(EntityAutoDiscoveryPass::TAG);
+        $container->setDefinition('doctrine.orm.default_auto_discover_class_locator', $locator);
+
+        $stub = new Definition('App\Entity\Book');
+        $stub->addTag('container.excluded');
+        $stub->addTag('doctrine.orm.entity');
+        $container->setDefinition('App\Entity\Book', $stub);
+
+        $stub = new Definition('App\Entity\AbstractContent');
+        $stub->setAbstract(true);
+        $stub->addTag('container.excluded');
+        $stub->addTag('doctrine.orm.entity');
+        $container->setDefinition('.abstract.App\Entity\AbstractContent', $stub);
+
+        (new EntityAutoDiscoveryPass())->process($container);
+
+        self::assertSame(
+            ['App\Entity\Book', 'App\Entity\AbstractContent'],
+            $container->getDefinition('doctrine.orm.default_auto_discover_class_locator')->getArgument(0),
+        );
+    }
+
+    public function testIgnoresExcludedClassesWithoutTheEntityTag(): void
+    {
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (! method_exists(ContainerBuilder::class, 'findTaggedResourceIds')) {
+            self::markTestSkipped('symfony/dependency-injection 8.2 is required.');
+        }
+
+        $container = new ContainerBuilder();
+
+        $locator = new Definition('ClassNames', [[]]);
+        $locator->addTag(EntityAutoDiscoveryPass::TAG);
+        $container->setDefinition('doctrine.orm.default_auto_discover_class_locator', $locator);
+
+        $stub = new Definition('App\Entity\Legacy');
+        $stub->setAbstract(true);
+        $stub->addTag('container.excluded');
+        $container->setDefinition('App\Entity\Legacy', $stub);
+
+        (new EntityAutoDiscoveryPass())->process($container);
+
+        self::assertSame(
+            [],
+            $container->getDefinition('doctrine.orm.default_auto_discover_class_locator')->getArgument(0),
+        );
+    }
+
+    public function testNoOpWithoutAutoDiscoverLocators(): void
+    {
+        $container = new ContainerBuilder();
+
+        $stub = new Definition('App\Entity\Book');
+        $stub->setAbstract(true);
+        $stub->addTag('container.excluded');
+        $stub->addTag('doctrine.orm.entity');
+        $container->setDefinition('App\Entity\Book', $stub);
+
+        (new EntityAutoDiscoveryPass())->process($container);
+
+        self::assertTrue($container->hasDefinition('App\Entity\Book'));
+    }
+}

--- a/tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineExtensionTest.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\DoctrineBundle\Attribute\AsDbalType;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\EntityAutoDiscoveryPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Tests\Builder\BundleConfigurationBuilder;
 use Doctrine\Bundle\DoctrineBundle\Tests\DependencyInjection\Fixtures\DbalType;
@@ -33,6 +34,8 @@ use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionParameter;
+use ReflectionUnionType;
 use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver as ConsoleEntityValueResolver;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
@@ -249,6 +252,78 @@ class DoctrineExtensionTest extends TestCase
             'Configuring the ORM layer requires to configure the DBAL layer as well.',
         );
         $extension->load([['orm' => ['auto_mapping' => true]]], $this->getContainer());
+    }
+
+    public function testAutoDiscoverEntities(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $extension = new DoctrineExtension();
+        $container = $this->getContainer();
+        $config    = [
+            'dbal' => [],
+            'orm' => ['auto_discover_entities' => true],
+        ];
+
+        if (! self::supportsAutoDiscovery()) {
+            $this->expectException(LogicException::class);
+            $this->expectExceptionMessage('The "auto_discover_entities" option requires');
+
+            $extension->load([$config], $container);
+
+            return;
+        }
+
+        $extension->load([$config], $container);
+
+        $locatorId = 'doctrine.orm.default_auto_discover_class_locator';
+        self::assertTrue($container->getDefinition($locatorId)->hasTag(EntityAutoDiscoveryPass::TAG));
+
+        $driverDef = $container->getDefinition('doctrine.orm.default_auto_discover_metadata_driver');
+        self::assertSame(AttributeDriver::class, $driverDef->getClass());
+        self::assertEquals([new Reference($locatorId)], $driverDef->getArguments());
+
+        self::assertContainsEquals(
+            ['setDefaultDriver', [new Reference('doctrine.orm.default_auto_discover_metadata_driver')]],
+            $container->getDefinition('doctrine.orm.default_metadata_driver')->getMethodCalls(),
+        );
+    }
+
+    public function testAutoDiscoverEntitiesIsEnabledWhenNoMappingIsConfigured(): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->getContainer();
+        (new DoctrineExtension())->load([['dbal' => [], 'orm' => []]], $container);
+
+        self::assertSame(self::supportsAutoDiscovery(), $container->hasDefinition('doctrine.orm.default_auto_discover_class_locator'));
+    }
+
+    /** @param array<string, mixed> $ormConfig */
+    #[TestWith([['auto_mapping' => true]])]
+    #[TestWith([['mappings' => ['XmlBundle' => null]]])]
+    #[TestWith([['auto_discover_entities' => false]])]
+    public function testAutoDiscoverEntitiesStaysOff(array $ormConfig): void
+    {
+        if (! interface_exists(EntityManagerInterface::class)) {
+            self::markTestSkipped('This test requires ORM');
+        }
+
+        $container = $this->getContainer(['XmlBundle']);
+        (new DoctrineExtension())->load([['dbal' => [], 'orm' => $ormConfig]], $container);
+
+        self::assertFalse($container->hasDefinition('doctrine.orm.default_auto_discover_class_locator'));
+    }
+
+    private static function supportsAutoDiscovery(): bool
+    {
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        return method_exists(ContainerBuilder::class, 'findTaggedResourceIds')
+            && (new ReflectionParameter([AttributeDriver::class, '__construct'], 'paths'))->getType() instanceof ReflectionUnionType;
     }
 
     /** @return mixed[][][][] */


### PR DESCRIPTION
Implements the proposal from #2124. 

Companion of symfony/symfony#65437 (merged in 8.2), which tags #[Entity]/#[MappedSuperclass] classes with doctrine.orm.entity during the container scan.

This PR adds a per-entity-manager option:

```yaml
doctrine:
    orm:
        auto_discover_entities: true
```

When enabled, `DoctrineExtension` registers a persistence `ClassNames` locator feeding an ORM `AttributeDriver`, set as the entity manager's `MappingDriverChain` default driver; the new `EntityAutoDiscoveryPass` (`TYPE_BEFORE_REMOVING`) fills the locator with the tagged class names via `ContainerBuilder::findTaggedResourceIds('doctrine.orm.entity', false)` — the same pattern Symfony's `MessengerPass` uses. Class names are resolved through the definitions, since PHP-abstract scanned classes (typically mapped superclasses) are registered under `.abstract.`-prefixed ids.

For most applications this removes the need for the explicit `mappings` configuration block entirely.

Design notes:
- **Explicit mappings still win**: prefixed chain drivers are consulted first; the discovery driver is only the chain's default. Both can coexist on the same entity manager (`getAllClassNames()` de-duplicates by design).
- **Multi-EM semantics**: every entity manager with the flag enabled receives the full discovered class list; partitioning entities across managers still requires explicit mappings — the option targets the single-EM majority case.
- **Legacy exclude globs**: entities behind an old `exclude: '../src/Entity'` line in `services.yaml` are not discovered (those stubs never receive the tag) — documented with a prominent warning in the configuration reference, plus a test pinning the limitation.
- **No dependency bumps**: enabling the option throws a `LogicException` on Symfony < 8.2, and when `ClassNames` (doctrine/persistence 4.2) or `AttributeDriver ClassLocator` support (doctrine/orm 3.6) is missing. Uses the "cleaner home" noted in symfony/symfony#65437's review; the transitional bridge driver was removed upstream in symfony/symfony#65445 (merged).
- **Deprecation**: not setting the option is deprecated (same approach as #1762 for `controller_resolver.auto_mapping`), so it can default to `true` in a future major version. See `UPGRADE-3.4.md`.
