### PR TITLE
Register the `EntityExists` constraint validator from symfony/doctrine-bridge 8.2

### DIFF
--- a/config/orm.php
+++ b/config/orm.php
@@ -42,6 +42,7 @@ use Symfony\Bridge\Doctrine\SchemaListener\LockStoreSchemaListener;
 use Symfony\Bridge\Doctrine\SchemaListener\PdoSessionHandlerSchemaListener;
 use Symfony\Bridge\Doctrine\SchemaListener\RememberMeTokenProviderDoctrineSchemaListener;
 use Symfony\Bridge\Doctrine\Security\User\EntityUserProvider;
+use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExistsValidator;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Bridge\Doctrine\Validator\DoctrineInitializer;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -88,6 +89,12 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('doctrine.orm.validator.unique', UniqueEntityValidator::class)
             ->tag('validator.constraint_validator', ['alias' => 'doctrine.orm.validator.unique'])
+            ->args([
+                service('doctrine'),
+            ])
+
+        ->set('doctrine.orm.validator.entity_exists', EntityExistsValidator::class)
+            ->tag('validator.constraint_validator')
             ->args([
                 service('doctrine'),
             ])

--- a/src/DependencyInjection/DoctrineExtension.php
+++ b/src/DependencyInjection/DoctrineExtension.php
@@ -50,6 +50,7 @@ use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 use Symfony\Bridge\Doctrine\Middleware\IdleConnection\Listener;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExistsValidator;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
@@ -768,6 +769,10 @@ final class DoctrineExtension extends Extension
 
         if (class_exists(AbstractType::class)) {
             $container->getDefinition('form.type.entity')->addTag('kernel.reset', ['method' => 'reset']);
+        }
+
+        if (! class_exists(EntityExistsValidator::class)) {
+            $container->removeDefinition('doctrine.orm.validator.entity_exists');
         }
 
         if (! class_exists(UlidGenerator::class)) {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -21,6 +21,7 @@ use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver as Cons
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExistsValidator;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -63,6 +64,13 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(EventManager::class, $container->get('doctrine.dbal.event_manager'));
         $this->assertInstanceOf(ManagerRegistry::class, $container->get('doctrine'));
         $this->assertInstanceOf(UniqueEntityValidator::class, $container->get('doctrine.orm.validator.unique'));
+
+        if (class_exists(EntityExistsValidator::class)) {
+            $this->assertInstanceOf(EntityExistsValidator::class, $container->get('doctrine.orm.validator.entity_exists'));
+        } else {
+            $this->assertFalse($container->has('doctrine.orm.validator.entity_exists'));
+        }
+
         $this->assertInstanceOf(InfoCommand::class, $container->get('doctrine.mapping_info_command'));
         $this->assertInstanceOf(MappingDescribeCommand::class, $container->get('doctrine.mapping_describe_command'));
         $this->assertInstanceOf(UpdateCommand::class, $container->get('doctrine.schema_update_command'));


### PR DESCRIPTION
symfony/symfony#63483 added an `EntityExists` constraint to the Doctrine bridge (8.2). Its validator needs the `ManagerRegistry`, so like `UniqueEntityValidator` it has to be registered as a `validator.constraint_validator` service by this bundle; without it the constraint fails at `ConstraintValidatorFactory` on any full-stack app.

The tag carries no alias: `EntityExists::validatedBy()` resolves to the validator class name, which is what an alias-less tag indexes by.

The definition is removed when the class does not exist (bridge < 8.2), following the `UlidGenerator`/`UuidGenerator` pattern, and the container test asserts whichever side applies. Ran locally against `symfony/doctrine-bridge` 8.2.x-dev: the service instantiates from the real container; phpcs clean.
