### PR TITLE
Deprecate passing null as lock mode to ServiceEntityRepository::find()

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 3.3 to 3.4
+=======================
+
+ServiceEntityRepository
+-----------------------
+
+Passing `null` as `$lockMode` to `ServiceEntityRepository::find()` is deprecated
+and will not be possible in DoctrineBundle 4.0. Omit the argument or pass
+`LockMode::NONE` instead.
+
+```diff
+-$repository->find($id, null);
++$repository->find($id);
+```

--- a/src/Repository/ServiceEntityRepository.php
+++ b/src/Repository/ServiceEntityRepository.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\AbstractLazyCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -61,9 +62,20 @@ class ServiceEntityRepository extends EntityRepository implements ServiceEntityR
 
     public function find(mixed $id, LockMode|int|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
     {
+        if ($lockMode === null) {
+            Deprecation::trigger(
+                'doctrine/doctrine-bundle',
+                'https://github.com/doctrine/DoctrineBundle/pull/2284',
+                'Passing null as $lockMode to %s() is deprecated and will not be possible in DoctrineBundle 4.0, pass LockMode::NONE instead.',
+                __METHOD__,
+            );
+
+            $lockMode = LockMode::NONE;
+        }
+
         /** @psalm-suppress InvalidReturnStatement This proxy is used only in combination with newer parent class */
         return ($this->repository ??= $this->resolveRepository())
-            ->find($id, $lockMode ?? LockMode::NONE, $lockVersion);
+            ->find($id, $lockMode, $lockVersion);
     }
 
     /**

--- a/tests/Repository/ServiceEntityRepositoryTest.php
+++ b/tests/Repository/ServiceEntityRepositoryTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\DoctrineBundle\Tests\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +17,8 @@ use function interface_exists;
 
 class ServiceEntityRepositoryTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public static function setUpBeforeClass(): void
     {
         if (interface_exists(EntityManagerInterface::class)) {
@@ -33,5 +38,40 @@ EXCEPTION);
         /* @phpstan-ignore class.notFound */
         $repo = new ServiceEntityRepository($registry, TestEntity::class);
         $repo->getClassName();
+    }
+
+    public function testFindTriggersDeprecationWhenPassingNullAsLockMode(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/2284');
+
+        /* @phpstan-ignore class.notFound */
+        $repo = new ServiceEntityRepository($this->createRegistry(), TestEntity::class);
+
+        self::assertNull($repo->find(1, null));
+    }
+
+    public function testFindDoesNotTriggerDeprecationWhenOmittingLockMode(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/DoctrineBundle/pull/2284');
+
+        /* @phpstan-ignore class.notFound */
+        $repo = new ServiceEntityRepository($this->createRegistry(), TestEntity::class);
+
+        self::assertNull($repo->find(1));
+        self::assertNull($repo->find(1, LockMode::NONE));
+    }
+
+    private function createRegistry(): ManagerRegistry
+    {
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getClassMetadata')
+            /* @phpstan-ignore class.notFound */
+            ->willReturn(new ClassMetadata(TestEntity::class));
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManagerForClass')
+            ->willReturn($em);
+
+        return $registry;
     }
 }


### PR DESCRIPTION
Follow-up to #2282, as discussed in https://github.com/doctrine/DoctrineBundle/pull/2282#issuecomment-5601843269.

ORM 3.7 [deprecated passing `null` as lock mode](https://github.com/doctrine/orm/pull/12548), and ORM 4.0 will not accept it anymore. #2282 made `ServiceEntityRepository::find()` default to `LockMode::NONE` and normalize an explicitly passed `null`, so that users stop getting an ORM deprecation they cannot act on.

Users who pass `null` themselves still need to hear about it, since the parameter loses its nullability in DoctrineBundle 4.0. This triggers our own deprecation for that case.

Note that the nullability cannot be dropped on `4.0.x` yet: as long as DoctrineBundle 4.0 requires ORM 3 (`"doctrine/orm": "<3.0 || >=4.0"` in `conflict`), the parent `Doctrine\ORM\EntityRepository::find()` still declares `LockMode|int|null $lockMode = null`, and narrowing that in a child class is a fatal error. The removal has to happen in the same change that requires ORM 4.
